### PR TITLE
Add support to editing rotation of virtual objects in Selection Info Panel of the Dynamic Context docker

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/inspector_controls/inspector_control_rotation/inspector_control_rotation.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/inspector_controls/inspector_control_rotation/inspector_control_rotation.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=2 format=3 uid="uid://b5vbd62iy64eg"]
+
+[ext_resource type="PackedScene" uid="uid://7oyj4up6dm2c" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/inspector_controls/inspector_control_vector3/inspector_control_vector3.tscn" id="1_aqyrp"]
+
+[node name="TypeVector3" instance=ExtResource("1_aqyrp")]
+
+[node name="LabelX" parent="Components" index="0"]
+text = "yaw"
+
+[node name="X" parent="Components" index="1"]
+min_value = -360.0
+max_value = 360.0
+suffix = "º"
+
+[node name="LabelX2" parent="Components" index="2"]
+text = "pitch"
+
+[node name="Y" parent="Components" index="3"]
+suffix = "º"
+
+[node name="LabelX3" parent="Components" index="4"]
+text = "roll"
+
+[node name="Z" parent="Components" index="5"]
+min_value = -180.0
+max_value = 180.0
+allow_greater = false
+allow_lesser = false
+suffix = "º"
+custom_arrow_step = 1.0

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
@@ -216,6 +216,11 @@ func _fit_editor_in_cell(in_item: TreeItem, in_rect: Rect2) -> void:
 	if min_size.x > in_rect.size.x:
 		editor.position.x = in_rect.end.x - min_size.x
 	editor.size = in_rect.size
+	if in_item.get_text(0).is_empty():
+		# Expand the editor to fit both colums:
+		const PADDING: int = 60
+		editor.position.x = PADDING
+		editor.size.x = in_rect.end.x - PADDING
 
 func _value_type_expands(value: Variant) -> bool:
 	return typeof(value) in [


### PR DESCRIPTION
- NanoVirtualMotor has special treatment because their model is facing to the right instead of to the front
- Also modified the rules when positioning the editor controls to expand using both columsn when first column has no text (This is exactly the case of Position and Rotation)

-----------
 Tasks:
- Part 2 of BUG: Position and Rotation of Reference shapes are not editable in Selection Information panel
- Part 2 of BUG: Virtual Motors do not show any information in SelectionInformation panel
