### PR TITLE
Fix wrong information character displayed in Auto Create Bonds panel

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_bonds_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_bonds_panel.tscn
@@ -57,7 +57,7 @@ text = "Auto-Create Bonds for All Atoms"
 [node name="NoSelectionLabel" type="Label" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-text = "i No atoms selected."
+text = "ℹ No atoms selected."
 horizontal_alignment = 1
 autowrap_mode = 2
 

--- a/godot_project/theme/Gidole-Regular.ttf.import
+++ b/godot_project/theme/Gidole-Regular.ttf.import
@@ -24,7 +24,7 @@ hinting=1
 subpixel_positioning=1
 oversampling=0.0
 Fallbacks=null
-fallbacks=[Object(SystemFont,"resource_local_to_scene":false,"resource_name":"","fallbacks":Array[Font]([]),"font_names":PackedStringArray("Noto Color Emoji", "Segoe UI Emoji", "Apple Color Emoji"),"font_italic":false,"font_weight":400,"font_stretch":100,"antialiasing":1,"generate_mipmaps":false,"allow_system_fallback":true,"force_autohinter":false,"hinting":1,"subpixel_positioning":1,"multichannel_signed_distance_field":false,"msdf_pixel_range":16,"msdf_size":48,"oversampling":0.0,"script":null)
+fallbacks=[Object(SystemFont,"resource_local_to_scene":false,"resource_name":"","fallbacks":Array[Font]([]),"font_names":PackedStringArray("Noto Color Emoji", "Segoe UI Emoji", "Apple Color Emoji", "Noto Emoji"),"font_italic":false,"font_weight":400,"font_stretch":100,"antialiasing":1,"generate_mipmaps":false,"allow_system_fallback":true,"force_autohinter":false,"hinting":1,"subpixel_positioning":1,"multichannel_signed_distance_field":false,"msdf_pixel_range":16,"msdf_size":48,"oversampling":0.0,"script":null)
 ]
 Compress=null
 compress=true
@@ -32,7 +32,8 @@ preload=[{
 "chars": [],
 "glyphs": [],
 "name": "New Configuration",
-"size": Vector2i(16, 0)
+"size": Vector2i(16, 0),
+"variation_embolden": 0.0
 }]
 language_support={}
 script_support={}


### PR DESCRIPTION
Task: Redundant letter "i" before "No atoms selected" (and other info text issues that could perhaps have different tickets)

Note: I refrained myself from including **Noto Regular Emoji** in the project, the application will already pick it up if the system has it installed. If this continues to be a problem we could just include the font in the repository (23Mb) and whitelist the characters we use (something i didn't know at first, _we have to whitelist unicode characters_)