### PR TITLE
Improve "auto atoms posing" discoverability and usage

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
@@ -83,4 +83,7 @@ func _on_show_hydrogens_toggle_toggled(button_pressed: bool) -> void:
 	else:
 		_workspace_context.disable_hydrogens_visualization(true)
 	_workspace_context.snapshot_moment("Change Hydrogen Visibility")
-	
+
+
+func _on_show_potential_atoms_toggle_toggled(button_pressed: bool) -> void:
+	_workspace_context.workspace.representation_settings.set_display_auto_posing(button_pressed)

--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
@@ -41,6 +41,12 @@ layout_mode = 2
 button_pressed = true
 text = "Show Hydrogens"
 
+[node name="ShowPotentialAtomsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer"]
+layout_mode = 2
+button_pressed = true
+text = "Show Potential Atom Positions"
+
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowBondsToggle" to="." method="_on_show_bonds_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowLabelsToggle" to="." method="_on_show_labels_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowHydrogensToggle" to="." method="_on_show_hydrogens_toggle_toggled"]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowPotentialAtomsToggle" to="." method="_on_show_potential_atoms_toggle_toggled"]

--- a/godot_project/editor/controls/editor_viewport_container/widgets/camera_widget/CameraWidget.gd
+++ b/godot_project/editor/controls/editor_viewport_container/widgets/camera_widget/CameraWidget.gd
@@ -82,14 +82,6 @@ func _process(_delta: float) -> void:
 	_manage_pressed_visuals()
 	_move_towards_the_goal()
 	
-	if _previous_move_direction != MoveDirection.NONE:
-		if _move_direction == MoveDirection.NONE:
-			if _editor_viewport.get_workspace_context().has_transformable_selection() && \
-					GizmoRoot.selected_node:
-						GizmoRoot.enable_gizmo()
-		else:
-			GizmoRoot.disable_gizmo()
-	
 	_previous_move_direction = _move_direction
 
 

--- a/godot_project/editor/input_handlers/camera_input_handler.gd
+++ b/godot_project/editor/input_handlers/camera_input_handler.gd
@@ -251,8 +251,6 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, \
 					axes_widget.start_mouse_wheel_movement_step()
 			else:
 				_reset_mouse()
-				if axes_widget_gizmo.workspace_has_transformable_selection:
-					GizmoRoot.enable_gizmo()
 		elif in_input_event is InputEventMouseMotion:
 			# To restore orbiting intertia check: 8c59342316b0407e60043b6a31772e39265e7275
 			axes_widget.set_mouse_delta(in_input_event.relative)
@@ -432,9 +430,7 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, \
 	
 	if is_direction_key_pressed:
 		return true
- 
-	if axes_widget_gizmo.workspace_has_transformable_selection:
-		GizmoRoot.enable_gizmo()
+	
 	return false
 
 

--- a/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
@@ -14,6 +14,7 @@ var _structure_context_2_initial_object_transforms: Dictionary = {
 }
 var _selection_initial_position: Vector3 = Vector3()
 var _is_grabbed: bool = false
+var _other_handler_has_exclusivity: bool = false
 
 # region: virtual
 
@@ -194,6 +195,13 @@ func handle_inputs_end() -> void:
 		_apply_selection_transform()
 		GizmoRoot.grab_mode = GizmoRoot.GrabMode.NONE
 	GizmoRoot.disable_gizmo()
+	_other_handler_has_exclusivity = true
+
+
+func handle_inputs_resume() -> void:
+	if get_workspace_context().has_transformable_selection():
+		GizmoRoot.enable_gizmo()
+	_other_handler_has_exclusivity = false
 
 
 ## Hides the transform gizmo when creating atoms chains
@@ -431,6 +439,8 @@ func _force_gizmo_update() -> void:
 		_selection_initial_position = _init_initial_positions_and_determine_center()
 		_helper.global_transform.basis = Basis()
 		_helper.global_position = _selection_initial_position
+	if _other_handler_has_exclusivity:
+		GizmoRoot.disable_gizmo()
 
 
 func _hide_gizmo() -> void:

--- a/godot_project/project_workspace/structs/representation_settings.gd
+++ b/godot_project/project_workspace/structs/representation_settings.gd
@@ -13,7 +13,7 @@ signal color_palette_changed(new_color_palette: PeriodicTable.ColorPalette)
 const LABELS_VISIBLE_BY_DEFAULT = false
 const HYDROGENS_VISIBLE_BY_DEFAULT = true
 const BONDS_VISIBLE_BY_DEFAULT = true
-
+const ATOMS_AUTO_POSING_VISIBLE_BY_DEFAULT = true
 
 enum UserAtomSizeSource {
 	PHYSICAL_RADIUS,
@@ -36,6 +36,9 @@ enum UserAtomSizeSource {
 
 
 @export var _display_atom_labels: bool = LABELS_VISIBLE_BY_DEFAULT
+
+
+@export var _display_auto_posing: bool = ATOMS_AUTO_POSING_VISIBLE_BY_DEFAULT
 
 
 @export var _custom_selection_outline_color_enabled: bool = false
@@ -103,6 +106,15 @@ func set_display_atom_labels(new_display_atom_labels: bool) -> void:
 
 func get_display_atom_labels() -> bool:
 	return _display_atom_labels
+
+
+func set_display_auto_posing(new_display_auto_posing: bool) -> void:
+	_display_auto_posing = new_display_auto_posing
+	emit_changed()
+
+
+func get_display_auto_posing() -> bool:
+	return _display_auto_posing
 
 
 func set_bond_visibility_and_notify(new_bond_visibility: bool) -> void:


### PR DESCRIPTION
The feature showing potential atoms positions is currently hidden behind a shortcut. 

+ Add a toggle under the Visibility settings (in the workspace docker)
  - When enabled, the ghost positions are always visible (as long as there is a selection)
+ When the Alt key is held:
  - Create mode is automatically enabled
  - Force the handler as an exclusive consumer to hide the transform gizmo which appears on top of the atoms candidates