### PR TITLE
CRASH FIX: Ensure virtual objects and groups are marked 'dirty' when visibility is changed

### DIFF
--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -664,6 +664,7 @@ func _on_nano_structure_visibility_changed(_in_visible: bool, in_structure_conte
 	if not workspace.has_structure_with_int_guid(in_structure_context_id):
 		return
 	var structure_context: StructureContext = get_structure_context(in_structure_context_id)
+	structure_context.mark_is_editable_dirty()
 	if structure_context.is_editable() and not _editable_structure_contexts_ids.has(in_structure_context_id):
 		_queue_emit_new_editable_structures()
 	elif not structure_context.is_editable() and _editable_structure_contexts_ids.has(in_structure_context_id):


### PR DESCRIPTION
Fixes a crash that occurs when box selecting a hidden virtual object (anchor, or motor)

Task: CRASH - Invisible objects cause crash errors

Before:

https://github.com/user-attachments/assets/e923f8c8-17e5-4b28-802c-0e4c324c4cf2

After:

https://github.com/user-attachments/assets/f25ae573-ab83-4b0c-a08b-857645bc67c9

