### PR TITLE
Fix single atoms not visible in stick view

### DIFF
--- a/godot_project/autoloads/shader_precompiler/shader_precompiler.gd
+++ b/godot_project/autoloads/shader_precompiler/shader_precompiler.gd
@@ -49,8 +49,6 @@ func _ensure_atom_material_preprendered(in_multimesh_instance: MultiMeshInstance
 	in_multimesh_instance.multimesh.instance_count = 2
 	in_multimesh_instance.multimesh.visible_instance_count = 2
 	in_multimesh_instance.material_override = shader
-	shader.set_shader_parameter("camera_up_vector", camera.global_transform.basis.y)
-	shader.set_shader_parameter("camera_right_vector", camera.global_transform.basis.x)
 	shader.set_shader_parameter("gizmo_origin", gizmo.global_transform.basis.y)
 	shader.set_shader_parameter("gizmo_rotation", gizmo.global_transform.basis.x)
 	shader.set_shader_parameter("scale", 1.0)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/billboard.gdshaderinc
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/billboard.gdshaderinc
@@ -1,0 +1,16 @@
+// Usage
+// VERTEX = billboard_atom(VERTEX, INV_VIEW_MATRIX);
+vec3 billboard_atom(vec3 vertex, mat4 inv_view_matrix) {
+	// Calculate rotation matrix to align model with camera
+	vec3 camera_right = normalize(inv_view_matrix[0].xyz);
+	vec3 camera_up = normalize(inv_view_matrix[1].xyz);
+	mat4 billboard_rot = mat4(
+		vec4(camera_right, 0.0),
+		vec4(camera_up, 0.0),
+		vec4(normalize(cross(camera_right, camera_up)), 0.0),
+		vec4(0.0, 0.0, 0.0, 1.0)
+	);
+	
+	// Transform the vertex using the billboard rotation
+	return (billboard_rot * vec4(vertex, 1.0)).xyz;
+}

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/hydrogens.gdshaderinc
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/hydrogens.gdshaderinc
@@ -5,9 +5,6 @@
 
 
 const float HYDROGEN_LABEL_ID = 0.0;
-const vec3 HYDROGEN_ATOM_COLOR = vec3(0.549,  0.471,   0.0);
-const vec3 HYDROGEN_BOND_COLOR = vec3(1.0,    0.7843,  0.0);
-const float HYDROGEN_SPRING_ALPHA = 0.1;
 
 uniform float show_hydrogens: hint_range(0.0, 1.0, 1.0) = 1.0;
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/label_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/label_material.gd
@@ -1,9 +1,6 @@
 class_name LabelMaterial extends StructureRepresentationMaterial
 
 
-const UNIFORM_CAMERA_FORWARD_VECTOR := &"camera_forward_vector"
-const UNIFORM_CAMERA_UP_VECTOR := &"camera_up_vector"
-const UNIFORM_CAMERA_RIGHT_VECTOR := &"camera_right_vector"
 const UNIFORM_CAMERA_SIZE := &"camera_size"
 const UNIFORM_SCALE := &"scale"
 const UNIFORM_GIZMO_ORIGIN = &"gizmo_origin"
@@ -12,9 +9,8 @@ const UNIFORM_SELECTION_DELTA = &"selection_delta"
 
 
 func _init() -> void:
-	RenderingUtils.has_uniforms(self, [UNIFORM_CAMERA_UP_VECTOR, UNIFORM_CAMERA_RIGHT_VECTOR,
-			UNIFORM_SHOW_HYDROGENS, UNIFORM_SCALE, UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION,
-			UNIFORM_SELECTION_DELTA])
+	RenderingUtils.has_uniforms(self, [UNIFORM_SHOW_HYDROGENS, UNIFORM_SCALE,
+		UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA])
 
 
 func set_selectable(in_is_selectable: bool) -> LabelMaterial:
@@ -30,11 +26,7 @@ func set_scale_factor(new_scale_factor: float) -> LabelMaterial:
 	return self
 
 
-func update_camera(in_camera_forward_vector: Vector3, in_camera_up_vector: Vector3,
-			in_camera_right_vector: Vector3, in_camera_size: float) -> LabelMaterial:
-	set_shader_parameter(UNIFORM_CAMERA_FORWARD_VECTOR, in_camera_forward_vector)
-	set_shader_parameter(UNIFORM_CAMERA_UP_VECTOR, in_camera_up_vector)
-	set_shader_parameter(UNIFORM_CAMERA_RIGHT_VECTOR, in_camera_right_vector)
+func update_camera(in_camera_size: float) -> LabelMaterial:
 	set_shader_parameter(UNIFORM_CAMERA_SIZE, in_camera_size)
 	return self
 
@@ -49,6 +41,6 @@ func update_selection_delta(in_selection_movement_delta: Vector3) -> void:
 
 
 func copy_state_from(in_from_material: ShaderMaterial) -> void:
-	RenderingUtils.copy_selected_uniforms_from(in_from_material, self, [UNIFORM_CAMERA_UP_VECTOR, 
-			UNIFORM_CAMERA_RIGHT_VECTOR, UNIFORM_SHOW_HYDROGENS, UNIFORM_SCALE, UNIFORM_GIZMO_ORIGIN, 
+	RenderingUtils.copy_selected_uniforms_from(in_from_material, self, [
+			UNIFORM_SHOW_HYDROGENS, UNIFORM_SCALE, UNIFORM_GIZMO_ORIGIN, 
 			UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA])

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/labels_representation.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/labels_representation.gdshader
@@ -4,6 +4,7 @@ render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlic
 
 #include "res://editor/rendering/atomic_structure_renderer/representation/hydrogens.gdshaderinc"
 #include "res://editor/rendering/atomic_structure_renderer/representation/gizmo_transform_delta.gdshaderinc"
+#include "res://editor/rendering/atomic_structure_renderer/representation/billboard.gdshaderinc"
 
 // determines the relationship between atom size and label size
 const float LABEL_SCALE = 0.6;
@@ -20,9 +21,6 @@ uniform float distance_fade_min;
 uniform float distance_fade_max;
 
 // camera info
-uniform vec3 camera_forward_vector;
-uniform vec3 camera_up_vector;
-uniform vec3 camera_right_vector;
 uniform float camera_size;
 
 // atom scale
@@ -34,15 +32,8 @@ void vertex() {
 	
 	mat4 inv_model_mat = inverse(MODEL_MATRIX);
 
-	// Calculate rotation matrix to align model with camera
-	mat4 billboard_rot = mat4(
-		vec4(normalize(camera_right_vector), 0.0),
-		vec4(normalize(camera_up_vector), 0.0),
-		vec4(cross(normalize(camera_right_vector), normalize(camera_up_vector)), 0.0),
-		vec4(0.0, 0.0, 0.0, 1.0)
-	);
-	
-	VERTEX = (billboard_rot * vec4(VERTEX, 1.0)).xyz;
+	// Make the atom face the camera
+	VERTEX = billboard_atom(VERTEX, INV_VIEW_MATRIX);
 	
 	// apply scale
 	VERTEX *= scale * LABEL_SCALE;
@@ -54,7 +45,8 @@ void vertex() {
 	VERTEX += get_translation_delta(COLOR, MODEL_MATRIX);
 	
 	// move a bit in front of the atoms
-	vec3 localCameraFacingVector = (inv_model_mat * vec4(camera_forward_vector, 0.0)).xyz;
+	vec3 camera_forward = normalize(INV_VIEW_MATRIX[2].xyz);
+	vec3 localCameraFacingVector = (inv_model_mat * vec4(camera_forward, 0.0)).xyz;
 	float atom_radius = COLOR.b;
 	// determined experimentally by checking how small and big atom's labels are behaving on minimal and maximal scale
 	float additional_distance_factor = 0.12 * scale - atom_radius * scale * 0.12;

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
@@ -264,11 +264,7 @@ func update(in_delta: float) -> void:
 	_segmented_multimesh.update(in_delta)
 	
 	var camera: Camera3D = get_viewport().get_camera_3d()
-	var to_local: Quaternion = Quaternion(self.global_basis.inverse())
-	var cam_forward: Vector3 = camera.global_transform.basis.z
-	var cam_up: Vector3 = to_local * camera.global_transform.basis.y
-	var cam_right: Vector3 = to_local * camera.global_transform.basis.x
-	_material.update_camera(cam_forward, cam_up, cam_right, camera.size)
+	_material.update_camera(camera.size)
 
 
 func set_transparency(_in_transparency: float) -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/assets/single_atom_representation.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/assets/single_atom_representation.gdshader
@@ -8,10 +8,8 @@ render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlic
 #include "res://editor/rendering/atomic_structure_renderer/representation/outlines.gdshaderinc"
 #include "res://editor/rendering/atomic_structure_renderer/representation/gizmo_transform_delta.gdshaderinc"
 #include "res://editor/rendering/atomic_structure_renderer/representation/selectable.gdshaderinc"
+#include "res://editor/rendering/atomic_structure_renderer/representation/billboard.gdshaderinc"
 
-// atom selection movement shift
-uniform vec3 camera_up_vector;
-uniform vec3 camera_right_vector;
 
 uniform float roughness : hint_range(0,1);
 uniform sampler2D texture_metallic : hint_default_white,filter_linear_mipmap,repeat_enable;
@@ -24,47 +22,34 @@ uniform vec3 uv1_offset;
 
 
 void vertex() {
-	// Hide hydrogens if necesary
-	// SingleAtomRepresentation uses bond color for atoms instead of atom color
-	// Because of that we use hide_hydrogen_bonds() instead
-	VERTEX = hide_hydrogen_bonds(VERTEX, COLOR.a, INSTANCE_CUSTOM.a);
 	COLOR.rgb = apply_selectable_dimming(COLOR).rgb;
-	
 	
 	if (!OUTPUT_IS_SRGB) {
 		COLOR.rgb = mix(pow((COLOR.rgb + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), COLOR.rgb * (1.0 / 12.92), lessThan(COLOR.rgb, vec3(0.04045)));
 	}
 	
-	// COLOR.a > 2.0 always means the atom is selected	
-
 	// Make the outline mesh visible if the atom is selected
 	is_outline = uv_is_outline(UV);
 	is_instance_hovered = is_atom_or_bond_hovered(COLOR.a);
 	VERTEX += calculate_outline_displacement(VERTEX, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR, 1.0);
 	
-	// Calculate rotation matrix to align model with camera
-	mat4 billboard_rot = mat4(
-		vec4(normalize(camera_right_vector), 0.0),
-		vec4(normalize(camera_up_vector), 0.0),
-		vec4(cross(normalize(camera_right_vector), normalize(camera_up_vector)), 0.0),
-		vec4(0.0, 0.0, 0.0, 1.0)
-	);
-	
-	// Transform the vertex using the billboard rotation
-	vec3 final_vertex = (billboard_rot * vec4(VERTEX, 1.0)).xyz;
+	// Make the atom face the camera
+	VERTEX = billboard_atom(VERTEX, INV_VIEW_MATRIX);
 
 	//apply rotation
-	final_vertex += get_rotation_delta(COLOR, MODEL_MATRIX);
+	VERTEX += get_rotation_delta(COLOR, MODEL_MATRIX);
 
 	//apply translation delta
-	final_vertex += get_translation_delta(COLOR, MODEL_MATRIX);
+	VERTEX += get_translation_delta(COLOR, MODEL_MATRIX);
 	
-	final_vertex *= is_atom_or_bond_visible(COLOR.a);
-	VERTEX = final_vertex;
+	// Hide if manually hidden by the user
+	VERTEX *= is_atom_or_bond_visible(COLOR.a);
+	
+	// Hide hydrogens if necesary
+	VERTEX = hide_hydrogen_atoms(VERTEX, COLOR.a);
 	
 	UV=UV*uv1_scale.xy+uv1_offset.xy;
 	MODELVIEW_NORMAL_MATRIX = mat3(inverse(MODEL_MATRIX));
-	
 }
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
@@ -4,8 +4,6 @@ const BASE_SCALE = 0.022;
 
 const SingleAtomMaterial: ShaderMaterial = preload("res://editor/rendering/atomic_structure_renderer/representation/single_atom_representation/assets/single_atom_representation_material.tres")
 
-const UNIFORM_CAMERA_UP_VECTOR: StringName = StringName("camera_up_vector")
-const UNIFORM_CAMERA_RIGHT_VECTOR: StringName = StringName("camera_right_vector")
 
 var _structure_id: int
 var _workspace_context: WorkspaceContext

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/multimesh_atom.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/multimesh_atom.gdshader
@@ -6,6 +6,7 @@ render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlic
 #include "res://editor/rendering/atomic_structure_renderer/representation/hydrogens.gdshaderinc"
 #include "res://editor/rendering/atomic_structure_renderer/representation/outlines.gdshaderinc"
 #include "res://editor/rendering/atomic_structure_renderer/representation/selectable.gdshaderinc"
+#include "res://editor/rendering/atomic_structure_renderer/representation/billboard.gdshaderinc"
 
 // wavy uv
 const float wave_aplitude = 0.05;
@@ -77,18 +78,8 @@ void vertex() {
 	is_instance_hovered = is_atom_or_bond_hovered(COLOR.a);
 	VERTEX += calculate_outline_displacement(VERTEX, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR, scale) * float_not(is_preview);
 	
-	// Calculate rotation matrix to align model with camera
-	vec3 camera_right = normalize(INV_VIEW_MATRIX[0].xyz);
-	vec3 camera_up = normalize(INV_VIEW_MATRIX[1].xyz);
-	mat4 billboard_rot = mat4(
-		vec4(normalize(camera_right), 0.0),
-		vec4(normalize(camera_up), 0.0),
-		vec4(cross(normalize(camera_right), normalize(camera_up)), 0.0),
-		vec4(0.0, 0.0, 0.0, 1.0)
-	);
-
 	// Transform the vertex using the billboard rotation
-	vec3 final_vertex = (billboard_rot * vec4(VERTEX, 1.0)).xyz;
+	vec3 final_vertex = billboard_atom(VERTEX, INV_VIEW_MATRIX);
 
 	// apply scale
 	final_vertex = final_vertex * scale;


### PR DESCRIPTION
The single atom representation shader is using a different billboard code that's not working, making unconnected atoms invisible in stick view.

This PR moves the billboard code (used by sticks, labels and sphere views) under a common shader include.
It's no longer necessary to pass the camera basis vector as uniform because that data is included in INV_VIEW_MATRIX already, so code related to that was removed.  