### PR TITLE
Fix atom suggestions not being restored after moving the camera with the keyboard

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -34,7 +34,7 @@ func handle_inputs_end() -> void:
 
 
 func handle_inputs_resume() -> void:
-	if not _is_shortcut_pressed() or not _should_show():
+	if not _should_show():
 		return
 	if _candidates_dirty:
 		_update_candidates()


### PR DESCRIPTION
The atom suggestions wouldn't re appear until the next mouse event if the camera was moved with the keyboard.

This is because a wrong condition in handle_inputs_resume.