### PR TITLE
fix non-existing function call 🔨

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/enhanced_sticks_and_balls_representation/enhanced_sticks_and_balls_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/enhanced_sticks_and_balls_representation/enhanced_sticks_and_balls_representation.gd
@@ -126,7 +126,7 @@ func set_material_overlay(_in_material: Material) -> void:
 
 
 func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array) -> void:
-	_stick_representation.set_partially_selected_bonds(in_partially_selected_bonds)
+	_stick_representation.refresh_bond_influence(in_partially_selected_bonds)
 
 
 func set_atom_selection_position_delta(in_movement_delta: Vector3) -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sticks_single_atom_representation/sticks_and_single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sticks_single_atom_representation/sticks_and_single_atom_representation.gd
@@ -144,8 +144,8 @@ func set_material_overlay(_in_material: Material) -> void:
 
 
 func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array) -> void:
-	_single_atom_representation.set_partially_selected_bonds(in_partially_selected_bonds)
-	_stick_representation.set_partially_selected_bonds(in_partially_selected_bonds)
+	_single_atom_representation.refresh_bond_influence(in_partially_selected_bonds)
+	_stick_representation.refresh_bond_influence(in_partially_selected_bonds)
 
 
 func set_atom_selection_position_delta(in_movement_delta: Vector3) -> void:


### PR DESCRIPTION
"Bonds disconnected from atoms during rotation"

-----------
The function has been renamed recently, but it was not updated everywhere
