### PR TITLE
Fix small molecules preview glitch

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
@@ -66,7 +66,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, in_structur
 
 func set_preview_position(in_position: Vector3) -> void:
 	var camera: Camera3D = get_workspace_context().get_editor_viewport().get_camera_3d()
-	var basis: Basis = camera.global_transform.basis
+	var basis: Basis = Basis()
 	var center_offset: Vector3 = basis * (_preview_size / 2.0)
 	_rendering.structure_preview_set_transform(Transform3D(basis, in_position - center_offset))
 


### PR DESCRIPTION
Small molecules preview graphical artifacts
-----------
    fix small molecules preview glitch 🔨
    
    After rotating camera small molecules had graphical glitch related to
    recent multimesh_atom.gdshader changes and inability to correctly
    transform atoms towards camera, shader is no longer prepared to serve
    objects with local rotation.
    Since it's the only instance of such rotation the most straightforward
    fix is to not rotate the model at all, this initial (preview) rotation
    is not crucial from user perspective

