### PR TITLE
Removed unused linking steps for libs from capnp and kj

### DIFF
--- a/modules/lmdb/thirdparty/capnpSCsub
+++ b/modules/lmdb/thirdparty/capnpSCsub
@@ -20,14 +20,8 @@ libs_to_link_against = [
   "libcapnp",
   "libcapnpc",
   "libcapnp-json",
-  "libcapnp-rpc",
-  "libcapnp-websocket",
   "libkj",
   "libkj-async",
-  "libkj-gzip",
-  "libkj-http",
-  "libkj-test",
-  "libkj-tls",
 ]
 if shutil.which("cygpath"):
   autotools_command = ["bash", "-c", "$(cygpath {}) -p {} -o $(cygpath {}) -a {}".format(os.path.join(os.getcwd(), "build_capnproto.sh"), platform, out_lib_dir, arch)]


### PR DESCRIPTION
Regression on capnpSCsub during migration to github

-----------

The following file was reverted during the migration to github. This adds back the changes done on the last days before open-sourcing.
