### PR TITLE
fix double bond preview rotation 🔨

### DIFF
--- a/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
+++ b/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
@@ -82,7 +82,7 @@ func _update_preview() -> void:
 	var second_data: ElementData = PeriodicTable.get_by_atomic_number(_second_atomic_number)
 	var camera: Camera3D = get_viewport().get_camera_3d()
 	var dir_between_start_and_end: Vector3 = _first_pos.direction_to(_second_pos)
-	var up_vector: Vector3 = dir_between_start_and_end.cross(camera.basis.z)
+	var up_vector: Vector3 = dir_between_start_and_end.cross(camera.global_transform.basis.y)
 	var scale_factor: float = Representation.get_atom_scale_factor(_representation_settings)
 	var first_radius: float = Representation.get_atom_radius(first_data, _representation_settings) * scale_factor
 	var second_radius: float = Representation.get_atom_radius(second_data, _representation_settings) * scale_factor


### PR DESCRIPTION
"Drag-drop double bond looks like single bond"
-----------
fix double bond preview rotation 🔨
    
    There has been a problem with double bond preview, from user
    perspective it looked exactly like single bond preview.
    It was caused by improper rotation that always positioned that mesh to
    be seen 'from a side'.
