### PR TITLE
Update the color settings panel when the theme is changed

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/color_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/color_settings.gd
@@ -67,16 +67,29 @@ func _setup(out_workspace_context: WorkspaceContext) -> void:
 			and is_instance_valid(_workspace_context.workspace.representation_settings) \
 			and _workspace_context.workspace.representation_settings.changed.is_connected(_on_representation_settings_changed):
 		_workspace_context.workspace.representation_settings.changed.disconnect(_on_representation_settings_changed)
+		_workspace_context.workspace.representation_settings.theme_changed.disconnect(_on_representation_settings_changed)
 		_workspace_context.history_snapshot_applied.disconnect(_on_workspace_context_history_snapshot_applied)
+
 	_workspace_context = out_workspace_context
 	_workspace_context.workspace.representation_settings.changed.connect(_on_representation_settings_changed)
+	_workspace_context.workspace.representation_settings.theme_changed.connect(_on_representation_settings_changed)
 	_workspace_context.history_snapshot_applied.connect(_on_workspace_context_history_snapshot_applied)
 	_on_representation_settings_changed()
 
 
 func _on_representation_settings_changed() -> void:
-	_background_color_button.set_color(_workspace_context.workspace.representation_settings.get_custom_background_color())
-	_selection_color_button.set_color(_workspace_context.workspace.representation_settings.get_custom_selection_outline_color())
+	var settings: RepresentationSettings = _workspace_context.workspace.representation_settings
+	var theme_3d: Theme3D = settings.get_theme()
+	var background_color: Color = theme_3d.get_background_color()
+	var outline_color: Color = theme_3d.get_highlight_color()
+	
+	if settings.get_custom_background_color_enabled():
+		background_color = settings.get_custom_background_color()
+	if settings.get_custom_selection_outline_color_enabled():
+		outline_color = settings.get_custom_selection_outline_color()
+
+	_background_color_button.set_color(background_color)
+	_selection_color_button.set_color(outline_color)
 
 
 func _on_workspace_context_history_snapshot_applied() -> void:

--- a/godot_project/theme/theme_3d/theme_3d.gd
+++ b/godot_project/theme/theme_3d/theme_3d.gd
@@ -143,3 +143,7 @@ func create_environment() -> Environment:
 
 func get_highlight_color() -> Color:
 	return _highlight_color
+
+
+func get_background_color() -> Color:
+	return _environment.background_color


### PR DESCRIPTION
Fixes: BUG - Background color selection box doesn't change when changing themes

-----------
The color boxes in the settings panel were not updated when switching from one theme to another.
