### PR TITLE
Move Camera Topbar/VisualMenu from the root of the topbar to a submenu of the View menu

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_bar.tscn
+++ b/godot_project/editor/controls/menu_bar/menu_bar.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://b711oqbglehtg"]
+[gd_scene load_steps=10 format=3 uid="uid://b711oqbglehtg"]
 
 [ext_resource type="Script" path="res://editor/controls/menu_bar/menu_bar.gd" id="1_6tam7"]
 [ext_resource type="PackedScene" uid="uid://c3s1rv4dhbs3w" path="res://editor/controls/menu_bar/menu_file/menu_file.tscn" id="1_ihotm"]
@@ -7,7 +7,6 @@
 [ext_resource type="PackedScene" uid="uid://biclwwtcsdrxo" path="res://editor/controls/menu_bar/menu_select/menu_select.tscn" id="3_ud0g4"]
 [ext_resource type="PackedScene" uid="uid://dmmofla5u8hjl" path="res://editor/controls/menu_bar/menu_create/menu_create.tscn" id="4_6sp8a"]
 [ext_resource type="PackedScene" uid="uid://d3khovvyi6gkr" path="res://editor/controls/menu_bar/menu_simulation/menu_simulation.tscn" id="6_w4q0l"]
-[ext_resource type="PackedScene" uid="uid://bh8iwsy4ji3k0" path="res://editor/controls/menu_bar/menu_camera/menu_camera.tscn" id="8_6vjee"]
 [ext_resource type="PackedScene" uid="uid://bk8h3hla8tqrp" path="res://editor/controls/menu_bar/menu_virtual_objects/menu_virtual_objects.tscn" id="9_sh1ey"]
 [ext_resource type="PackedScene" uid="uid://ppxc7kfobo2x" path="res://editor/controls/menu_bar/menu_help/menu_help.tscn" id="10_e4f34"]
 
@@ -34,9 +33,6 @@ visible = false
 visible = false
 
 [node name="Simulation" parent="." instance=ExtResource("6_w4q0l")]
-visible = false
-
-[node name="Camera" parent="." instance=ExtResource("8_6vjee")]
 visible = false
 
 [node name="VirtualObjects" parent="." instance=ExtResource("9_sh1ey")]

--- a/godot_project/editor/controls/menu_bar/menu_help/menu_help.tscn
+++ b/godot_project/editor/controls/menu_bar/menu_help/menu_help.tscn
@@ -5,8 +5,7 @@
 [ext_resource type="Script" path="res://editor/controls/menu_bar/menu_help/menu_help.gd" id="3_slcf1"]
 
 [node name="MenuHelp" type="PopupMenu"]
-size = Vector2i(215, 100)
-visible = true
+size = Vector2i(229, 100)
 item_count = 2
 item_0/text = "About MSEP.one"
 item_0/icon = ExtResource("1_tflsd")
@@ -15,4 +14,3 @@ item_1/text = "Tutorials and Instructions"
 item_1/icon = ExtResource("2_ejfnr")
 item_1/id = 1
 script = ExtResource("3_slcf1")
-item_1/text = "Tutorials and Instructions"

--- a/godot_project/editor/controls/menu_bar/menu_view/menu_camera/menu_camera.gd
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_camera/menu_camera.gd
@@ -5,6 +5,7 @@ signal request_hide
 
 enum {
 	ID_CAPTURE_CAMERA_IMAGE            = 0,
+	ID_CAMERA_PROJECTION               = 1,
 }
 
 
@@ -36,4 +37,7 @@ func _on_id_pressed(in_id: int) -> void:
 		ID_CAPTURE_CAMERA_IMAGE:
 			request_hide.emit()
 			WorkspaceUtils.open_screen_capture_dialog(workspace_context)
+		ID_CAMERA_PROJECTION:
+			request_hide.emit()
+			MolecularEditorContext.request_workspace_docker_focus(WorkspaceSettingsDocker.UNIQUE_DOCKER_NAME, &"MSEP Settings")
 

--- a/godot_project/editor/controls/menu_bar/menu_view/menu_camera/menu_camera.tscn
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_camera/menu_camera.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://bh8iwsy4ji3k0"]
+[gd_scene load_steps=6 format=3 uid="uid://bh8iwsy4ji3k0"]
 
-[ext_resource type="Script" path="res://editor/controls/menu_bar/menu_camera/menu_camera.gd" id="2_qiyix"]
+[ext_resource type="Texture2D" uid="uid://bdtmhsuvkbll3" path="res://editor/icons/icon_camera_x16.svg" id="2_67edx"]
+[ext_resource type="Script" path="res://editor/controls/menu_bar/menu_view/menu_camera/menu_camera.gd" id="2_qiyix"]
 [ext_resource type="Texture2D" uid="uid://bgwo87rpq5iys" path="res://editor/icons/icon_add_x16.svg" id="3_u0t3u"]
 
 [sub_resource type="InputEventKey" id="InputEventKey_3k5pr"]
@@ -12,11 +13,14 @@ keycode = 80
 events = [SubResource("InputEventKey_3k5pr")]
 
 [node name="Camera" type="PopupMenu"]
-size = Vector2i(192, 100)
+size = Vector2i(206, 100)
 visible = true
-item_count = 1
+item_count = 2
 item_0/text = "Capture Camera Image"
 item_0/icon = ExtResource("3_u0t3u")
 item_0/id = 0
