### PR TITLE
Fixes after selection preview rework

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/3d_preview.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/3d_preview.gd
@@ -6,7 +6,7 @@ var _workspace_context: WorkspaceContext = null
 
 
 func _ready() -> void:
-	three_d_preview_container.gui_input.connect(_on_d_preview_container_gui_input)
+	three_d_preview_container.gui_input.connect(_on_3d_preview_container_gui_input)
 
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:
@@ -16,6 +16,8 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 		in_workspace_context.structure_contents_changed.connect(_on_workspace_context_structure_contents_changed)
 		in_workspace_context.structure_about_to_remove.connect(_on_workspace_context_structure_about_to_remove)
 		in_workspace_context.atoms_position_in_structure_changed.connect(_on_workspace_context_atoms_position_in_structure_changed)
+		in_workspace_context.shape_transformed.connect(_on_workspace_context_shape_transformed)
+		in_workspace_context.motor_transformed.connect(_on_workspace_context_motor_transformed)
 	
 	var selected_atoms_count: int = 0
 	var contexts_with_selection: Array[StructureContext] = in_workspace_context.get_structure_contexts_with_selection()
@@ -31,7 +33,7 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	return selected_atoms_count > 1
 
 
-func _on_d_preview_container_gui_input(in_event: InputEvent) -> void:
+func _on_3d_preview_container_gui_input(in_event: InputEvent) -> void:
 	if in_event is InputEventMouseMotion and in_event.button_mask & MOUSE_BUTTON_MASK_LEFT:
 		var rotation_strength: float = deg_to_rad(-in_event.relative.x)
 		_workspace_context.get_rendering().rotate_selection_preview(rotation_strength)
