### PR TITLE
Fix Bonds disconnected from atoms during rotation

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
@@ -445,10 +445,10 @@ func update(delta: float) -> void:
 	_springs_representation.update(delta)
 
 
-func set_partially_selected_bonds(in_partially_selected_bonds: PackedInt32Array) -> void:
-	_current_representation.set_partially_selected_bonds(in_partially_selected_bonds)
+func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array) -> void:
+	_current_representation.refresh_bond_influence(in_partially_selected_bonds)
 	if _are_labels_active():
-		_labels_representation.set_partially_selected_bonds(in_partially_selected_bonds)
+		_labels_representation.refresh_bond_influence(in_partially_selected_bonds)
 	_outdate_non_active_representations()
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/balls_and_sticks_representation/balls_and_sticks_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/balls_and_sticks_representation/balls_and_sticks_representation.gd
@@ -153,8 +153,8 @@ func update(_in_delta: float) -> void:
 	_stick_representation.update(_in_delta)
 
 
-func set_partially_selected_bonds(in_partially_selected_bonds: PackedInt32Array) -> void:
-	_stick_representation.set_partially_selected_bonds(in_partially_selected_bonds)
+func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array) -> void:
+	_stick_representation.refresh_bond_influence(in_partially_selected_bonds)
 
 
 func set_atom_selection_position_delta(in_movement_delta: Vector3) -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/enhanced_sticks_and_balls_representation/enhanced_sticks_and_balls_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/enhanced_sticks_and_balls_representation/enhanced_sticks_and_balls_representation.gd
@@ -125,7 +125,7 @@ func set_material_overlay(_in_material: Material) -> void:
 	_stick_representation.set_material_overlay(_in_material)
 
 
-func set_partially_selected_bonds(in_partially_selected_bonds: PackedInt32Array) -> void:
+func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array) -> void:
 	_stick_representation.set_partially_selected_bonds(in_partially_selected_bonds)
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
@@ -202,7 +202,7 @@ func lowlight_bonds(_in_bonds_ids: PackedInt32Array) -> void:
 	return
 
 
-func set_partially_selected_bonds(_in_partially_selected_bonds: PackedInt32Array) -> void:
+func refresh_bond_influence(_in_partially_selected_bonds: PackedInt32Array) -> void:
 	return
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/representation.gd
@@ -150,7 +150,7 @@ func update(_in_delta_time: float) -> void:
 	return
 
 
-func set_partially_selected_bonds(_in_partially_selected_bonds: PackedInt32Array) -> void:
+func refresh_bond_influence(_in_partially_selected_bonds: PackedInt32Array) -> void:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
 	return
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
@@ -319,7 +319,7 @@ func update(_delta: float) -> void:
 	pass
 
 
-func set_partially_selected_bonds(_in_partially_selected_bonds: PackedInt32Array) -> void:
+func refresh_bond_influence(_in_partially_selected_bonds: PackedInt32Array) -> void:
 	return
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -371,7 +371,7 @@ func show_bond_rendering() -> void:
 	return
 
 
-func set_partially_selected_bonds(_in_partially_selected_bonds: PackedInt32Array) -> void:
+func refresh_bond_influence(_in_partially_selected_bonds: PackedInt32Array) -> void:
 	return
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
@@ -205,14 +205,11 @@ func lowlight_bonds(_in_bonds_ids: PackedInt32Array) -> void:
 
 
 func highlight_springs(in_springs_to_highlight: PackedInt32Array) -> void:
-	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
-	var nano_struct: NanoStructure = structure_context.nano_structure
 	for spring_id: int in in_springs_to_highlight:
 		_spring_renderer.change_spring_color(spring_id, COLOR_HIGHLIGHT, true)
 
 
 func lowlight_springs(in_springs_to_lowlight: PackedInt32Array) -> void:
-	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
 	for spring_id: int in in_springs_to_lowlight:
 		_spring_renderer.change_spring_color(spring_id, COLOR_LOWLIGHT, false)
 
@@ -236,7 +233,7 @@ func update(_in_delta_time: float) -> void:
 	return
 
 
-func set_partially_selected_bonds(_in_partially_selected_bonds: PackedInt32Array) -> void:
+func refresh_bond_influence(_in_partially_selected_bonds: PackedInt32Array) -> void:
 	assert(false, "Implement me")
 	return
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sticks_single_atom_representation/sticks_and_single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sticks_single_atom_representation/sticks_and_single_atom_representation.gd
@@ -143,7 +143,7 @@ func set_material_overlay(_in_material: Material) -> void:
 	_stick_representation.set_material_overlay(_in_material)
 
 
-func set_partially_selected_bonds(in_partially_selected_bonds: PackedInt32Array) -> void:
+func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array) -> void:
 	_single_atom_representation.set_partially_selected_bonds(in_partially_selected_bonds)
 	_stick_representation.set_partially_selected_bonds(in_partially_selected_bonds)
 

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -489,10 +489,10 @@ func disable_hydrogens() -> void:
 		structure_renderer.ensure_hydrogens_rendering_off()
 
 
-func set_partially_selected_bonds(in_partially_selected_bonds: PackedInt32Array, in_structure: AtomicStructure) -> void:
+func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array, in_structure: AtomicStructure) -> void:
 	if not enabled: return
 	var atomic_structure_renderer: AtomicStructureRenderer = _get_renderer_for_atomic_structure(in_structure)
-	atomic_structure_renderer.set_partially_selected_bonds(in_partially_selected_bonds)
+	atomic_structure_renderer.refresh_bond_influence(in_partially_selected_bonds)
 
 
 func set_atom_selection_position_delta(in_selection_delta: Vector3, in_structure: AtomicStructure) -> void:

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/atom_selection/atom_selection.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/atom_selection/atom_selection.gd
@@ -70,6 +70,13 @@ func get_non_selected_bonds_fully_influenced_by_selection() -> PackedInt32Array:
 	return PackedInt32Array(_non_selected_bonds_fully_influenced_by_atoms.keys())
 
 
+func get_bonds_partially_influenced_by_selection_as_dict() -> Dictionary:
+	return _bonds_partially_influenced_by_atoms.duplicate()
+
+
+func get_non_selected_bonds_fully_influenced_by_selection_as_dict() -> Dictionary:
+	return _non_selected_bonds_fully_influenced_by_atoms.duplicate()
+
 func get_newest_selected_atom_id() -> int:
 	if _atoms_selection.is_empty():
 		assert(false, "Can't return newest selected atom id, there is no selection")


### PR DESCRIPTION
Bonds disconnected from atoms during rotation
-----------

    fix bond independent movement after atom creation 🔨
    
    When user had non selected bond connecting two selected atoms and they
    created new atom, the bond moved together with newly created atom
    despite the fact the related atoms were standing still (not the bond
    nor related atoms were selected at that point)
    
    This issue was caused by the fact in such case shader never gets
    information that the bond is no longer connected to any selected atom
    This commit fixes the issue by ensuring SelectionDB.set_atom_selection
    always refreshes any involved bond


    fix bond independent movement after deselection 🔨
    
    When user had non selected bond connecting two selected atoms and they
    deselected those atoms one by one, then after doing drag drop selection
    the bond moved twice as fast as it should.
    
    It was caused by error in StickRepresentation where 'partial_selection'
    variable value was not representing real situation anymore (missing
    check for case where bond is no longer influenced by any atom)
    As a result of bond being inside this variable it has been moved twice,
    once by cpu and then by the shader



To anyone who will review this, it's probably the best to look at one commit at a time for simplicity