### PR TITLE
Show 'Help > About MSEP.one' menu item in MacOS

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_help/menu_help.gd
+++ b/godot_project/editor/controls/menu_bar/menu_help/menu_help.gd
@@ -7,22 +7,11 @@ enum {
 	POPUP_ID_DOCUMENTATION = 1,
 }
 
-@onready var _is_macos: bool = OS.get_name().to_lower() == "macos"
-
-func _ready() -> void:
-	super._ready()
-	if _is_macos:
-		# MacOS has it's own About MSEP in the Application menu
-		# We remove it from the Help menu to avoid having duplicated functionality
-		var idx: int = get_item_index(POPUP_ID_ABOUT_MSEP_ONE)
-		remove_item(idx)
-
 
 func _update_menu() -> void:
-	if not _is_macos:
-		var has_workspace_context: bool = MolecularEditorContext.get_current_workspace_context() != null
-		var can_show_about: bool = not has_workspace_context or not BusyIndicator.is_active()
-		set_item_disabled(get_item_index(POPUP_ID_ABOUT_MSEP_ONE), !can_show_about)
+	var has_workspace_context: bool = MolecularEditorContext.get_current_workspace_context() != null
+	var can_show_about: bool = not has_workspace_context or not BusyIndicator.is_active()
+	set_item_disabled(get_item_index(POPUP_ID_ABOUT_MSEP_ONE), !can_show_about)
 	set_item_disabled(get_item_index(POPUP_ID_DOCUMENTATION), false)
 
 


### PR DESCRIPTION
It was hidden because it was already accesible from the Application Menu, but removing it causes a regression where 'Tutorials and Documentation' doesn't work on this platform

Task: BUG - Tutorial PDF doesn't launch **ON MACOS** when selected from the menu bar pulldown menu
-----------

