### PR TITLE
Fix the modern, academic color switching

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/color/confirmation_color_popup.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/color/confirmation_color_popup.gd
@@ -2,6 +2,7 @@ class_name ConfirmationColorPopup
 extends PopupPanel
 
 const SINGLE_COLOR_BUTTON := preload("./single_color_button.tscn")
+const DEFAULT_COLOR: Color = Color.BLACK
 
 @onready var _apply_btn: Button = %ApplyBtn
 @onready var _default_btn: Button = %DefaultBtn
@@ -16,6 +17,8 @@ signal default_pressed()
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	_color_picker.color = DEFAULT_COLOR
+	
 	_apply_btn.pressed.connect(_on_apply_button_pressed)
 	_default_btn.pressed.connect(_on_default_button_pressed)
 
@@ -29,6 +32,10 @@ func _on_apply_button_pressed() -> void:
 
 
 func _on_default_button_pressed() -> void:
+	_color_picker.color = DEFAULT_COLOR
+	_selected_color = _color_picker.color
+	color_selected.emit(_selected_color)
+	
 	default_pressed.emit()
 	hide()
 

--- a/godot_project/theme/theme_3d/available_themes/flat_theme/flat_environment.tres
+++ b/godot_project/theme/theme_3d/available_themes/flat_theme/flat_environment.tres
@@ -10,11 +10,10 @@ sky_material = SubResource("PanoramaSkyMaterial_u41f5")
 
 [resource]
 background_mode = 1
-background_color = Color(0.920995, 0.920995, 0.920995, 1)
-background_energy_multiplier = 0.9
+background_color = Color(0.74978, 0.74978, 0.74978, 1)
+background_energy_multiplier = 2.0
 sky = SubResource("Sky_1u7jr")
 ambient_light_source = 2
 ambient_light_color = Color(1, 1, 1, 1)
 ambient_light_energy = 0.5
 reflected_light_source = 1
-tonemap_mode = 1


### PR DESCRIPTION
The bug as written is fixed, however, the bg color varies slightly between Academic and Modern. Also, setting the colors back to Default does not set the color swatches back to the default.

- Go to workspace settings
- Switch to academic view
- Change the background color
- Switch to modern view
- Switch back to academic view
- Observe that the background color is reset to the default, but the settings still shows that the new color is being used

-------

Task: Modern view resets the user specified colors in Academic view