### PR TITLE
cleanup startup warnings 🔧

### DIFF
--- a/godot_project/editor/controls/workspace_view/tab_bar_active_workspaces.gd
+++ b/godot_project/editor/controls/workspace_view/tab_bar_active_workspaces.gd
@@ -40,7 +40,7 @@ func _ready() -> void:
 	MolecularEditorContext.homepage_activated.connect(_on_homepage_activated)
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	var tab_bar_rect: Rect2 = tab_bar_active_workspaces.get_global_rect()
 	var mouse_pos: Vector2 = get_global_mouse_position()
 	if not tab_bar_rect.has_point(mouse_pos):

--- a/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
@@ -65,7 +65,6 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, in_structur
 
 
 func set_preview_position(in_position: Vector3) -> void:
-	var camera: Camera3D = get_workspace_context().get_editor_viewport().get_camera_3d()
 	var basis: Basis = Basis()
 	var center_offset: Vector3 = basis * (_preview_size / 2.0)
 	_rendering.structure_preview_set_transform(Transform3D(basis, in_position - center_offset))

--- a/godot_project/editor/rendering/virtual_anchor_and_spring_renderer/virtual_anchor_preview.tscn
+++ b/godot_project/editor/rendering/virtual_anchor_and_spring_renderer/virtual_anchor_preview.tscn
@@ -5,11 +5,3 @@
 
 [node name="VirtualAnchorPreview" instance=ExtResource("1_2qmfx")]
 script = ExtResource("2_15h8q")
-
-[node name="Model" parent="." index="0"]
-transform = Transform3D(0.013, 0, 0, 0, -5.68248e-10, 0.008, 0, -0.013, -3.49691e-10, 0, 0, 0)
-
-[node name="Circle" parent="Model" index="0"]
-transparency = 0.35
-
-[editable path="Model"]

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
@@ -459,10 +459,7 @@ func get_selection_snapshot() -> Dictionary:
 
 func apply_selection_snapshot(in_snapshot: Dictionary) -> void:
 	_is_virtual_object_selected = in_snapshot.is_virtual_object_selected
-	
-	var nano_structure: NanoStructure = _structure_context.nano_structure
 	var atom_snapshot: Array = in_snapshot.atom_snapshot
 	var spring_snapshot: Array = in_snapshot.spring_snapshot
-	
 	var _apply_result: AtomSelection.ApplySnapshotResult = _atom_selection.apply_snapshot(atom_snapshot)
 	_spring_selection.apply_snapshot(spring_snapshot)


### PR DESCRIPTION
This commit cleanups startup warnings, such as:
- unused variables
- vanished nodes

Vanished node warning was caused by the fact some parent scenes has changed but child scene still tried to overwrite values on nodes which no longer exists