### PR TITLE
remove redundant line on top of startup screen 🔧

### DIFF
--- a/godot_project/autoloads/initial_info_screen/initial_info_screen.tscn
+++ b/godot_project/autoloads/initial_info_screen/initial_info_screen.tscn
@@ -91,8 +91,7 @@ theme_override_constants/separation = 0
 [node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
 custom_minimum_size = Vector2(350, 0)
 layout_mode = 2
-text = "
-MSEP.one is a powerful, freely available, open-source platform to help with today's scientific tasks and foster designs for the future of generative nanotechnology.
+text = "MSEP.one is a powerful, freely available, open-source platform to help with today's scientific tasks and foster designs for the future of generative nanotechnology.
 
 With it you can design, visualize, and simulate nanodevices.
 


### PR DESCRIPTION
"Change the Start-Up Splash Screen Text"

-----------
It has been done in order to align the text vertically inside the popup


![image](https://github.com/user-attachments/assets/8f002aa4-23d3-4c7e-aa2e-415ba7edb404)