@@ -51,6 +53,14 @@ func _on_workspace_context_structure_about_to_remove(_in_nano_structure: NanoStr
 
 func _on_workspace_context_atoms_position_in_structure_changed(_in_structure_context: StructureContext,
 			_in_atoms: PackedInt32Array) -> void:
+	ScriptUtils.call_deferred_once(_internal_update)
+
+
+func _on_workspace_context_shape_transformed(_in_transform: Transform3D, _in_shape_structure_id: int) -> void:
+	ScriptUtils.call_deferred_once(_internal_update)
+
+
+func _on_workspace_context_motor_transformed(_in_transform: Transform3D, _in_motor_structure_id: int) -> void:
 	ScriptUtils.call_deferred_once(_internal_update)
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/3d_preview.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/3d_preview.gd
@@ -16,8 +16,7 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 		in_workspace_context.structure_contents_changed.connect(_on_workspace_context_structure_contents_changed)
 		in_workspace_context.structure_about_to_remove.connect(_on_workspace_context_structure_about_to_remove)
 		in_workspace_context.atoms_position_in_structure_changed.connect(_on_workspace_context_atoms_position_in_structure_changed)
-		in_workspace_context.shape_transformed.connect(_on_workspace_context_shape_transformed)
-		in_workspace_context.motor_transformed.connect(_on_workspace_context_motor_transformed)
+		in_workspace_context.virtual_object_transform_changed.connect(_on_workspace_virtual_object_transform_changed)
 	
 	var selected_atoms_count: int = 0
 	var contexts_with_selection: Array[StructureContext] = in_workspace_context.get_structure_contexts_with_selection()
@@ -56,11 +55,7 @@ func _on_workspace_context_atoms_position_in_structure_changed(_in_structure_con
 	ScriptUtils.call_deferred_once(_internal_update)
 
 
-func _on_workspace_context_shape_transformed(_in_transform: Transform3D, _in_shape_structure_id: int) -> void:
-	ScriptUtils.call_deferred_once(_internal_update)
-
-
-func _on_workspace_context_motor_transformed(_in_transform: Transform3D, _in_motor_structure_id: int) -> void:
+func _on_workspace_virtual_object_transform_changed(_structure_context: StructureContext) -> void:
 	ScriptUtils.call_deferred_once(_internal_update)
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.tscn
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.tscn
@@ -17,6 +17,7 @@ script = ExtResource("2_0fyfn")
 
 [node name="SegmentedMultiMesh" parent="." index="0" instance=ExtResource("3_yh5yh")]
 multimesh = SubResource("MultiMesh_sb3wt")
-lod_bias = 0.1
-material_override = ExtResource("5_ks85r")
+_lod_bias = 0.1
+_material_override = ExtResource("5_ks85r")
 update_segments_on_movement = true
+visual_layers = 5

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -7,8 +7,6 @@ signal structure_renamed(struct: NanoStructure, new_name: String)
 signal selection_in_structures_changed(structure_contexts: Array[StructureContext])
 signal atoms_position_in_structure_changed(structure_context: StructureContext)
 signal atoms_locking_in_structure_changed(structure_context: StructureContext, atoms_changed: PackedInt32Array)
-signal shape_transformed(transform: Transform3D, structure_context_id: int)
-signal motor_transformed(transform: Transform3D, structure_context_id: int)
 signal structure_contents_changed(structure_context: StructureContext)
 signal virtual_object_transform_changed(structure_context: StructureContext)
 signal atoms_added_to_structure(structure_context: StructureContext, atom_ids: PackedInt32Array)
@@ -645,6 +643,7 @@ func _on_structure_contents_modified_arg1(_ignore_arg1: Variant, in_structure_co
 func _on_virtual_object_transform_changed(_ignore_arg1: Variant, in_structure_context_id: int) -> void:
 	if not workspace.has_structure_with_int_guid(in_structure_context_id):
 		return
+	set_meta(_META_CACHED_SELECTION_AABB, null)
 	var structure_context: StructureContext = get_structure_context(in_structure_context_id)
 	if structure_context != null:
 		virtual_object_transform_changed.emit(structure_context)
@@ -666,20 +665,6 @@ func _on_nano_structure_atoms_locking_changed(in_atoms_changed: PackedInt32Array
 	var structure_context: StructureContext = get_structure_context(in_structure_context_id)
 	if structure_context != null:
 		atoms_locking_in_structure_changed.emit(structure_context, in_atoms_changed)
-
-
-func _on_shape_structure_transform_changed(in_transform: Transform3D, in_structure_context_id: int) -> void:
-	if not workspace.has_structure_with_int_guid(in_structure_context_id):
-		return
-	set_meta(_META_CACHED_SELECTION_AABB, null)
-	shape_transformed.emit(in_transform, in_structure_context_id)
-
-
-func _on_motor_structure_transform_changed(in_transform: Transform3D, in_structure_context_id: int) -> void:
-	if not workspace.has_structure_with_int_guid(in_structure_context_id):
-		return
-	set_meta(_META_CACHED_SELECTION_AABB, null)
-	motor_transformed.emit(in_transform, in_structure_context_id)
 
 
 func _on_structure_context_virtual_object_selection_changed(_in_selected: bool, in_structure_context_id: int) -> void:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -7,6 +7,8 @@ signal structure_renamed(struct: NanoStructure, new_name: String)
 signal selection_in_structures_changed(structure_contexts: Array[StructureContext])
 signal atoms_position_in_structure_changed(structure_context: StructureContext)
 signal atoms_locking_in_structure_changed(structure_context: StructureContext, atoms_changed: PackedInt32Array)
+signal shape_transformed(transform: Transform3D, structure_context_id: int)
+signal motor_transformed(transform: Transform3D, structure_context_id: int)
 signal structure_contents_changed(structure_context: StructureContext)
 signal virtual_object_transform_changed(structure_context: StructureContext)
 signal atoms_added_to_structure(structure_context: StructureContext, atom_ids: PackedInt32Array)
@@ -664,6 +666,20 @@ func _on_nano_structure_atoms_locking_changed(in_atoms_changed: PackedInt32Array
 	var structure_context: StructureContext = get_structure_context(in_structure_context_id)
 	if structure_context != null:
 		atoms_locking_in_structure_changed.emit(structure_context, in_atoms_changed)
+
+
+func _on_shape_structure_transform_changed(in_transform: Transform3D, in_structure_context_id: int) -> void:
+	if not workspace.has_structure_with_int_guid(in_structure_context_id):
+		return
+	set_meta(_META_CACHED_SELECTION_AABB, null)
+	shape_transformed.emit(in_transform, in_structure_context_id)
+
+
+func _on_motor_structure_transform_changed(in_transform: Transform3D, in_structure_context_id: int) -> void:
+	if not workspace.has_structure_with_int_guid(in_structure_context_id):
+		return
+	set_meta(_META_CACHED_SELECTION_AABB, null)
+	motor_transformed.emit(in_transform, in_structure_context_id)
 
 
 func _on_structure_context_virtual_object_selection_changed(_in_selected: bool, in_structure_context_id: int) -> void:

--- a/godot_project/theme/theme_3d/available_themes/flat_theme/flat_ball.gdshader
+++ b/godot_project/theme/theme_3d/available_themes/flat_theme/flat_ball.gdshader
@@ -19,9 +19,6 @@ uniform float metallic;
 uniform vec3 uv1_scale;
 uniform vec3 uv1_offset;
 
-uniform vec3 camera_up_vector;
-uniform vec3 camera_right_vector;
-
 uniform float scale = 0.01;
 
 uniform float flat_saturation: hint_range(0,1) = 0.75;
@@ -70,15 +67,18 @@ void vertex() {
 	UV=UV*uv1_scale.xy+uv1_offset.xy;
 	
 	// outline
+	float is_preview = _unpack_flag(SELECTION_PREVIEW_VISUAL_LAYER, int(CAMERA_VISIBLE_LAYERS));
 	is_instance_hovered = is_atom_or_bond_hovered(COLOR.a);
 	is_outline = uv_is_outline(UV);
-	VERTEX += displace_outline(VERTEX, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR);
+	VERTEX += displace_outline(VERTEX, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR) * float_not(is_preview);;
 	
 	// Calculate rotation matrix to align model with camera
+	vec3 camera_right = normalize(INV_VIEW_MATRIX[0].xyz);
+	vec3 camera_up = normalize(INV_VIEW_MATRIX[1].xyz);
 	mat4 billboard_rot = mat4(
-		vec4(normalize(camera_right_vector), 0.0),
-		vec4(normalize(camera_up_vector), 0.0),
-		vec4(cross(normalize(camera_right_vector), normalize(camera_up_vector)), 0.0),
+		vec4(normalize(camera_right), 0.0),
+		vec4(normalize(camera_up), 0.0),
+		vec4(cross(normalize(camera_right), normalize(camera_up)), 0.0),
 		vec4(0.0, 0.0, 0.0, 1.0)
 	);
 	vec3 final_vertex = (billboard_rot * vec4(VERTEX, 1.0)).xyz;
@@ -91,6 +91,9 @@ void vertex() {
 
 	//apply translation delta
 	final_vertex += get_translation_delta(COLOR, MODEL_MATRIX);
+	
+	//preview visibility
+	final_vertex *= float_or(float_not(is_preview), is_atom_or_bond_selected(COLOR.a));
 	
 	VERTEX = hide_hydrogen_atoms(final_vertex, COLOR.a);
 }

--- a/godot_project/theme/theme_3d/available_themes/flat_theme/flat_bond.gdshader
+++ b/godot_project/theme/theme_3d/available_themes/flat_theme/flat_bond.gdshader
@@ -115,9 +115,10 @@ void vertex() {
 	COLOR.rgb = _apply_bond_highlight_factor(COLOR.rgb, right_active * is_bond_influence_highlight_enabled);
 	custom_color.rgb = _apply_bond_highlight_factor(custom_color.rgb, left_active * is_bond_influence_highlight_enabled);
 	
+	float is_preview = _unpack_flag(SELECTION_PREVIEW_VISUAL_LAYER, int(CAMERA_VISIBLE_LAYERS));
 	is_outline = uv_is_outline(UV);
 	is_instance_hovered = is_atom_or_bond_hovered(COLOR.a);
-	VERTEX += flat_calculate_bond_outline_displacement(VERTEX, NORMAL, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR);
+	VERTEX += flat_calculate_bond_outline_displacement(VERTEX, NORMAL, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR) * float_not(is_preview);
 	
 	vec3 vertex_position = VERTEX;
 	ROUGHNESS=roughness;
@@ -129,6 +130,9 @@ void vertex() {
 	
 	// translation
 	vertex_position += get_bond_translation_delta(VERTEX, COLOR, MODEL_MATRIX);
+	
+	//preview visibility
+	vertex_position *= float_or(float_not(is_preview), is_atom_or_bond_selected(COLOR.a));
 	
 	//
 	VERTEX = vertex_position;

--- a/godot_project/theme/theme_3d/available_themes/flat_theme/flat_capsule.gdshader
+++ b/godot_project/theme/theme_3d/available_themes/flat_theme/flat_capsule.gdshader
@@ -95,9 +95,10 @@ void vertex() {
 	COLOR.rgb = _apply_bond_highlight_factor(COLOR.rgb, right_active);
 	custom_color.rgb = _apply_bond_highlight_factor(custom_color.rgb, left_active);
 	
+	float is_preview = _unpack_flag(SELECTION_PREVIEW_VISUAL_LAYER, int(CAMERA_VISIBLE_LAYERS));
 	is_outline = uv_is_outline(UV);
 	is_instance_hovered = is_atom_or_bond_hovered(COLOR.a);
-	VERTEX += flat_calculate_bond_outline_displacement(VERTEX, NORMAL, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR);
+	VERTEX += flat_calculate_bond_outline_displacement(VERTEX, NORMAL, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR) * float_not(is_preview);
 	
 	//helper to prevent numerical errors
 	float cap_vertexes_above_local_pos = caps_starts_at_local_z_position - NUMERICAL_PRECISION;
@@ -130,6 +131,10 @@ void vertex() {
 	rotation[2] /= scale.z;
 	position /= scale;
 	position = (modelview * vec4(position, 1.0)).xyz;
+	
+	//preview visibility
+	position *= float_or(float_not(is_preview), is_atom_or_bond_selected(COLOR.a));
+	
 	VERTEX = position;
 	VERTEX = hide_hydrogen_bonds(VERTEX, COLOR.a, INSTANCE_CUSTOM.a);
 	VERTEX *= is_atom_or_bond_visible(COLOR.a);


### PR DESCRIPTION
Selected shape preview behaves as it appears inconsistently

-----------
    fix selection-preview for flat theme 🔨
    
    Flat theme has never been updated to work in new selection preview
    This commit fixes this oversight by applying changes needed for it to
    work


    refresh selection preview for shapes and motors 🔧
    
    This commit ensures the selection previews for shapes and motors will
    update on every motor/shape transform change
