### PR TITLE
Add missing definition caused by a bad merge

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -415,6 +415,10 @@ func _on_molecular_editor_load_workspace_confirmed(in_path: String) -> void:
 	load_and_activate_workspace(in_path)
 
 
+func _on_molecular_editor_export_workspace_confirmed(in_workspace: Workspace, in_path: String) -> void:
+	export_workspace(in_workspace, in_path)
+
+
 func _on_about_msep_one_confirmed() -> void:
 	AboutMsepOne.confirmed.disconnect(_on_about_msep_one_confirmed)
 	var first_run_dialog := NanoAcceptDialog.new()


### PR DESCRIPTION
This function definition was accidentally left outside of https://github.com/MSEP-one/msep.one/commit/124c6fe2004d927df83f74b579396ff0a212bdd1

The change was added to our **devel** branch in [f71003f (diff)](https://github.com/MSEP-one/msep.one/commit/f71003fd128e6188071f9d95ac6c396f9a3f7e1b#diff-e276351b8ff9f3fa9861cf18c32f0b7edb7b4186c0d57c1e8d9b949fe26618fdR417-R418)
To have a stable main branch this fix is needed (current release was manually built with this code in)