### PR TITLE
Pause the simulation playback when pressing the 'End simulation' button

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -667,6 +667,9 @@ func _on_button_end_pressed() -> void:
 	_workspace_context.end_simulation_if_running()
 	_button_end.disabled = true
 	_total_simulation_len_nanoseconds = _simulation_length_nanoseconds
+	
+	if _status == Status.PLAYING:
+		_status = Status.PAUSED
 
 
 func _on_button_view_alerts_pressed() -> void:


### PR DESCRIPTION
In the simulation docker, pressing "End simulation" will cause openMM to stop processing the simulation, but MSEP will keep playing the cached frame.
This PR simply pauses the playback (the user can resume until the end of the processed sim)