### PR TITLE
Keep autoposing visible when hovering an atom or other UI elements

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
@@ -32,6 +32,8 @@ var _up_to_date_representations: Dictionary = {
 #	Rendering.Representation: true
 }
 var _workspace_context: WorkspaceContext = null
+var _selection_position_delta: Vector3
+
 
 func rebuild() -> void:
 	var structure_context: StructureContext = _workspace_context.get_structure_context(_nano_structure_id)
@@ -457,11 +459,16 @@ func set_transparency(in_transparency: float) -> void:
 
 
 func set_atom_selection_position_delta(in_selection_delta: Vector3) -> void:
+	_selection_position_delta = in_selection_delta
 	_current_representation.set_atom_selection_position_delta(in_selection_delta)
 	_springs_representation.set_atom_selection_position_delta(in_selection_delta)
 	if _are_labels_active():
 		_labels_representation.set_atom_selection_position_delta(in_selection_delta)
 	_outdate_non_active_representations()
+
+
+func get_atom_selection_position_delta() -> Vector3:
+	return _selection_position_delta
 
 
 func rotate_atom_selection_around_point(in_point: Vector3, in_rotation_to_apply: Basis) -> void:

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -502,6 +502,12 @@ func set_atom_selection_position_delta(in_selection_delta: Vector3, in_structure
 	atomic_structure_renderer.set_atom_selection_position_delta(in_selection_delta)
 
 
+func get_atom_selection_position_delta(in_structure: AtomicStructure) -> Vector3:
+	if not enabled: return Vector3.ZERO
+	var atomic_structure_renderer: AtomicStructureRenderer = _get_renderer_for_atomic_structure(in_structure)
+	return atomic_structure_renderer.get_atom_selection_position_delta()
+
+
 func rotate_atom_selection_around_point(in_point: Vector3, in_rotation_to_apply: Basis, in_structure: AtomicStructure) -> void:
 	if not enabled: return
 	var atomic_structure_renderer: AtomicStructureRenderer = _get_renderer_for_atomic_structure(in_structure)


### PR DESCRIPTION
The atoms auto posing handler now stays visible, even if other handlers (exclusive or higher priority) are active, and even if no input events are received.

This PR also forces a redraw when the create mode is enabled (instead of waiting for the next input event to draw the candidates)