### PR TITLE
Fix the auto pose recommendations and bond order

### DIFF
--- a/godot_project/autoloads/data/ElementData.gd
+++ b/godot_project/autoloads/data/ElementData.gd
@@ -75,4 +75,3 @@ func _get_contact_radius() -> float:
 		return contact_radius
 	var fallback_factor: float = ProjectSettings.get_setting(VAN_DER_WAALS_FALLBACK_FACTOR_SETTING, 1.5)
 	return render_radius * fallback_factor
-

--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -459,7 +459,7 @@ func _paste_atoms_and_bonds_in_structure(
 		old_atom_id_to_new_atom_id[atom.origin_id] = old_index_to_new_index[idx]
 		if in_auto_bond_order > -1:
 			assert(atom.origin_id > -1, "Bonded paste has been used, but there is no information about the source atom")
-			var valence_left: int = out_structure.atom_get_remaininig_valence(atom.origin_id)
+			var valence_left: int = out_structure.atom_get_remaining_valence(atom.origin_id)
 			var valance_allows_new_bond: bool = valence_left > 0
 			if valance_allows_new_bond:
 				var new_bond_order: int = min(in_auto_bond_order, valence_left)

--- a/godot_project/autoloads/openmm/openmm_payload.gd
+++ b/godot_project/autoloads/openmm/openmm_payload.gd
@@ -280,7 +280,7 @@ func _create_random_nudge() -> Vector3:
 # Returns a list of positions where hydrogens bonded to atoms would preferably be placed
 func _passivate_atom(in_structure: AtomicStructure, in_atom_id: int) -> PackedVector3Array:
 	var directions: PackedVector3Array = []
-	var remaininig_valence: int = in_structure.atom_get_remaininig_valence(in_atom_id)
+	var remaininig_valence: int = in_structure.atom_get_remaining_valence(in_atom_id)
 	if remaininig_valence > 0:
 		# Add hydrogens
 		var atomic_number: int = in_structure.atom_get_atomic_number(in_atom_id)

--- a/godot_project/editor/rendering/atom_autopose_preview/atom_autopose_preview.gd
+++ b/godot_project/editor/rendering/atom_autopose_preview/atom_autopose_preview.gd
@@ -5,7 +5,9 @@ class AtomCandidate:
 	var structrure_id: int
 	var atom_ids: PackedInt32Array
 	var atom_position: Vector3
+	var total_free_valence: int
 	var pos_2d_cache: Vector2 = Vector2.ONE * -15
+
 
 
 var _new_atomic_number: int = PeriodicTable.ATOMIC_NUMBER_HYDROGEN
@@ -57,7 +59,7 @@ func _ready() -> void:
 	_camera = get_viewport().get_camera_3d()
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if visible and is_instance_valid(_camera) and (
 			_camera.global_transform != _camera_last_transform
 			or _camera.size != _camera_last_zoom
@@ -78,16 +80,10 @@ func _draw() -> void:
 	_camera = get_viewport().get_camera_3d()
 	var camera_up_vector: Vector3 = _camera.basis.y
 	var curr_atom_data: ElementData = PeriodicTable.get_by_atomic_number(_new_atomic_number)
-	const CARBON: int = 6
-	var carbon_data: ElementData = PeriodicTable.get_by_atomic_number(CARBON)
-	const NITROGEN: int = 7
-	var nitrogen_data: ElementData = PeriodicTable.get_by_atomic_number(NITROGEN)
-	const OXIGEN: int = 8
-	var oxygen_data: ElementData = PeriodicTable.get_by_atomic_number(OXIGEN)
 	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context() as WorkspaceContext
 	var context: StructureContext = null
 	var atomic_structure: AtomicStructure = null
-	var candidate_element: ElementData
+	var candidate_element: ElementData = curr_atom_data
 	for candidate: AtomCandidate in _candidates:
 		if context == null or context.nano_structure.int_guid != candidate.structrure_id:
 			# OPTIMIZATION: Candidates are meant to be grouped by structure,
@@ -103,15 +99,7 @@ func _draw() -> void:
 		if not get_rect().grow(15).has_point(pos_2d):
 			# clip out of the view
 			continue
-		match candidate.atom_ids.size():
-			1: # Whatever user selected
-				candidate_element = curr_atom_data
-			2: # Merging 2 candidates, use Oxygen
-				candidate_element = oxygen_data
-			3: # Merging 3 candidates, use Nitrogen
-				candidate_element = nitrogen_data
-			4, _: # Merging 4 or more candidates, use Carbon
-				candidate_element = carbon_data
+		
 		var atom_color: Color = Color.WHITE if _hovered_candidate == candidate else candidate_element.color
 		var bond_color: Color = Color.WHITE if _hovered_candidate == candidate else candidate_element.bond_color
 		var label_color: Color = Color.DIM_GRAY if _hovered_candidate == candidate else candidate_element.font_color
@@ -137,7 +125,6 @@ func _draw() -> void:
 
 func _draw_line_connection(in_from: Vector2, in_to: Vector2, in_color: Color) -> void:
 	draw_line(in_from, in_to, in_color, 2)
-
 
 
 func _draw_wedge_connection(in_from: Vector2, in_to: Vector2, in_color: Color) -> void:

--- a/godot_project/project_workspace/structs/atomic_structure.gd
+++ b/godot_project/project_workspace/structs/atomic_structure.gd
@@ -340,7 +340,7 @@ func atom_find_bond_between(_in_atom_id_a: int, _in_atom_id_b: int) -> int:
 
 
 ## Returns remaining valence which is still free to use
-func atom_get_remaininig_valence(in_atom_id: int) -> int:
+func atom_get_remaining_valence(in_atom_id: int) -> int:
 	var data: ElementData = PeriodicTable.get_by_atomic_number(atom_get_atomic_number(in_atom_id))
 	var atom_bonds: PackedInt32Array = atom_get_bonds(in_atom_id)
 	var used_valence: int = 0


### PR DESCRIPTION
This PR forces the auto pose feature to always use the selected atomic element, instead of switching to oxygen or hydrogens based on the parent atom free valence.

Clicking a candidate will now pick a smaller bond order if necessary. 