### PR TITLE
Prevent from creating atoms and bonds with Shift+Click when application is in Select Mode

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
@@ -245,6 +245,8 @@ func _check_context_can_bind(in_context: StructureContext, in_atom_pos: Vector3)
 
 
 func _check_input_event_can_bind(in_event: InputEvent) -> bool:
+	if not _workspace_context.create_object_parameters.get_create_mode_enabled():
+		return false
 	if not in_event is InputEventWithModifiers:
 		return false
 	var alt_pressed: bool = in_event.alt_pressed


### PR DESCRIPTION
-----------
 Task: BUG: Is posible to create atoms and bonds in Select Mode