### PR TITLE
Add a placeholder for Simulation Toolkit

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_settings_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_settings_panel.gd
@@ -8,6 +8,8 @@ var _extension_option_button: OptionButton
 var _extension_advanced_menu_button: MenuButton
 var _extensions_info_label: InfoLabel
 var _user_forcefield_info_label: InfoLabel
+var _molecular_simulation_toolkit_option_button: OptionButton
+var _molecular_simulation_toolkit_advanced_menu_button: MenuButton
 
 
 var _workspace_context: WorkspaceContext
@@ -24,6 +26,8 @@ func _notification(what: int) -> void:
 		_advanced_menu_button = %AdvancedMenuButton as MenuButton
 		_extension_option_button = %ExtensionOptionButton as OptionButton
 		_extension_advanced_menu_button = %ExtensionAdvancedMenuButton as MenuButton
+		_molecular_simulation_toolkit_option_button = %MolecularSimulationToolkitOptionButton as OptionButton
+		_molecular_simulation_toolkit_advanced_menu_button = %MolecularSimulationToolkitAdvancedMenuButton as MenuButton
 		_extensions_info_label = %ExtensionsInfoLabel as InfoLabel
 		_user_forcefield_info_label = %UserForcefieldInfoLabel as InfoLabel
 		_advanced_menu_button.get_popup().id_pressed.connect(_on_advanced_menu_button_id_pressed)
@@ -95,6 +99,8 @@ func _on_workspace_context_simulation_started() -> void:
 	_advanced_menu_button.disabled = true
 	_extension_option_button.disabled = true
 	_extension_advanced_menu_button.disabled = true
+	_molecular_simulation_toolkit_option_button.disabled = true
+	_molecular_simulation_toolkit_advanced_menu_button.disabled = true
 
 
 func _on_workspace_context_simulation_finished() -> void:
@@ -102,6 +108,8 @@ func _on_workspace_context_simulation_finished() -> void:
 	_advanced_menu_button.disabled = false
 	_extension_option_button.disabled = false
 	_extension_advanced_menu_button.disabled = false
+	_molecular_simulation_toolkit_option_button.disabled = false
+	_molecular_simulation_toolkit_advanced_menu_button.disabled = false
 
 
 func _update_forcefields_list() -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_settings_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_settings_panel.tscn
@@ -76,6 +76,37 @@ popup/item_0/text = "Show user defined files"
 popup/item_0/checkable = 1
 popup/item_0/id = 0
 
+[node name="Label3" type="Label" parent="VBoxContainer/GridContainer"]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+text = "Molecular Simulation Toolkit "
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+
+[node name="MolecularSimulationToolkitOptionButton" type="OptionButton" parent="VBoxContainer/GridContainer/HBoxContainer3"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+item_count = 2
+selected = 0
+popup/item_0/text = "OpenMM"
+popup/item_0/id = 0
+popup/item_1/text = "LAMMPS (under development)"
+popup/item_1/id = 1
+popup/item_1/disabled = true
+
+[node name="MolecularSimulationToolkitAdvancedMenuButton" type="MenuButton" parent="VBoxContainer/GridContainer/HBoxContainer3"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(27.31, 0)
+layout_mode = 2
+icon = ExtResource("3_r271m")
+expand_icon = true
+item_count = 1
+popup/item_0/text = "Show user defined files"
+popup/item_0/checkable = 1
+popup/item_0/id = 0
+
 [node name="ExtensionsInfoLabel" parent="VBoxContainer" instance=ExtResource("2_i1oqk")]
 unique_name_in_owner = true
 layout_mode = 2

--- a/godot_project/theme/theme.tres
+++ b/godot_project/theme/theme.tres
@@ -981,6 +981,7 @@ OptionButton/styles/pressed = SubResource("StyleBoxFlat_cvnwt")
 OptionButton/styles/pressed_mirrored = SubResource("StyleBoxFlat_4y3vi")
 Panel/styles/panel = SubResource("StyleBoxFlat_b5xkc")
 PanelContainer/styles/panel = SubResource("StyleBoxFlat_udr83")
+PopupMenu/colors/font_disabled_color = Color(0.733333, 0.729412, 0.729412, 0.8)
 RoundedWindow/base_type = &"AcceptDialog"
 RoundedWindow/styles/panel = SubResource("StyleBoxFlat_r6qfk")
 SpinboxSlider/base_type = &"HSlider"


### PR DESCRIPTION
In the 3 settings panels for Simulation Force Fields (Relax,Molecular Simulation, and Validate), add an option for "Molecular Simulation Toolkit"

This should be a pull-down control:
The default option should be "OpenMM"
There should be a grayed out option for "LAMMPS (under development)"

So, the user won't be able to choose anything other than OpenMM. This option should be placed below the Force-Field selectors.
