### PR TITLE
Show distances between hower and selection as well as Bond/Spring length

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -349,6 +349,11 @@ func is_clipboard_empty() -> bool:
 	return not _clipboard.has_content()
 
 
+func bottom_bar_update_distance(in_workspace_context: WorkspaceContext, in_distance_description: String, in_distance: float) -> void:
+	var view: WorkspaceMainView = in_workspace_context.workspace_main_view
+	view.bottom_bar_update_distance(in_distance_description, in_distance)
+
+
 func _init() -> void:
 	if FileAccess.file_exists(MSEPSettings.SETTINGS_RESOURCE_PATH):
 		msep_editor_settings = ResourceLoader.load(MSEPSettings.SETTINGS_RESOURCE_PATH)

--- a/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
+++ b/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
@@ -105,6 +105,10 @@ func show_warning_in_message_bar(in_message: String) -> void:
 	_message_bar.show_warning(in_message)
 
 
+func bottom_bar_update_distance(in_message_text: String, in_distance: float) -> void:
+	_message_bar.update_distance(in_message_text, in_distance)
+
+
 func _on_show_transform_rotation_message(_in_dir_vec: Vector3, _in_degrees: float, \
 		_in_degrees_formatted_string: String) -> void:
 	if !is_visible_in_tree():

--- a/godot_project/editor/controls/message_bar/message_bar.gd
+++ b/godot_project/editor/controls/message_bar/message_bar.gd
@@ -16,6 +16,7 @@ const Priority: Dictionary = {
 
 @onready var _label_messages: RichTextLabel = $HBoxContainerMessages/LabelMessages
 @onready var _label_fps: Label = $HBoxContainerMessages/LabelFPS
+@onready var _label_distance: Label = $HBoxContainerMessages/Distance
 
 var _meta_callbacks: Dictionary = {
 #	meta_identifier<String> = callback<Callable>
@@ -53,6 +54,14 @@ func show_warning(in_warning: String, in_meta_callbacks: Dictionary = {}) -> voi
 func clear() -> void:
 	_meta_callbacks.clear()
 	_label_messages.text = ""
+
+
+func update_distance(in_message_text: String, in_distance: float) -> void:
+	if in_message_text.is_empty():
+		_label_distance.text = ""
+	else:
+		var distance: String = "%.2f" % in_distance
+		_label_distance.text = in_message_text + " " + distance
 
 
 func _can_show(in_text: String, in_priority: int) -> bool:

--- a/godot_project/editor/controls/message_bar/message_bar.gd
+++ b/godot_project/editor/controls/message_bar/message_bar.gd
@@ -61,7 +61,7 @@ func update_distance(in_message_text: String, in_distance: float) -> void:
 		_label_distance.text = ""
 	else:
 		var distance: String = "%.2f" % in_distance
-		_label_distance.text = in_message_text + " " + distance
+		_label_distance.text = in_message_text + " " + distance + " nm"
 
 
 func _can_show(in_text: String, in_priority: int) -> bool:

--- a/godot_project/editor/controls/message_bar/message_bar.tscn
+++ b/godot_project/editor/controls/message_bar/message_bar.tscn
@@ -35,6 +35,9 @@ fit_content = true
 scroll_active = false
 autowrap_mode = 0
 
+[node name="Distance" type="Label" parent="HBoxContainerMessages"]
+layout_mode = 2
+
 [node name="LabelFPS" type="Label" parent="HBoxContainerMessages"]
 custom_minimum_size = Vector2(100, 2.08165e-12)
 layout_mode = 2

--- a/godot_project/editor/controls/workspace_view/WorkspaceMainView.gd
+++ b/godot_project/editor/controls/workspace_view/WorkspaceMainView.gd
@@ -154,3 +154,7 @@ func set_camera_global_transform(in_transform: Transform3D) -> void:
 
 func get_camera_global_transform() -> Transform3D:
 	return get_camera().global_transform
+
+
+func bottom_bar_update_distance(in_message_text: String, in_distance: float) -> void:
+	editor_viewport_container.bottom_bar_update_distance(in_message_text, in_distance)

--- a/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
@@ -1,5 +1,7 @@
 extends InputHandlerCreateObjectBase
 
+const BOND_LENGTH_MSG_TEXT = "Bond length: "
+const SPRING_LENGTH_MSG_TEXT = "Spring length: "
 
 enum {
 	_NO_DRAG,
@@ -158,11 +160,13 @@ func set_preview_position(in_position: Vector3) -> void:
 				# and Spring end is located at mouse current position
 				rendering.virtual_anchor_preview_set_position(_press_down_position_3d)
 				rendering.virtual_anchor_preview_set_spring_ends([in_position])
+				_update_distance(SPRING_LENGTH_MSG_TEXT, _press_down_position_3d, in_position)
 			elif _drag_state == _DRAG_FROM_ATOM:
 				# When dragging from atom, anchor is located at current mouse position and
 				# and Spring end is located at initial _press_down_position_3d position
 				rendering.virtual_anchor_preview_set_position(in_position)
 				rendering.virtual_anchor_preview_set_spring_ends([_press_down_position_3d])
+				_update_distance(SPRING_LENGTH_MSG_TEXT, _press_down_position_3d, in_position)
 			else:
 				assert(false, "Unsupported drag state %d" % _drag_state)
 				pass
@@ -191,6 +195,15 @@ func _drag_drop_bond_preview_update(in_position: Vector3) -> void:
 
 	rendering.bond_preview_show()
 	rendering.bond_preview_update_all(bond_start_pos, in_position, first_atomic_number, second_atom_atomic_nmb, bond_order)
+	_update_distance(BOND_LENGTH_MSG_TEXT, bond_start_pos, in_position)
+
+
+func _update_distance(in_msg: String, in_position_one: Vector3, in_position_two: Vector3) -> void:
+	var distance: float = in_position_one.distance_to(in_position_two)
+	if is_equal_approx(distance, 0.0):
+		MolecularEditorContext.bottom_bar_update_distance(_workspace_context, "", 0)
+	else:
+		MolecularEditorContext.bottom_bar_update_distance(_workspace_context, in_msg, distance)
 
 
 func _find_target_candidate(in_camera: Camera3D, in_input_event: InputEvent) -> bool:

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -166,7 +166,7 @@ func _update_distance_message(in_workspace_context: WorkspaceContext, in_positio
 	var is_anything_selected: bool = in_workspace_context.has_selection()
 	var should_show_distance: bool = are_positions_valid and is_anything_selected and not is_equal_approx(distance, 0.0)
 	if should_show_distance:
-		MolecularEditorContext.bottom_bar_update_distance(in_workspace_context, "Distance to selection", distance)
+		MolecularEditorContext.bottom_bar_update_distance(in_workspace_context, "Distance to selection center: ", distance)
 	else:
 		MolecularEditorContext.bottom_bar_update_distance(in_workspace_context, "", 0.0)
 

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -115,31 +115,60 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 		var hovering_atom_id: int = -1
 		var hovering_bond_id: int = -1
 		var hovering_spring_id: int = -1
+		var hover_position: Vector3 = Vector3(INF, INF, INF)
 		if not editable_structures.is_empty():
 			var multi_structure_hit_result := MultiStructureHitResult.new(in_camera, in_input_event.position, editable_structures)
 			match multi_structure_hit_result.hit_type:
 				MultiStructureHitResult.HitType.HIT_ATOM:
 					hovering_object = multi_structure_hit_result.closest_hit_structure_context
 					hovering_atom_id = multi_structure_hit_result.closest_hit_atom_id
+					hover_position = hovering_object.nano_structure.atom_get_position(hovering_atom_id)
 				MultiStructureHitResult.HitType.HIT_BOND:
 					hovering_object = multi_structure_hit_result.closest_hit_structure_context
 					hovering_bond_id = multi_structure_hit_result.closest_hit_bond_id
+					var bond_data: Vector3i = hovering_object.nano_structure.get_bond(hovering_bond_id)
+					hover_position = (hovering_object.nano_structure.atom_get_position(bond_data.x) + \
+							hovering_object.nano_structure.atom_get_position(bond_data.y)) / 2.0
 				MultiStructureHitResult.HitType.HIT_SPRING:
 					hovering_object = multi_structure_hit_result.closest_hit_structure_context
 					hovering_spring_id = multi_structure_hit_result.closest_hit_spring_id
-				MultiStructureHitResult.HitType.HIT_MOTOR, MultiStructureHitResult.HitType.HIT_ANCHOR:
+					hover_position = (hovering_object.nano_structure.spring_get_atom_position(hovering_spring_id) + \
+							hovering_object.nano_structure.spring_get_anchor_position(hovering_spring_id, hovering_object)) / 2.0
+				MultiStructureHitResult.HitType.HIT_MOTOR:
 					hovering_object = multi_structure_hit_result.closest_hit_structure_context
+					hover_position = hovering_object.nano_structure.get_transform().origin
+				MultiStructureHitResult.HitType.HIT_ANCHOR:
+					hovering_object = multi_structure_hit_result.closest_hit_structure_context
+					hover_position = hovering_object.nano_structure.get_position()
 				MultiStructureHitResult.HitType.HIT_SHAPE:
 					if _is_shape_selectable():
 						hovering_object = multi_structure_hit_result.closest_hit_structure_context
+					hover_position = hovering_object.nano_structure.get_position()
 				_:
 					# do nothing
 					pass
 		get_workspace_context().set_hovered_structure_context(hovering_object, hovering_atom_id, hovering_bond_id, hovering_spring_id)
+		var selection_center: Vector3 = workspace_context.get_selection_aabb().get_center() if \
+				workspace_context.has_selection() else Vector3(INF, INF,INF)
+		_update_distance_message(workspace_context, hover_position, selection_center)
+		
 		var consume_input: bool = hovering_object != null
 		return consume_input
 	
 	return false
+
+
+func _update_distance_message(in_workspace_context: WorkspaceContext, in_position_one: Vector3,
+			in_position_two: Vector3) -> void:
+	var are_positions_valid: bool = not in_position_one.is_equal_approx(Vector3(INF, INF, INF)) and \
+			not in_position_two.is_equal_approx(Vector3(INF, INF, INF))
+	var distance: float = in_position_one.distance_to(in_position_two)
+	var is_anything_selected: bool = in_workspace_context.has_selection()
+	var should_show_distance: bool = are_positions_valid and is_anything_selected and not is_equal_approx(distance, 0.0)
+	if should_show_distance:
+		MolecularEditorContext.bottom_bar_update_distance(in_workspace_context, "Distance to selection", distance)
+	else:
+		MolecularEditorContext.bottom_bar_update_distance(in_workspace_context, "", 0.0)
 
 
 func _is_near_press_down_pos(in_input_event: InputEventMouseButton) -> bool:


### PR DESCRIPTION
Distance calculation feature should be in Nanometers, not pixels

-----------
commit f5bc035effac3339ceea808955908dfb7a3f4643 (HEAD -> pr/show-distances, origin/pr/show-distances)
Author: Jakub Grzesik <kubecz3k@gmail.com>
Date:   Mon Nov 4 14:45:39 2024 +0100

    show bond/spring length 📦
    
    This commit will display information about bond/spring length in
    message bar

commit 0d06e40d305e0af786ae6a25568d0953626de7c4
Author: Jakub Grzesik <kubecz3k@gmail.com>
Date:   Mon Nov 4 14:44:52 2024 +0100

    show distance between hover and selection 📦
    
    This commit will display information about distance between object
    which is being hovered and selection
    Information is displayed in bottom right corner of the screen
