### PR TITLE
Correct alignment of element picker in 'Appy atoms to shape' panel

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.tscn
@@ -25,6 +25,7 @@ theme_type_variation = &"SubcategoryPanel"
 [node name="ElementPicker" parent="PanelContainerElement" instance=ExtResource("2_wxv1h")]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 4
 
 [node name="Tree" type="Tree" parent="."]
 unique_name_in_owner = true


### PR DESCRIPTION
Task: "Apply Atoms to Shapes" section UI is not correctly set up and stretches incorrectly
-----------

