### PR TITLE
Fix assert after deleting a structure during a simulation

### DIFF
--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1222,6 +1222,8 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 			continue
 		_structure_contexts[structure_context_id].queue_free()
 		_structure_contexts.erase(structure_context_id)
+		_modified_structure_contexts.erase(structure_context_id)
+		_selection_modified_structure_contexts.erase(structure_context_id)
 	
 	_current_structure_context_id = in_snapshot["_current_structure_context_id"]
 	


### PR DESCRIPTION
Finding the root cause for that one was tricky.

When deleting a structure, if a simulation is running, two snapshots are taken to avoid merging two user operations under a single undo step.

But reapplying the final state was inconsistent because `_modified_structure_contexts` is not part of the snapshot and still contains a reference to the deleted structures. This PR clears this array on restore.

I don't think it should be part of the snapshot, since there's already code in place to take care of the orphaned structures, but if that's not right, I can put it in the snapshot data. 