### PR TITLE
Fix: Specify utf-8 encoding to ensure proper handling of extended characters

### DIFF
--- a/godot_project/python/scripts/openmm_server.py
+++ b/godot_project/python/scripts/openmm_server.py
@@ -815,7 +815,8 @@ def create_forcefield_for_topology(topology_payload: PayloadTopologyReader) -> F
 	forcefield = ForceField(openff_forcefield_path)
 	for i in range(1, len(topology_payload.forcefields)):
 		forcefield_extension_path = os.path.join(os.path.dirname(__file__ ), "offxml_extensions", topology_payload.forcefields[i])
-		forcefield.parse_sources([forcefield_extension_path])
+		with open(forcefield_extension_path, 'r', encoding='utf-8') as f:
+			forcefield.parse_sources([f])
 	return forcefield
 
 


### PR DESCRIPTION
'ascii' codec can't decode byte 0xe2 in position 1467: ordinal not in range(128) #95 
-----------
 
The error occurred because Python was trying to read the file using ASCII encoding by default, but encountered a non-ASCII character (byte 0xe2) which couldn't be decoded.

This is a common issue that can occur specifically on Linux because different operating systems have different default file encodings:
- Windows typically defaults to cp1252 (a superset of ASCII)
- macOS typically defaults to UTF-8
- Linux's default can vary, but often defaults to ASCII

So we explicitly set `utf-8` as the default encoding.