### PR TITLE
Fix a case where hovering a group in sticks mode highlights only the bond and not the entire group

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -35,6 +35,10 @@ func show() -> void:
 	_single_stick_multimesh.set_material_override(_capsule_material)
 	_double_stick_multimesh.set_material_override(_capsule_material)
 	_tripple_stick_multimesh.set_material_override(_capsule_material)
+	# Override members from parent class
+	_material_bond_1 = _capsule_material
+	_material_bond_2 = _capsule_material
+	_material_bond_3 = _capsule_material
 	_init_material_uniforms()
 
 


### PR DESCRIPTION
-----------
 Task: BUG: When hovering a group in **Sticks** or **Enhanced Sticks** representation, all the bonds of the group doesn't highlight, only the bond under the cursor
 
 Preview:
![image](https://github.com/user-attachments/assets/bf98674e-6e29-4d8b-adea-1d7bbf0ddba3)
