### PR TITLE
Block UI hover detection while transform gizmo is moved

### DIFF
--- a/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoRotationArcs.gd
+++ b/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoRotationArcs.gd
@@ -357,6 +357,11 @@ func manage_ortho_arc_rotation() -> void:
 		_reset_state_on_release()
 
 
+func _process(in_delta: float) -> void:
+	if is_rotating:
+		UIBlocker.block_current_frame_input_events()
+
+
 func rotate_on_axis(in_dir_vec: Vector3) -> void:
 	var current_mouse_position: Vector2 = get_viewport().get_mouse_position()
 	var node_position: Vector2 = camera.unproject_position(selected_node.global_position)

--- a/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoTranslationAxes.gd
+++ b/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoTranslationAxes.gd
@@ -347,6 +347,7 @@ func _process(_delta: float) -> void:
 		calculate_grab_offset()
 	if GizmoRoot.grab_mode == GizmoRoot.GrabMode.AXIS && GizmoRoot.mouse_hover_detected.translation_axis:
 		place_ortho()
+		UIBlocker.block_current_frame_input_events()
 	
 	mouse_movement = Vector2.ZERO
 

--- a/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoZHandle.gd
+++ b/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoZHandle.gd
@@ -134,6 +134,7 @@ func detect_collision(in_mouse_position: Vector2) -> void:
 
 func move_on_camera_local_z_axis() -> void:
 	if GizmoRoot.grab_mode == GizmoRoot.GrabMode.ORTHO_Z_HANDLE:
+		UIBlocker.block_current_frame_input_events()
 		var mouse_delta: Vector2 = _mouse_position - _mouse_old_position
 		var camera_relative_movement_speed: float = _movement_speed * \
 		selected_node.global_position.distance_to(camera.global_position)

--- a/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoZSurface.gd
+++ b/godot_project/addons/runtimespatialgizmo/RuntimeSpatialGizmo/OrthoZSurface.gd
@@ -122,6 +122,7 @@ func detect_collision() -> void:
 
 func move_on_camera_local_xy_axis() -> void:
 	if GizmoRoot.grab_mode == GizmoRoot.GrabMode.ORTHO_Z_SURFACE:
+		UIBlocker.block_current_frame_input_events()
 		var distance_from_screen: float = -(camera.global_transform.affine_inverse() * \
 				selected_node.global_position).z
 		var mouse_clamped_position: Vector2 = _mouse_position

--- a/godot_project/autoloads/ui_blocker/ui_blocker.gd
+++ b/godot_project/autoloads/ui_blocker/ui_blocker.gd
@@ -1,0 +1,24 @@
+extends CanvasLayer
+
+var _blocker: Control = null
+
+
+func _ready() -> void:
+	_blocker = %BlockerRect as Control
+	_blocker.set_mouse_filter(_blocker.MOUSE_FILTER_STOP)
+
+
+func _process(in_delta: float) -> void:
+	_unblock_last_frame_input_events()
+
+
+func is_blocking() -> bool:
+	return _blocker.get_mouse_filter() == _blocker.MOUSE_FILTER_STOP
+
+
+func block_current_frame_input_events() -> void:
+	_blocker.set_mouse_filter(_blocker.MOUSE_FILTER_STOP)
+
+
+func _unblock_last_frame_input_events() -> void:
+	_blocker.set_mouse_filter(_blocker.MOUSE_FILTER_IGNORE)

--- a/godot_project/autoloads/ui_blocker/ui_blocker.tscn
+++ b/godot_project/autoloads/ui_blocker/ui_blocker.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=2 format=3 uid="uid://djysvtj85xgxs"]
+
+[ext_resource type="Script" path="res://autoloads/ui_blocker/ui_blocker.gd" id="1_lyq0i"]
+
+[node name="UiBlocker" type="CanvasLayer"]
+layer = 128
+script = ExtResource("1_lyq0i")
+
+[node name="BlockerRect" type="Control" parent="."]
+unique_name_in_owner = true
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/DrawOrientationWidget.gd
+++ b/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/DrawOrientationWidget.gd
@@ -135,7 +135,7 @@ func _on_size_changed() -> void:
 
 
 func _process(_in_delta: float, in_force: bool = false, in_finish: bool = false) -> void:
-	if !in_force && (InitialInfoScreen.visible || BusyIndicator.visible):
+	if !in_force && (InitialInfoScreen.visible || BusyIndicator.visible || UIBlocker.is_blocking()):
 		return
 	
 	_resolution_factor = _calculate_resolution_factor()

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -39,6 +39,7 @@ Settings="*res://autoloads/settings/settings.tscn"
 BusyIndicator="*res://autoloads/busy_indicator/busy_indicator.tscn"
 UserInterfaceBehavior="*res://autoloads/ui_behavior/ui_behavior.gd"
 InitialInfoScreen="*res://autoloads/initial_info_screen/initial_info_screen.tscn"
+UIBlocker="*res://autoloads/ui_blocker/ui_blocker.tscn"
 
 [debug]
 


### PR DESCRIPTION
REPRODUCTION STEPS
- Grab the transform gizmo xy movement tool and move the selection around so that mouse hovers over various UI elements
-- Or any other transform gizmo handle.
- Observe that most UI interactive controls become activated as the mouse hovers over them

------

Task: UI elements become active, while transform gizmo is grabbed