### PR TITLE
Improve preview bonds

### DIFF
--- a/godot_project/editor/rendering/ballstick_bond_preview/assets/bond_preview_material.tres
+++ b/godot_project/editor/rendering/ballstick_bond_preview/assets/bond_preview_material.tres
@@ -11,7 +11,7 @@ point_count = 4
 curve = SubResource("Curve_jww5y")
 
 [resource]
-render_priority = 0
+render_priority = -100
 shader = ExtResource("1_cnh8c")
 shader_parameter/emission_energy = 0.2
 shader_parameter/first_color = Color(1, 0, 0, 1)

--- a/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
+++ b/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
@@ -81,9 +81,15 @@ func _update_preview() -> void:
 	var first_data: ElementData = PeriodicTable.get_by_atomic_number(_first_atomic_number)
 	var second_data: ElementData = PeriodicTable.get_by_atomic_number(_second_atomic_number)
 	var camera: Camera3D = get_viewport().get_camera_3d()
-	var up_vector: Vector3 = camera.basis.z * -1.0
-	var bond_transform: Transform3D = CylinderStickRepresentation.calculate_transform_for_bond(_first_pos,
-			_second_pos, up_vector)
+	var dir_between_start_and_end: Vector3 = _first_pos.direction_to(_second_pos)
+	var up_vector: Vector3 = dir_between_start_and_end.cross(camera.basis.z)
+	var scale_factor: float = Representation.get_atom_scale_factor(_representation_settings)
+	var first_radius: float = Representation.get_atom_radius(first_data, _representation_settings) * scale_factor
+	var second_radius: float = Representation.get_atom_radius(second_data, _representation_settings) * scale_factor
+	var first_update_point: Vector3 = _first_pos + dir_between_start_and_end * first_radius
+	var second_update_point: Vector3 = _second_pos - dir_between_start_and_end * second_radius
+	var bond_transform: Transform3D = CylinderStickRepresentation.calculate_transform_for_bond(first_update_point,
+			second_update_point, up_vector)
 	_preview.transform = bond_transform
 	_material.apply_element_data(first_data, second_data)
 	set_order(_bond_order)


### PR DESCRIPTION
BUG - Hydrogen bond drawn in front of atom after relaxation failure

-----------
    improve preview bond 🔧
    
    preview bonds had presentation issues
    - they were overlapping with preview atoms during drag and drop
      gesture
    - they tend to change rendering order in visible way, sometimes they
      were rendered in front of preview atom and other moment behind
    
    This commit deals with both of those issues in following way:
    - render priority is defined so the bonds are always rendered behind
      the atom
    - preview bond length is now calculated more carefully so bond should
      not overlap the atom at all
    
    In practical terms only the latter change is really needed since when
    there is no overlap between bond and atom there is no real need to be
    careful about rendering order, for the sake of easier maintenance both
    changes are applied
