### PR TITLE
Fix missing outline when closing the screen capture popup

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
@@ -70,7 +70,7 @@ var _is_about_to_popup: bool = false
 
 var prev_size_preset: SizePresets = SizePresets.RES_MATCH_EDITOR
 var high_resolution_rendering_confirmed: bool = false
-var selection_snapshots: Dictionary # key: StructureContext, value: SelectionSnapshot}
+var workspace_snapshot: Dictionary
 
 
 func _init() -> void:
@@ -149,9 +149,7 @@ func _on_about_to_popup() -> void:
 	_set_remote_camera(workspace_camera_3d)
 	_on_option_button_size_preset_item_selected(_option_button_size_preset.get_selected_id())
 	# Store existing selection and deselect everything
-	selection_snapshots.clear()
-	for context in workspace_context.get_structure_contexts_with_selection():
-		selection_snapshots[context] = context.get_selection_snapshot()
+	workspace_snapshot = workspace_context.create_state_snapshot()
 	workspace_context.clear_all_selection()
 	_is_about_to_popup = false
 
@@ -180,9 +178,10 @@ func _on_confirmed() -> void:
 func _on_visibility_changed() -> void:
 	if visible:
 		return # Popup was opened, ignore
-	for context: StructureContext in selection_snapshots:
-		context.apply_selection_snapshot(selection_snapshots[context])
-	selection_snapshots.clear()
+	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
+	assert(workspace_context != null)
+	workspace_context.apply_state_snapshot(workspace_snapshot)
+	workspace_snapshot.clear()
 
 
 func _on_main_window_size_changed() -> void:

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
@@ -459,55 +459,5 @@ func apply_selection_snapshot(in_snapshot: Dictionary) -> void:
 	var atom_snapshot: Array = in_snapshot.atom_snapshot
 	var spring_snapshot: Array = in_snapshot.spring_snapshot
 	
-	var atoms_to_selection_status: Dictionary = {
-		# atom_id<int> : is_atom_currently_selected<bool>
-	}
-	
-	var bond_to_selection_status: Dictionary = {
-		# bond_id<int> : is_bond_currently_selected<bool>
-	}
-	var spring_to_selection_status: Dictionary = {
-		# spring_id<int> : is_spring_selected<bool>
-	}
-	
 	var _apply_result: AtomSelection.ApplySnapshotResult = _atom_selection.apply_snapshot(atom_snapshot)
-	var atoms_to_highlight: PackedInt32Array = PackedInt32Array()
-	var atoms_to_lowlight: PackedInt32Array = PackedInt32Array()
-	var new_atom_selection: PackedInt32Array = _atom_selection.get_atoms_selection()
-	for atom_id in new_atom_selection:
-		assert(nano_structure.is_atom_valid(atom_id))
-		atoms_to_selection_status[atom_id] = true
-	
-	for atom_id: int in atoms_to_selection_status:
-		if atoms_to_selection_status[atom_id]:
-			atoms_to_highlight.append(atom_id)
-		else:
-			atoms_to_lowlight.append(atom_id)
-	
-	var bonds_to_highlight: PackedInt32Array = PackedInt32Array()
-	var bonds_to_lowlight: PackedInt32Array = PackedInt32Array()
-	var new_bond_selection: PackedInt32Array = _atom_selection.get_bonds_selection()
-	for bond_id in new_bond_selection:
-		assert(nano_structure.is_bond_valid(bond_id))
-		bond_to_selection_status[bond_id] = true
-	
-	for bond_id: int in bond_to_selection_status:
-		if bond_to_selection_status[bond_id]:
-			bonds_to_highlight.append(bond_id)
-		else:
-			bonds_to_lowlight.append(bond_id)
-	
 	_spring_selection.apply_snapshot(spring_snapshot)
-	var springs_to_highlight: PackedInt32Array = PackedInt32Array()
-	var springs_to_lowlight: PackedInt32Array = PackedInt32Array()
-	var new_spring_selection: PackedInt32Array = _spring_selection.get_selection()
-	for spring_id in new_spring_selection:
-		assert(nano_structure.spring_has(spring_id))
-		spring_to_selection_status[spring_id] = true
-	
-	for spring_id: int in spring_to_selection_status:
-		var spring_selected: bool = spring_to_selection_status[spring_id]
-		if spring_selected:
-			springs_to_highlight.append(spring_id)
-		else:
-			springs_to_lowlight.append(spring_id)


### PR DESCRIPTION
The selection state was properly saved (and restored), but the rendering state was not. Before the snapshot system, changing the selection used to cause the renderer to refresh its state, but now this has to be done explicitly.