### PR TITLE
Improbe the About MSEP.one window with license information about third party software used in the project

### DIFF
--- a/godot_project/autoloads/about_msep_one/about_msep_attribution_page.gd
+++ b/godot_project/autoloads/about_msep_one/about_msep_attribution_page.gd
@@ -1,0 +1,112 @@
+class_name AboutMsepAttributionPage extends MarginContainer
+
+var _tree: Tree
+var _rich_text_label: RichTextLabel
+
+var _last_selected_item: TreeItem = null
+var _custom_control: Control = null
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_SCENE_INSTANTIATED:
+		_tree = %Tree as Tree
+		_rich_text_label = %RichTextLabel as RichTextLabel
+		
+		_tree.clear()
+		var _root: TreeItem = _tree.create_item()
+		_tree.hide_root = true
+	if what == NOTIFICATION_READY:
+		_tree.item_selected.connect(_on_tree_item_selected)
+		_rich_text_label.meta_clicked.connect(_on_rich_text_label_meta_clicked)
+
+
+func _create_software_tree_item(in_info: LicenseInfo) -> TreeItem:
+	var tree_item: TreeItem = _tree.create_item(_tree.get_root())
+	const COLUMN_0: int = 0
+	tree_item.set_text(COLUMN_0, in_info.software_name)
+	tree_item.set_tooltip_text(COLUMN_0, "{0} ({1})".format([in_info.license_short_name, in_info.license_long_name]))
+	tree_item.set_metadata(COLUMN_0, in_info)
+	return tree_item
+
+
+func _format_lisence(in_text: String, in_year: String, in_copyright_holders: String) -> String:
+	var text: String = in_text
+	text = text.replace("<year>", in_year)
+	text = text.replace("<copyright holders>", in_copyright_holders)
+	return text
+
+
+func _on_tree_item_selected() -> void:
+	var selected: TreeItem = _tree.get_selected()
+	if _last_selected_item == selected:
+		return
+	_last_selected_item = selected
+	_rich_text_label.clear()
+	_rich_text_label.show()
+	if is_instance_valid(_custom_control):
+		_custom_control.queue_free()
+		_custom_control = null
+	if selected == null:
+		return
+	const COLUMN_0: int = 0
+	var meta: Variant = selected.get_metadata(COLUMN_0)
+	if meta is LicenseInfo:
+		_fill_license_info(meta)
+	elif meta is PackedScene:
+		# Custom scene with a control
+		_custom_control = meta.instantiate() as Control
+		_custom_control.set_anchors_preset(Control.PRESET_FULL_RECT)
+		_custom_control.size_flags_stretch_ratio = _rich_text_label.size_flags_stretch_ratio
+		_rich_text_label.hide()
+		_rich_text_label.get_parent_control().add_child(_custom_control)
+
+
+func _fill_license_info(in_info: LicenseInfo) -> void:
+	var has_url: bool = not in_info.software_external_url.is_empty()
+	# Header
+	_rich_text_label.add_text("\n\n")
+	_rich_text_label.push_paragraph(HORIZONTAL_ALIGNMENT_CENTER)
+	if has_url:
+		_rich_text_label.push_meta(in_info.software_external_url)
+	_rich_text_label.add_text(in_info.software_name)
+	_rich_text_label.pop_all()
+	_rich_text_label.add_text("\n\n")
+	# Version
+	if not in_info.software_version.is_empty():
+		_rich_text_label.push_list(0, RichTextLabel.LIST_DOTS, false)
+		_rich_text_label.add_text(tr(&"Version: ") + in_info.software_version)
+		_rich_text_label.pop_all()
+		_rich_text_label.add_text("\n\n")
+	
+	_rich_text_label.push_list(0, RichTextLabel.LIST_DOTS, false)
+	var lic_info: String = "{0} ({1})".format([in_info.license_short_name, in_info.license_long_name])
+	_rich_text_label.add_text(tr(&"License: ") + lic_info)
+	_rich_text_label.pop_all()
+	_rich_text_label.add_text("\n\n")
+	
+	_rich_text_label.push_indent(2)
+	_rich_text_label.add_text(in_info.license_text)
+	_rich_text_label.pop_all()
+
+
+func _on_rich_text_label_meta_clicked(in_meta: String) -> void:
+	assert(in_meta.begins_with("https://"), "Unexpected meta: %s" % in_meta)
+	OS.shell_open(in_meta)
+
+
+class LicenseInfo:
+	var software_name: String
+	var software_version: String
+	var software_external_url: String
+	var license_short_name: String
+	var license_long_name: String
+	var license_text: String
+	
+	func _init(in_name: String, in_version: String, in_url: String,
+			in_license_short: String, in_license_long: String,
+			in_license_text: String) -> void:
+		software_name = in_name
+		software_version = in_version
+		software_external_url = in_url
+		license_short_name = in_license_short
+		license_long_name = in_license_long
+		license_text = in_license_text

