### PR TITLE
Fix invalid candidates appearing on screen, not connected to any atoms

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -136,6 +136,7 @@ func _update_candidates_if_needed() -> void:
 	for context: StructureContext in selected_contexts:
 		total_atoms_selected += context.get_selected_atoms().size()
 	if total_atoms_selected > MAX_ATOMS_FOR_AUTO_POSING:
+		_get_rendering().atom_autopose_preview_set_candidates(_candidates)
 		return
 	
 	for context: StructureContext in selected_contexts:


### PR DESCRIPTION
This happens if you have atom candidates on screen, and select too many atoms at once. The auto posing feature gets disabled but the previous candidates were not cleared, so they stayed up on screen.