### PR TITLE
Fix star gears missing connections

### DIFF
--- a/godot_project/project_workspace/structs/nano_molecular_structure.gd
+++ b/godot_project/project_workspace/structs/nano_molecular_structure.gd
@@ -449,12 +449,12 @@ func _on_anchor_position_change(_in_position: Vector3, in_anchor: NanoVirtualAnc
 	ScriptUtils.call_deferred_once(_ensure_edit_queue_flushed)
 
 
-
 func _on_anchor_visibility_changed(in_is_visible: bool, in_anchor: NanoVirtualAnchor) -> void:
 	var changed_springs: PackedInt32Array = in_anchor.get_related_springs(int_guid)
 	for related_spring_id: int in changed_springs:
 		_springs[related_spring_id].anchor_is_visible = in_is_visible
 	springs_visibility_changed.emit(changed_springs)
+
 
 func _ensure_edit_queue_flushed() -> void:
 	# Workaround, there are two scenarios:
@@ -695,6 +695,14 @@ func get_aabb() -> AABB:
 			else:
 				aabb = aabb.expand(atom.position)
 	return aabb.abs()
+
+
+func init_remap_structure_ids(in_structures_map: Dictionary) -> void:
+	for spring: NanoSpring in _springs.values():
+		var old_id: int = spring.target_anchor
+		var new_structure: NanoStructure = in_structures_map.get(old_id, null)
+		assert(is_instance_valid(new_structure), "Virtual anchor has vanished during import")
+		spring.target_anchor = new_structure.int_guid
 
 
 func create_state_snapshot() -> Dictionary:

--- a/godot_project/project_workspace/structs/nano_structure.gd
+++ b/godot_project/project_workspace/structs/nano_structure.gd
@@ -131,6 +131,16 @@ func _ensure_structure_is_not_virtual(in_structure: NanoStructure) -> bool:
 	return not in_structure.is_virtual_object()
 
 
+## Called when importing a workspace, before the structures are actually added.
+## Because the all the structure ids have changed, any reference to external
+## structures must be updated.
+## New structures may or may not have been added to the workspace yet, but
+## already have a valid (new) int_guid.
+## in_structure_map: {old_structure_id<int> : new_structure<NanoStructure>}
+func init_remap_structure_ids(_in_structures_map: Dictionary) -> void:
+	pass
+
+
 func create_state_snapshot() -> Dictionary:
 	var state_snapshot: Dictionary = {}
 	state_snapshot["int_guid"] = int_guid

--- a/godot_project/project_workspace/structs/nano_virtual_anchor.gd
+++ b/godot_project/project_workspace/structs/nano_virtual_anchor.gd
@@ -98,6 +98,15 @@ func is_anchor_within_screen_rect(in_camera: Camera3D, screen_rect: Rect2i) -> b
 	return false
 
 
+func init_remap_structure_ids(in_structures_map: Dictionary) -> void:
+	for old_structure_id: int in get_related_structures():
+		var springs: Dictionary = _linked_nano_structures[old_structure_id]
+		_linked_nano_structures.erase(old_structure_id)
+		var new_structure: NanoStructure = in_structures_map.get(old_structure_id, null)
+		assert(is_instance_valid(new_structure), "Structure has vanished during import")
+		_linked_nano_structures[new_structure.int_guid] = springs
+
+
 func create_state_snapshot() -> Dictionary:
 	var state_snapshot: Dictionary =  super.create_state_snapshot()
 	state_snapshot["script.resource_path"] = get_script().resource_path

--- a/godot_project/project_workspace/structs/nano_virtual_motor.gd
+++ b/godot_project/project_workspace/structs/nano_virtual_motor.gd
@@ -139,6 +139,14 @@ func is_motor_within_screen_rect(in_camera: Camera3D, screen_rect: Rect2i) -> bo
 	return false
 
 
+func init_remap_structure_ids(in_structures_map: Dictionary) -> void:
+	for old_structure_id: int in get_connected_structures():
+		_connected_structures.erase(old_structure_id)
+		var new_structure: NanoStructure = in_structures_map.get(old_structure_id, null)
+		assert(is_instance_valid(new_structure), "Structure has vanished during import")
+		_connected_structures[new_structure.int_guid] = true
+
+
 func create_state_snapshot() -> Dictionary:
 	var state_snapshot: Dictionary = super.create_state_snapshot()
 	state_snapshot["script.resource_path"] = get_script().resource_path


### PR DESCRIPTION
Fixes: "Add Star Gears Project to Sample Library - The file doesn’t seem to import correctly. Neither of the motors are attached to groups"

Springs, anchors and motors were pointing at the old structures id (from before the import), causing various issues. 

This PR adds a new `init_remap_structure_ids()` method in `NanoStructure`, called automatically when a workspace is imported from another workspace. If the structure is holding a reference to another structure, it has to update that link here.