### PR TITLE
Restore some of the old state when loading a saved project

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -169,8 +169,11 @@ func load_and_activate_workspace(in_path: String) -> void:
 		return
 	var workspace_context: WorkspaceContext = get_workspace_context(workspace)
 	workspace_context.set_camera_global_transform(workspace.camera_transform)
-	var root_structure: NanoStructure = workspace.get_root_child_structures()[0]
-	workspace_context.set_current_structure_context(workspace_context.get_nano_structure_context(root_structure))
+	# Needs to call_deferred to be executed after msep_editor_settings.changed is emmited
+	workspace_context.set_camera_orthogonal_size.call_deferred(workspace.camera_orthogonal_size)
+	var active_structure_id: int = workspace.active_structure_int_guid
+	var active_structure: NanoStructure = workspace.get_structure_by_int_guid(active_structure_id)
+	workspace_context.set_current_structure_context(workspace_context.get_nano_structure_context(active_structure))
 	if is_instance_valid(workspace):
 		activate_workspace(workspace)
 	_validate_forcefield_files(workspace_context)
@@ -192,6 +195,7 @@ func save_workspace(in_workspace: Workspace, in_path: String = "") -> void:
 	var path: String = in_path
 	var workspace_context: WorkspaceContext = get_workspace_context(in_workspace)
 	in_workspace.camera_transform = workspace_context.get_camera_global_transform()
+	in_workspace.camera_orthogonal_size = workspace_context.get_camera_orthogonal_size()
 	if path.is_empty():
 		path = in_workspace.resource_path
 	if path.is_empty():

--- a/godot_project/editor/controls/workspace_view/WorkspaceMainView.gd
+++ b/godot_project/editor/controls/workspace_view/WorkspaceMainView.gd
@@ -154,5 +154,13 @@ func get_camera_global_transform() -> Transform3D:
 	return get_camera().global_transform
 
 
+func set_camera_orthogonal_size(in_orthogonal_size: float) -> void:
+	get_camera().size = in_orthogonal_size
+
+
+func get_camera_orthogonal_size() -> float:
+	return get_camera().size
+
+
 func bottom_bar_update_distance(in_message_text: String, in_distance: float) -> void:
 	editor_viewport_container.bottom_bar_update_distance(in_message_text, in_distance)

--- a/godot_project/project_workspace/workspace.gd
+++ b/godot_project/project_workspace/workspace.gd
@@ -19,6 +19,12 @@ static var instance_counter: int = 0
 	# ID<int> : NanoStructure
 }
 
+@export var active_structure_int_guid: int = -1:
+	get:
+		if active_structure_int_guid == -1:
+			# active structure has never set, fallback to root
+			return main_structure_int_guid
+		return active_structure_int_guid
 
 @export var main_structure_int_guid: int:
 	get:
@@ -124,6 +130,12 @@ var _rng: RandomNumberGenerator = RandomNumberGenerator.new()
 @export var camera_transform: Transform3D = Transform3D():
 	set(v):
 		camera_transform = v
+		changed.emit()
+
+## Create workspace camera with this orthogonal size
+@export var camera_orthogonal_size: float = 1.0:
+	set(v):
+		camera_orthogonal_size = v
 		changed.emit()
 
 

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -153,6 +153,7 @@ func initialize(in_workspace: Workspace) -> void:
 	for structure: NanoStructure in nano_structures:
 		# ensure structure contexts are created
 		get_nano_structure_context(structure)
+	
 
 
 func notify_activated() -> void:
@@ -330,6 +331,7 @@ func set_current_structure_context(in_structure_context: StructureContext) -> vo
 		return
 	# Activating an object cancels create mode
 	abort_creating_object()
+	workspace.active_structure_int_guid = in_structure_context.get_int_guid()
 	_current_structure_context_id = in_structure_context.get_int_guid()
 	current_structure_context_changed.emit(in_structure_context)
 	_queue_emit_new_editable_structures()
@@ -1004,6 +1006,14 @@ func set_camera_global_transform(in_transform: Transform3D) -> void:
 
 func get_camera_global_transform() -> Transform3D:
 	return workspace_main_view.get_camera_global_transform()
+
+
+func set_camera_orthogonal_size(in_orthogonal_size: float) -> void:
+	workspace_main_view.set_camera_orthogonal_size(in_orthogonal_size)
+
+
+func get_camera_orthogonal_size() -> float:
+	return workspace_main_view.get_camera_orthogonal_size()
 
 
 func get_rendering() -> Rendering:


### PR DESCRIPTION
- Zoom level in orthogonal projection will be restored
- Currently edited group will be restored

Tasks:
BUG - Ortogonal Camera is not restored properly after saving and restoring a file
BUG - Save files not maintaining UI position in groups
