### PR TITLE
Select source atom when performing drag-drop 🔧

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
@@ -189,6 +189,8 @@ func _drag_drop_bond_preview_update(in_position: Vector3) -> void:
 				AtomicStructure.INVALID_BOND_ID, AtomicStructure.INVALID_SPRING_ID)
 		return
 	
+	structure_context.set_atom_selection([_drag_start_atom_id])
+	
 	assert(_target_atom_id == AtomicStructure.INVALID_ATOM_ID, "This method should only handle dragging into void")
 	rendering.atom_preview_show()
 	rendering.atom_preview_set_position(in_position).atom_preview_set_atomic_number(second_atom_atomic_nmb)


### PR DESCRIPTION
"Preview Atom Can be Wrong Size in Perspective mode"
-----------
    select source atom when performing drag-drop 🔧
    
    This commit ensures the source atom of drag and drop is selected.
    It's done in order to ensure preview is being visualized at creation
    distance which is expected by the user
    (in case when selected atom was at significantly different position
    from drag-drop source atom the preview was visualized nearby that
    selection)