--- a/godot_project/autoloads/about_msep_one/about_msep_attribution_page.tscn
+++ b/godot_project/autoloads/about_msep_one/about_msep_attribution_page.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=2 format=3 uid="uid://x6gk8had4k33"]
+
+[ext_resource type="Script" path="res://autoloads/about_msep_one/about_msep_attribution_page.gd" id="1_5fc3a"]
+
+[node name="AttributionPage" type="MarginContainer"]
+size_flags_horizontal = 3
+size_flags_vertical = 4
+theme_type_variation = &"CollapsableCategoryPanel"
+script = ExtResource("1_5fc3a")
+
+[node name="VBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="Tree" type="Tree" parent="VBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 300)
+layout_mode = 2
+size_flags_horizontal = 3
+hide_root = true
+
+[node name="RichTextLabel" type="RichTextLabel" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.5
+focus_mode = 2
+autowrap_mode = 0
+selection_enabled = true

--- a/godot_project/autoloads/about_msep_one/about_msep_one.gd
+++ b/godot_project/autoloads/about_msep_one/about_msep_one.gd
@@ -15,9 +15,7 @@ var was_closed: bool = false
 var _blur_background: ColorRect
 var _label_date_of_build: Label
 var _button_close: Button
-var _button_view_copyright_info: LinkButton
 var _blur_tween: Tween = null
-var _popup_copyright_info: PopupPanel
 
 var _blur: float = 0.0:
 	set = _set_blur
@@ -35,8 +33,6 @@ func _notification(in_what: int) -> void:
 		_blur_background = %BlurBackground
 		_label_date_of_build = %LabelDateOfBuild
 		_button_close = %ButtonClose
-		_button_view_copyright_info = %ButtonViewCopyrightInfo
-		_popup_copyright_info = %PopupCopyrightInfo
 		
 		var build_date: String = ProjectSettings.get_setting(
 			_EXPORT_DATE_SETTING_NAME,
@@ -52,7 +48,6 @@ func _notification(in_what: int) -> void:
 			_label_date_of_build.text += "." + short_hash
 		
 		_button_close.pressed.connect(_on_button_close_pressed)
-		_button_view_copyright_info.pressed.connect(_on_button_view_copyright_info_pressed)
 
 
 func _on_button_close_pressed() -> void:
@@ -62,8 +57,6 @@ func _on_button_close_pressed() -> void:
 	disappear()
 	confirmed.emit()
 
-func _on_button_view_copyright_info_pressed() -> void:
-	_popup_copyright_info.show()
 
 func appear(in_fade_time: float = 0.3) -> void:
 	show()

--- a/godot_project/autoloads/about_msep_one/about_msep_one.tscn
+++ b/godot_project/autoloads/about_msep_one/about_msep_one.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=8 format=3 uid="uid://gxawguce88cy"]
+[gd_scene load_steps=10 format=3 uid="uid://gxawguce88cy"]
 
 [ext_resource type="Script" path="res://autoloads/about_msep_one/about_msep_one.gd" id="1_6fjpy"]
 [ext_resource type="Shader" path="res://autoloads/initial_info_screen/initial_info_screen.gdshader" id="2_8o7yo"]
 [ext_resource type="Theme" uid="uid://d3fnr4sbrd6ik" path="res://theme/theme.tres" id="3_beojv"]
 [ext_resource type="Texture2D" uid="uid://bm36o6fo1evuo" path="res://logo.png" id="4_38ii1"]
+[ext_resource type="PackedScene" uid="uid://ceqlu15mn5g3q" path="res://autoloads/about_msep_one/third_party_software/third_party_software.tscn" id="5_p4fbb"]
+[ext_resource type="PackedScene" uid="uid://v30lo2ux3ujo" path="res://autoloads/about_msep_one/other_attributions/other_attributions.tscn" id="6_qip5g"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_g7c2g"]
 shader = ExtResource("2_8o7yo")
@@ -67,28 +69,31 @@ horizontal_alignment = 1
 vertical_alignment = 1
 autowrap_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
 layout_mode = 2
-size_flags_vertical = 3
-theme_override_constants/separation = 13
+theme_type_variation = &"TabContainerCrystal"
 
-[node name="Logo" type="TextureRect" parent="VBoxContainer/HBoxContainer"]
-layout_mode = 2
-texture = ExtResource("4_38ii1")
-expand_mode = 3
-stretch_mode = 6
-
-[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="About Us" type="MarginContainer" parent="VBoxContainer/TabContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_type_variation = &"CollapsableCategoryPanel"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/About Us"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Logo" type="TextureRect" parent="VBoxContainer/TabContainer/About Us/HBoxContainer"]
+layout_mode = 2
+texture = ExtResource("4_38ii1")
+expand_mode = 3
+stretch_mode = 6
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/About Us/HBoxContainer"]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/About Us/HBoxContainer/VBoxContainer"]
 layout_mode = 2
 text = "(c) 2022-Present, MSEP.one Contributors
 
@@ -96,12 +101,12 @@ Ongoing contributions provided by Prehensile Tales, BV
 
 "
 
-[node name="LabelDateOfBuild" type="Label" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
+[node name="LabelDateOfBuild" type="Label" parent="VBoxContainer/TabContainer/About Us/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Build date: yyyy-mm-dd.git_commit_hash"
 
-[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
+[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/About Us/HBoxContainer/VBoxContainer"]
 layout_mode = 2
 text = "
 The initial phase of MSEP.one's development was made possible by support from the Astera Institute, with contributions by the Survival and Flourishing Fund and Protocol Labs.
@@ -111,15 +116,13 @@ Currently, many more features are under development.
 "
 autowrap_mode = 2
 
-[node name="ButtonViewCopyrightInfo" type="LinkButton" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
-unique_name_in_owner = true
+[node name="Third Party Software" parent="VBoxContainer/TabContainer" instance=ExtResource("5_p4fbb")]
+visible = false
 layout_mode = 2
-size_flags_horizontal = 8
-theme_type_variation = &"FlatButton"
-shortcut = SubResource("Shortcut_hmq7l")
-shortcut_feedback = false
-shortcut_in_tooltip = false
-text = "View Copyright Information"
+
+[node name="Other Attributions" parent="VBoxContainer/TabContainer" instance=ExtResource("6_qip5g")]
+visible = false
+layout_mode = 2
 
 [node name="ButtonClose" type="Button" parent="VBoxContainer"]
 unique_name_in_owner = true
@@ -130,63 +133,3 @@ shortcut = SubResource("Shortcut_hmq7l")
 shortcut_feedback = false
 shortcut_in_tooltip = false
 text = "Continue"
-
-[node name="PopupCopyrightInfo" type="PopupPanel" parent="."]
-unique_name_in_owner = true
-title = "Copyright Info"
-initial_position = 2
-size = Vector2i(658, 608)
-borderless = false
-min_size = Vector2i(600, 600)
-keep_title_visible = true
-
-[node name="Control" type="Control" parent="PopupCopyrightInfo"]
-custom_minimum_size = Vector2(650, 600)
-layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 4.0
-offset_top = 4.0
-offset_right = -4.0
-offset_bottom = -4.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="MarginContainer" type="MarginContainer" parent="PopupCopyrightInfo/Control"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="PopupCopyrightInfo/Control/MarginContainer"]
-layout_mode = 2
-
-[node name="TextEdit" type="TextEdit" parent="PopupCopyrightInfo/Control/MarginContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 3
-text = "Copyright 2006-2009 The Chemical Structures Project. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE CHEMICAL STRUCTURES PROJECT ``AS IS'' AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE CHEMICAL STRUCTURES PROJECT OR CONTRIBUTORS
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-editable = false
-scroll_smooth = true

--- a/godot_project/autoloads/about_msep_one/other_attributions/other_attributions.gd
+++ b/godot_project/autoloads/about_msep_one/other_attributions/other_attributions.gd
@@ -1,0 +1,36 @@
+extends AboutMsepAttributionPage
+
+
+const LICENSES: Dictionary = {
+	"SMALL_MOLECULES" =
+"""Copyright 2006-2009 The Chemical Structures Project. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE CHEMICAL STRUCTURES PROJECT ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE CHEMICAL STRUCTURES PROJECT OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+}
+
+
+func _ready() -> void:
+	var small_molecules_info := LicenseInfo.new(
+			"The Chemical Structures Project", "2.2.0", "https://chem-file.sourceforge.net/",
+			"BSD", "Berkeley Software Distribution",
+			LICENSES["SMALL_MOLECULES"])
+	_create_software_tree_item(small_molecules_info)

--- a/godot_project/autoloads/about_msep_one/other_attributions/other_attributions.tscn
+++ b/godot_project/autoloads/about_msep_one/other_attributions/other_attributions.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=3 format=3 uid="uid://v30lo2ux3ujo"]
+
+[ext_resource type="Script" path="res://autoloads/about_msep_one/other_attributions/other_attributions.gd" id="1_0l2rr"]
+[ext_resource type="PackedScene" uid="uid://x6gk8had4k33" path="res://autoloads/about_msep_one/about_msep_attribution_page.tscn" id="1_5bfvd"]
+
+[node name="AttributionPage" instance=ExtResource("1_5bfvd")]
+script = ExtResource("1_0l2rr")

--- a/godot_project/autoloads/about_msep_one/third_party_software/third_party_software.gd
+++ b/godot_project/autoloads/about_msep_one/third_party_software/third_party_software.gd
@@ -1,0 +1,53 @@
+extends AboutMsepAttributionPage
+
+
+const OTHERS_LICENSES: Dictionary = {
+	"MIT" =
+"""Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."""
+
+}
+
+func _ready() -> void:
+	# Godot Engine
+	var licences_texts: Dictionary = Engine.get_license_info()
+	var conda_info := LicenseInfo.new(
+			"Conda", "", "https://anaconda.org/",
+			"BSD3", "Berkeley Software Distribution",
+			licences_texts["BSD-3-clause"])
+	_create_software_tree_item(conda_info)
+	var openmm_info := LicenseInfo.new(
+			"OpenMM", "8.0.0", "https://openmm.org/",
+			"MIT", "Massachusetts Institute of Technology",
+			_format_lisence(OTHERS_LICENSES["MIT"], "2017-2024", "OpenMM team"))
+	var openff_info := LicenseInfo.new(
+			"OpenFF", "openff-interchange 0.3.9; openff-toolkit 0.14.0", "https://openforcefield.org/",
+			"MIT", "Massachusetts Institute of Technology",
+			_format_lisence(OTHERS_LICENSES["MIT"], "2020", "Open Force Field Initiative"))
+	_create_software_tree_item(openff_info)
+	var rdkit_info := LicenseInfo.new(
+			"RDKit", "2023.03.2", "https://www.rdkit.org/",
+			"BSD3", "Berkeley Software Distribution",
+			licences_texts["BSD-3-clause"])
+	_create_software_tree_item(rdkit_info)
+	var pyzmq_info := LicenseInfo.new(
+			"pyzmq", "25.1.0", "https://zeromq.org/",
+			"BSD3", "Berkeley Software Distribution",
+			licences_texts["BSD-3-clause"])
+	_create_software_tree_item(pyzmq_info)
+	var zeromq_info := LicenseInfo.new(
+			"zeromq", "4.3.5", "https://zeromq.org/",
+			"MPL 2.0", "Mozilla Public License Version 2.0",
+			licences_texts["BSD-3-clause"])
+	_create_software_tree_item(zeromq_info)
+	var godot_info := LicenseInfo.new(
+			"Godot Engine", "4.2.3-(custom)", "https://godotengine.org/",
+			"MIT", "Massachusetts Institute of Technology",
+			Engine.get_license_text())
+	_create_software_tree_item(godot_info)
+	

--- a/godot_project/autoloads/about_msep_one/third_party_software/third_party_software.tscn
+++ b/godot_project/autoloads/about_msep_one/third_party_software/third_party_software.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=3 format=3 uid="uid://ceqlu15mn5g3q"]
+
+[ext_resource type="PackedScene" uid="uid://x6gk8had4k33" path="res://autoloads/about_msep_one/about_msep_attribution_page.tscn" id="1_f1pfw"]
+[ext_resource type="Script" path="res://autoloads/about_msep_one/third_party_software/third_party_software.gd" id="1_xjwa1"]
+
+[node name="Third Party Software" instance=ExtResource("1_f1pfw")]
+script = ExtResource("1_xjwa1")

--- a/godot_project/theme/theme.tres
+++ b/godot_project/theme/theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=85 format=3 uid="uid://d3fnr4sbrd6ik"]
+[gd_resource type="Theme" load_steps=89 format=3 uid="uid://d3fnr4sbrd6ik"]
 
 [ext_resource type="FontFile" uid="uid://b3jkav4yxw06w" path="res://theme/Gidole-Regular.ttf" id="1_8indu"]
 [ext_resource type="Texture2D" uid="uid://bh1ju2ymvv1co" path="res://theme/icons/icon_on.svg" id="1_n28s0"]
@@ -709,6 +709,48 @@ content_margin_top = 0.0
 content_margin_right = 0.0
 content_margin_bottom = 0.0
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5po8w"]
+content_margin_left = 10.0
+content_margin_top = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 10.0
+bg_color = Color(1, 1, 1, 0.101961)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4dj6a"]
+content_margin_left = 10.0
+content_margin_top = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 10.0
+bg_color = Color(1, 1, 1, 0.101961)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1yd73"]
+content_margin_left = 10.0
+content_margin_top = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 10.0
+bg_color = Color(1, 1, 1, 0.101961)
+draw_center = false
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qh4gh"]
+content_margin_left = 10.0
+content_margin_top = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 10.0
+bg_color = Color(1, 1, 1, 0.0431373)
+corner_radius_top_left = 10
+corner_radius_top_right = 10
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b7kn0"]
 content_margin_left = 4.0
 content_margin_top = 4.0
@@ -1004,6 +1046,13 @@ TabContainer/styles/tab_hovered = SubResource("StyleBoxFlat_2llre")
 TabContainer/styles/tab_selected = SubResource("StyleBoxFlat_mmv7o")
 TabContainer/styles/tab_unselected = SubResource("StyleBoxFlat_f1kck")
 TabContainer/styles/tabbar_background = SubResource("StyleBoxEmpty_kjuvf")
+TabContainerCrystal/base_type = &"TabContainer"
+TabContainerCrystal/styles/panel = SubResource("StyleBoxFlat_5po8w")
+TabContainerCrystal/styles/tab_disabled = SubResource("StyleBoxFlat_4dj6a")
+TabContainerCrystal/styles/tab_focus = SubResource("StyleBoxFlat_1yd73")
+TabContainerCrystal/styles/tab_hovered = SubResource("StyleBoxFlat_4dj6a")
+TabContainerCrystal/styles/tab_selected = SubResource("StyleBoxFlat_4dj6a")
+TabContainerCrystal/styles/tab_unselected = SubResource("StyleBoxFlat_qh4gh")
 TextEdit/colors/selection_color = Color(0.396078, 0.168627, 0.85098, 0.941176)
 TextEdit/styles/focus = SubResource("StyleBoxFlat_b7kn0")
 TextEdit/styles/normal = SubResource("StyleBoxFlat_t06f6")


### PR DESCRIPTION
- A page for third party software (godot engine, openmm, openff, zeromq, conda, rdkit)
- Displays software name, with a link to web page, version, and license text for each of them
- An additional page for other (non software) content. For now only small molecules library is in there

-----------
Tasks:
- Part 2 of Add Open Source Information for Small Molecules
- Get License Information
DEPENDS ON: https://github.com/MSEP-one/msep.one/pull/3