### PR TITLE
Fix a corner case where side docker would not scroll to focus the view on the requested highlighted category

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -277,7 +277,8 @@ func request_workspace_docker_focus(in_docker_unique_name: StringName, in_catego
 	
 	if in_category_name == StringName():
 		return
-	
+	# Wait one frame to allow controls update their visibility
+	await get_tree().process_frame
 	if docker.has_category(in_category_name):
 		docker.highlight_category(in_category_name)
 


### PR DESCRIPTION
----------
Task: Move Camera menu in the topbar inside the View menu to match new RingMenu layout
 - This was a bug detected during feedback: docker should not scroll to show the entire highlighted category
