### PR TITLE
ensure auto-wrap on license pages 🔧

### DIFF
--- a/godot_project/autoloads/about_msep_one/about_msep_attribution_page.tscn
+++ b/godot_project/autoloads/about_msep_one/about_msep_attribution_page.tscn
@@ -24,5 +24,4 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.5
 focus_mode = 2
-autowrap_mode = 0
 selection_enabled = true


### PR DESCRIPTION
BUG - Text needs word wrapping in attribution boxes.
-----------
ensure auto-wrap on license pages 🔧

Some licenses could not be read in full since lines were too long This commit adds word auto-wrap to ensure this is no longer the case