### PR TITLE
CRASH FIX: Fix crash when navigating to homepage while Autopose preview is active

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -50,6 +50,10 @@ func show_homepage() -> void:
 	_update_window_title()
 
 
+func is_homepage_active() -> bool:
+	return _current_workspace == null
+
+
 ## Create a new workspace, initially stored in ram, will not be saved to disk until required
 func create_workspace() -> Workspace:
 	var workspace := Workspace.new()

--- a/godot_project/editor/rendering/atom_autopose_preview/atom_autopose_preview.gd
+++ b/godot_project/editor/rendering/atom_autopose_preview/atom_autopose_preview.gd
@@ -72,6 +72,8 @@ func _process(_delta: float) -> void:
 		_camera_last_projection = _camera.projection
 		queue_redraw()
 		return
+	if MolecularEditorContext.is_homepage_active():
+		return
 	# Redraw if the selection is being moved
 	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context() as WorkspaceContext
 	var rendering: Rendering = workspace_context.get_rendering()


### PR DESCRIPTION
Task: CRASH - Create a new Workspace, then click on welcome tab
