### PR TITLE
Fix changing active group interrupts the simulation

### DIFF
--- a/godot_project/project_workspace/workspace_context/history/history.gd
+++ b/godot_project/project_workspace/workspace_context/history/history.gd
@@ -11,7 +11,7 @@ signal previous_snapshot_applied(undone_snapshot_name: String)
 signal next_snapshot_applied(redone_snapshot_name: String)
 
 const ACTION_WHITELIST_DURING_SIMULATION: Dictionary = {
-	"Change Edited Group" : true,
+	"Change Active Group" : true,
 	"Change Selection" : true,
 	"Box Selection" : true,
 	"Box Deselection" : true,


### PR DESCRIPTION
When changing the active group using the group bar at the top of the workspace, the simulation stops.

This is because the change group action was renamed but the whitelist wasn't updated. 