+item_1/text = "Camera Projection"
+item_1/icon = ExtResource("2_67edx")
+item_1/id = 1
 script = ExtResource("2_qiyix")
 shortcut_capture_camera_image = SubResource("Shortcut_3lanh")

--- a/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
@@ -29,6 +29,7 @@ func _ready() -> void:
 		remove_item(feature_flag_index)
 		var algorithm_tweaks_index: int = get_item_index(ID_SHOW_ALGORITHM_TWEAKS)
 		remove_item(algorithm_tweaks_index)
+	add_submenu_item("Camera", "Camera")
 
 
 func _update_menu() -> void:
@@ -136,9 +137,6 @@ func _on_id_pressed(in_id: int) -> void:
 		ID_THEME_3D:
 			request_hide.emit()
 			MolecularEditorContext.request_workspace_docker_focus(WorkspaceSettingsDocker.UNIQUE_DOCKER_NAME, &"Representation Settings")
-		ID_CAMERA_PROJECTION:
-			request_hide.emit()
-			MolecularEditorContext.request_workspace_docker_focus(WorkspaceSettingsDocker.UNIQUE_DOCKER_NAME, &"MSEP Settings")
 		ID_REPRESENTATION_SHOW_BONDS:
 			request_hide.emit()
 			MolecularEditorContext.request_workspace_docker_focus(WorkspaceSettingsDocker.UNIQUE_DOCKER_NAME, &"Representation Settings")
@@ -172,5 +170,4 @@ enum {
 	ID_SHOW_HIDDEN_OBJECTS             = 19,
 	ID_OVERRIDE_DEFAULT_COLORS         = 20,
 	ID_THEME_3D                        = 21,
-	ID_CAMERA_PROJECTION               = 22,
 }

--- a/godot_project/editor/controls/menu_bar/menu_view/menu_view.tscn
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_view.tscn
@@ -18,8 +18,8 @@
 [ext_resource type="Texture2D" uid="uid://endpnrg38txn" path="res://editor/controls/menu_bar/menu_view/icons/icon_show_hydrogens_16px.svg" id="12_3iftq"]
 [ext_resource type="Texture2D" uid="uid://ntg2llf45ky2" path="res://editor/controls/menu_bar/menu_edit/icons/icon_theme.svg" id="15_jjf8c"]
 [ext_resource type="Texture2D" uid="uid://cbc43vi425q4b" path="res://editor/controls/dockers/workspace_docker/icons/icon_deactivated.svg" id="15_uj6uj"]
-[ext_resource type="Texture2D" uid="uid://bdtmhsuvkbll3" path="res://editor/icons/icon_camera_x16.svg" id="16_epqix"]
 [ext_resource type="Texture2D" uid="uid://f6ceimdovp8j" path="res://editor/controls/dockers/workspace_docker/icons/icon_visible.svg" id="16_wh84c"]
+[ext_resource type="PackedScene" uid="uid://bh8iwsy4ji3k0" path="res://editor/controls/menu_bar/menu_view/menu_camera/menu_camera.tscn" id="21_qnyh1"]
 
 [sub_resource type="InputEventKey" id="InputEventKey_dap46"]
 device = -1
@@ -58,8 +58,7 @@ events = [SubResource("InputEventKey_hkl84")]
 
 [node name="View" type="PopupMenu"]
 size = Vector2i(492, 636)
-visible = true
-item_count = 22
+item_count = 21
 item_0/text = "Focus on Visible Objects"
 item_0/icon = ExtResource("1_jslvw")
 item_0/id = 0
@@ -117,24 +116,23 @@ item_15/id = 10
 item_16/text = "Theme"
 item_16/icon = ExtResource("15_jjf8c")
 item_16/id = 21
-item_17/text = "Camera Projection"
-item_17/icon = ExtResource("16_epqix")
-item_17/id = 22
-item_18/text = "Debug Separator"
-item_18/id = 11
-item_18/separator = true
-item_19/text = "Show Object Model Tree"
-item_19/icon = ExtResource("3_svvq5")
-item_19/checkable = 1
-item_19/id = 12
-item_20/text = "Feature Flags"
-item_20/icon = ExtResource("15_uj6uj")
-item_20/id = 13
-item_21/text = "Tweak Algorithm Parameters"
-item_21/icon = ExtResource("16_wh84c")
-item_21/id = 14
+item_17/text = "Debug Separator"
+item_17/id = 11
+item_17/separator = true
+item_18/text = "Show Object Model Tree"
+item_18/icon = ExtResource("3_svvq5")
+item_18/checkable = 1
+item_18/id = 12
+item_19/text = "Feature Flags"
+item_19/icon = ExtResource("15_uj6uj")
+item_19/id = 13
+item_20/text = "Tweak Algorithm Parameters"
+item_20/icon = ExtResource("16_wh84c")
+item_20/id = 14
 script = ExtResource("1_2o615")
 shortcut_focus_on_visible_objects = SubResource("Shortcut_2fwj8")
 shortcut_focus_on_selected_objects = SubResource("Shortcut_5xqur")
 shortcut_hide_selected_objects = SubResource("Shortcut_suqnu")
 shortcut_show_hidden_objects = SubResource("Shortcut_hp7en")
+
+[node name="Camera" parent="." instance=ExtResource("21_qnyh1")]


### PR DESCRIPTION
- This mirrors the layout of the RingMenu
- Also moved 'View/Camera Projection' to 'View/Camera/Camera Projection'

-----------
Task: Move Camera menu in the topbar inside the View menu to match new RingMenu layout
