### PR TITLE
Fix crash on group cut

### DIFF
--- a/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_child_list/structure_child_list.gd
+++ b/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_child_list/structure_child_list.gd
@@ -96,8 +96,9 @@ func _on_workspace_context_structure_added(in_nano_structure: NanoStructure) -> 
 
 func _on_workspace_context_structure_removed(in_nano_structure: NanoStructure) -> void:
 	var other_parent_id: int = in_nano_structure.int_parent_guid
-	var self_parent_id: int = \
-			0 if _parent_structure_context == null else _parent_structure_context.nano_structure.int_guid
+	var is_structure_context_valid: bool = _parent_structure_context != null and \
+			is_instance_valid(_parent_structure_context.nano_structure)
+	var self_parent_id: int = 0 if not is_structure_context_valid else _parent_structure_context.nano_structure.int_guid
 	if other_parent_id == self_parent_id:
 		rebuild_list()
 


### PR DESCRIPTION
"Crash on group cut"
-----------
    fix crash on group cut 🔨
    
    This commit fixes a crash that happens when user is cutting a structure
    Crash happened in very specific scenario in which:
    1. User creates two groups, one parent of the other
    2. User ensures the child structure is selected/edited and merges it up
    3. User ensures the parent structure is selected/edited and performs
       cut operation on it
    
    The direct cause of the crash was insufficient check on 'parent
    structure' availability inside StructureChildList
