### PR TITLE
Block UI hover detection while transform gizmo is moved

### DIFF
--- a/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoRotationArcs.gd
+++ b/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoRotationArcs.gd
@@ -357,6 +357,11 @@ func manage_ortho_arc_rotation() -> void:
 		_reset_state_on_release()
 
 
+func _process(in_delta: float) -> void:
+	if is_rotating:
+		UIBlocker.block_input()
+
+
 func rotate_on_axis(in_dir_vec: Vector3) -> void:
 	var current_mouse_position: Vector2 = get_viewport().get_mouse_position()
 	var node_position: Vector2 = camera.unproject_position(selected_node.global_position)

--- a/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoTranslationAxes.gd
+++ b/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoTranslationAxes.gd
@@ -347,6 +347,7 @@ func _process(_delta: float) -> void:
 		calculate_grab_offset()
 	if GizmoRoot.grab_mode == GizmoRoot.GrabMode.AXIS && GizmoRoot.mouse_hover_detected.translation_axis:
 		place_ortho()
+		UIBlocker.block_input()
 	
 	mouse_movement = Vector2.ZERO
 

--- a/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoZHandle.gd
+++ b/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoZHandle.gd
@@ -134,6 +134,7 @@ func detect_collision(in_mouse_position: Vector2) -> void:
 
 func move_on_camera_local_z_axis() -> void:
 	if GizmoRoot.grab_mode == GizmoRoot.GrabMode.ORTHO_Z_HANDLE:
+		UIBlocker.block_input()
 		var mouse_delta: Vector2 = _mouse_position - _mouse_old_position
 		var camera_relative_movement_speed: float = _movement_speed * \
 		selected_node.global_position.distance_to(camera.global_position)

--- a/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoZSurface.gd
+++ b/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoZSurface.gd
@@ -122,6 +122,7 @@ func detect_collision() -> void:
 
 func move_on_camera_local_xy_axis() -> void:
 	if GizmoRoot.grab_mode == GizmoRoot.GrabMode.ORTHO_Z_SURFACE:
+		UIBlocker.block_input()
 		var distance_from_screen: float = -(camera.global_transform.affine_inverse() * \
 				selected_node.global_position).z
 		var mouse_clamped_position: Vector2 = _mouse_position

--- a/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/DrawOrientationWidget.gd
+++ b/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/DrawOrientationWidget.gd
@@ -135,7 +135,7 @@ func _on_size_changed() -> void:
 
 
 func _process(_in_delta: float, in_force: bool = false, in_finish: bool = false) -> void:
-	if !in_force && (AboutMsepOne.visible || BusyIndicator.visible):
+	if !in_force && (AboutMsepOne.visible || BusyIndicator.visible || UIBlocker.is_blocking()):
 		return
 	
 	_resolution_factor = _calculate_resolution_factor()

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -38,6 +38,7 @@ OpenMM="*res://autoloads/openmm/openmm.tscn"
 Settings="*res://autoloads/settings/settings.tscn"
 BusyIndicator="*res://autoloads/busy_indicator/busy_indicator.tscn"
 UserInterfaceBehavior="*res://autoloads/ui_behavior/ui_behavior.gd"
+UIBlocker="*res://autoloads/ui_blocker/ui_blocker.tscn"
 
 [debug]
 


### PR DESCRIPTION
REPRODUCTION STEPS
- Grab the transform gizmo xy movement tool and move the selection around so that mouse hovers over various UI elements
- Observe that most UI interactive controls become activated as the mouse hovers over them

------

Task: UI elements become active, while transform gizmo is grabbed
