### PR TITLE
fix adding a structure after simulation

### DIFF
--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -833,7 +833,9 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	for renderer_name: String in renderers:
 		var renderer: AtomicStructureRenderer
 		var renderer_snapshot: Dictionary = renderers_snapshots[renderer_name]
-		if is_instance_valid(renderers[renderer_name]):
+		var is_alive: bool = is_instance_valid(renderers[renderer_name]) and \
+				not renderers[renderer_name].is_queued_for_deletion()
+		if is_alive:
 			renderer = renderers[renderer_name]
 		else:
 			# create new one

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -576,11 +576,9 @@ func get_nano_structure_context(in_nano_structure: NanoStructure) -> StructureCo
 	var guid: int = in_nano_structure.int_guid
 	assert(workspace.has_structure(in_nano_structure))
 	if !_structure_contexts.has(guid):
-		var structure_context: StructureContext = null
-		if structure_context == null:
-			structure_context = StructureContextScn.instantiate()
-			structure_context.initialize(self, guid, in_nano_structure)
-			_structure_contexts_holder.add_child_with_name(structure_context, in_nano_structure.get_structure_name().to_snake_case())
+		var structure_context: StructureContext = StructureContextScn.instantiate()
+		structure_context.initialize(self, guid, in_nano_structure)
+		_structure_contexts_holder.add_child_with_name(structure_context, in_nano_structure.get_structure_name().to_snake_case())
 		structure_context.selection_changed.connect(_on_structure_context_selection_changed.bind(structure_context.get_int_guid()))
 		structure_context.virtual_object_selection_changed.connect(_on_structure_context_virtual_object_selection_changed.bind(structure_context.get_int_guid()))
 		if structure_context.nano_structure is AtomicStructure:


### PR DESCRIPTION
CRASH
-----------
fix Rendering snapshot edge case issue 🔨

There was an issue related to snapshot implementation of Rendering that
revealed itself in case when snapshot has been applied multiple times
during the same frame.
In case when in the result of snapshot 'apply' operation the structure
has been removed, and then later during the same frame other snapshot
'apply' operation is requested this time re-instantiating the same
structure, such structure was not re-instantiated correctly.

The direct cause for this was incomplete is_instance_valid check(),
such instance is valid at that point but already queued for deletion.

The edge case described in here is happening every time when directly
after running mechanical simulation user decides to add new structure
from library (WorkspaceContext.snapshot_moment() performs couple
apply_snapshot in a row in such case)