### PR TITLE
grayscale non editable groups 🔧

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -305,6 +305,7 @@ func _screen_selection_logic(
 				_:
 					assert(false, "Invalid hit result")
 	if need_to_create_snapshot:
+		_workspace_context.refresh_group_saturation()
 		_workspace_context.snapshot_moment(snapshot_name)
 	return need_to_create_snapshot
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
@@ -157,6 +157,16 @@ func refresh_atom_sizes() -> void:
 	_outdate_non_active_representations()
 
 
+func saturate() -> void:
+	_current_representation.saturate()
+	_outdate_non_active_representations()
+
+
+func desaturate() -> void:
+	_current_representation.desaturate()
+	_outdate_non_active_representations()
+
+
 func change_representation(new_representation: Rendering.Representation) -> void:
 	var struct_context: StructureContext = _workspace_context.get_structure_context(_nano_structure_id)
 	var old_representation: Representation = _current_representation

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/balls_and_sticks_representation/balls_and_sticks_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/balls_and_sticks_representation/balls_and_sticks_representation.gd
@@ -186,6 +186,16 @@ func handle_hover_structure_changed(in_toplevel_hovered_structure_context: Struc
 			in_hovered_structure_context, in_atom_id, in_bond_id, in_spring_id)
 
 
+func saturate() -> void:
+	_sphere_representation.saturate()
+	_stick_representation.saturate()
+
+
+func desaturate() -> void:
+	_sphere_representation.desaturate()
+	_stick_representation.desaturate()
+
+
 func get_materials() -> Array[ShaderMaterial]:
 	var materials: Array[ShaderMaterial] = []
 	materials.append_array(_sphere_representation.get_materials())

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/enhanced_sticks_and_balls_representation/enhanced_sticks_and_balls_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/enhanced_sticks_and_balls_representation/enhanced_sticks_and_balls_representation.gd
@@ -201,6 +201,16 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_balls_representation.apply_theme(in_theme)
 
 
+func saturate() -> void:
+	_stick_representation.saturate()
+	_balls_representation.saturate()
+
+
+func desaturate() -> void:
+	_stick_representation.desaturate()
+	_balls_representation.desaturate()
+
+
 func create_state_snapshot() -> Dictionary:
 	var snapshot: Dictionary = {}
 	snapshot["_bond_rendering_visible"] = _bond_rendering_visible

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
@@ -319,6 +319,14 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_material = new_material
 
 
+func saturate() -> void:
+	return
+
+
+func desaturate() -> void:
+	return
+
+
 func create_state_snapshot() -> Dictionary:
 	var snapshot: Dictionary = {}
 	snapshot["_workspace_context"] = _workspace_context

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/representation.gd
@@ -189,6 +189,16 @@ func apply_theme(_in_theme: Theme3D) -> void:
 	return
 
 
+func saturate() -> void:
+	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
+	return
+
+
+func desaturate() -> void:
+	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
+	return
+
+
 static func get_atom_scale_factor(in_representation_settings: RepresentationSettings) -> float:
 	var representation := Rendering.Representation.BALLS_AND_STICKS
 	if in_representation_settings != null:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/selectable.gdshaderinc
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/selectable.gdshaderinc
@@ -4,6 +4,7 @@
 #include "float_operations.gdshaderinc"
 
 uniform float is_selectable: hint_range(0.0, 1.0, 1.0) = 1.0;
+uniform float saturation: hint_range(0.0, 1.0, 1.0) = 1.0;
 
 
 // Usage:
@@ -14,4 +15,10 @@ vec4 apply_selectable_dimming(vec4 color) {
 	
 	float selectable_factor = mix(DIMM_FACTOR, 1.0, is_selectable);
 	return color * selectable_factor;
+}
+
+
+vec3 apply_saturation(vec3 color) {
+	vec3 desaturated_color = vec3((color.r + color.g + color.b) / 3.0);
+	return mix(color, desaturated_color, float_eq(float_not(saturation), 1.0));
 }

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
@@ -376,6 +376,13 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_material.copy_state_from(old_material)
 
 
+func saturate() -> void:
+	_material.saturate()
+
+
+func desaturate() -> void:
+	_material.desaturate()
+
 
 func create_state_snapshot() -> Dictionary:
 	assert(is_instance_valid(_workspace_context))

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/multimesh_atom.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/multimesh_atom.gdshader
@@ -147,7 +147,8 @@ void fragment() {
 	RIM = strength * 0.5 * rim * rim_tex.x;
 	RIM_TINT = rim_tint*rim_tex.y;
 	vec2 clearcoat_tex = texture(texture_clearcoat,base_uv).xy;
-	CLEARCOAT = clearcoat*clearcoat_tex.x;	CLEARCOAT_ROUGHNESS = clearcoat_roughness*clearcoat_tex.y;
+	CLEARCOAT = clearcoat*clearcoat_tex.x;
+	CLEARCOAT_ROUGHNESS = clearcoat_roughness*clearcoat_tex.y;
 	vec4 detail_tex = texture(texture_detail_albedo,UV2);
 	vec4 detail_norm_tex = texture(texture_detail_normal,UV2);
 	vec4 detail_mask_tex = texture(texture_detail_mask,base_uv);
@@ -155,6 +156,6 @@ void fragment() {
 	vec3 detail_norm = mix(NORMAL_MAP,detail_norm_tex.rgb,detail_tex.a);
 	NORMAL_MAP = mix(NORMAL_MAP,detail_norm,detail_mask_tex.r);
 	ALBEDO.rgb = mix(ALBEDO.rgb,detail,detail_mask_tex.r);
-	
 	ALBEDO = calculate_outline_color(ALBEDO, COLOR);
+	ALBEDO.rgb = apply_saturation(ALBEDO.rgb);
 }

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/multimesh_atom_material.tres
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/multimesh_atom_material.tres
@@ -28,6 +28,7 @@ shader_parameter/uv1_scale = Vector3(1.1, 1.1, 1.1)
 shader_parameter/uv1_offset = null
 shader_parameter/uv2_scale = Vector3(1, 1, 1)
 shader_parameter/uv2_offset = null
+shader_parameter/saturation = 1.0
 shader_parameter/texture_noise = ExtResource("4_hcfkd")
 shader_parameter/texture_detail_albedo = ExtResource("3_frygv")
 script = ExtResource("1_olce1")

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/sphere_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/sphere_material.gd
@@ -6,11 +6,16 @@ const UNIFORM_OUTLINE_THICKNESS = &"outline_thickness"
 const UNIFORM_GIZMO_ORIGIN = &"gizmo_origin"
 const UNIFORM_GIZMO_ROTATION = &"gizmo_rotation"
 const UNIFORM_SELECTION_DELTA = &"selection_delta"
+const UNIFORM_SATURATION = &"saturation"
+
+const LOW_SATURATION = 0.0;
+const NORMAL_SATURATION = 1.0;
 
 
 func _init() -> void:
 	RenderingUtils.has_uniforms(self, [UNIFORM_SCALE, UNIFORM_IS_SELECTABLE, UNIFORM_IS_HOVERED, UNIFORM_SHOW_HYDROGENS,
-			UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA, UNIFORM_OUTLINE_THICKNESS])
+			UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA, UNIFORM_OUTLINE_THICKNESS,
+			UNIFORM_SATURATION])
 
 
 func set_selectable(in_is_selectable: bool) -> SphereMaterial:
@@ -41,6 +46,14 @@ func update_gizmo(in_gizmo_origin: Vector3, in_gizmo_rotation: Basis) -> void:
 
 func update_selection_delta(in_selection_movement_delta: Vector3) -> void:
 	set_shader_parameter(UNIFORM_SELECTION_DELTA, in_selection_movement_delta)
+
+
+func desaturate() -> void:
+	set_shader_parameter(UNIFORM_SATURATION, LOW_SATURATION)
+
+
+func saturate() -> void:
+	set_shader_parameter(UNIFORM_SATURATION, NORMAL_SATURATION)
 
 
 func reset() -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -375,6 +375,14 @@ func refresh_bond_influence(_in_partially_selected_bonds: PackedInt32Array) -> v
 	return
 
 
+func saturate() -> void:
+	_material.saturate()
+
+
+func desaturate() -> void:
+	_material.desaturate()
+
+
 func apply_theme(in_theme: Theme3D) -> void:
 	var old_material: ShaderMaterial = _material
 	var new_mesh: Mesh = in_theme.create_ball_mesh()

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/spring.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/spring.gdshader
@@ -4,6 +4,7 @@ render_mode blend_mix,depth_draw_always,cull_disabled,diffuse_burley,specular_sc
 
 #include "res://editor/rendering/atomic_structure_renderer/representation/hydrogens.gdshaderinc"
 #include "res://editor/rendering/atomic_structure_renderer/representation/instance_state.gdshaderinc"
+#include "res://editor/rendering/atomic_structure_renderer/representation/selectable.gdshaderinc"
 
 uniform vec4 albedo : source_color;
 uniform sampler2D texture_albedo : source_color,filter_linear,repeat_enable;
@@ -44,6 +45,7 @@ void fragment() {
 	vec2 base_uv = UV;
 	vec4 albedo_tex = texture(texture_albedo,base_uv);
 	ALBEDO = albedo.rgb * COLOR.rgb * albedo_tex.rgb;
+	ALBEDO.rgb = apply_saturation(ALBEDO.rgb);
 	float metallic_tex = dot(texture(texture_metallic,base_uv),metallic_texture_channel);
 	METALLIC = metallic_tex * metallic;
 	vec4 roughness_texture_channel = vec4(0.0,1.0,0.0,0.0);

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/spring_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/spring_renderer.gd
@@ -147,6 +147,14 @@ func get_structure_context() -> StructureContext:
 	return _workspace_context.get_structure_context(_structure_id)
 
 
+func saturate() -> void:
+	_material.saturate()
+
+
+func desaturate() -> void:
+	_material.desaturate()
+
+
 class TransformHandler:
 	var _spring_renderer: SpringRenderer
 	

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
@@ -293,6 +293,14 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_spring_renderer.change_look(in_theme.create_spring_mesh(), in_theme.create_spring_material())
 
 
+func saturate() -> void:
+	_spring_renderer.saturate()
+
+
+func desaturate() -> void:
+	_spring_renderer.desaturate()
+
+
 func create_state_snapshot() -> Dictionary:
 	var snapshot: Dictionary = {}
 	snapshot["_workspace_context"] = _workspace_context

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/bond_capsule.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/bond_capsule.gdshader
@@ -106,6 +106,7 @@ void fragment() {
 	albedo += COLOR.rgb * first_lower_then_second(percent, 0.0);
 	albedo += custom_color.rgb * first_greater_then_second(percent, 0.0);
 	ALBEDO = calculate_outline_color(albedo, COLOR);
+	ALBEDO.rgb = apply_saturation(ALBEDO.rgb);
 	
 	//
 	float metallic_tex = dot(texture(texture_metallic,base_uv),metallic_texture_channel);

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.gd
@@ -5,11 +5,14 @@ const INSTANCE_UNIFORM_BASE_SCALE: StringName = &"base_scale"
 const UNIFORM_CAPS_STARTS_AT_LOCAL_Z: StringName = &"caps_starts_at_local_z_position"
 const UNIFORM_OUTLINE_THICKNESS = &"outline_thickness"
 const UNIFORM_IS_HOVERED = &"is_hovered"
+const UNIFORM_SATURATION = &"saturation"
 
+const LOW_SATURATION = 0.0;
+const NORMAL_SATURATION = 1.0;
 
 func _init() -> void:
-	RenderingUtils.has_uniforms(self, [INSTANCE_UNIFORM_BASE_SCALE,
-			UNIFORM_CAPS_STARTS_AT_LOCAL_Z, UNIFORM_OUTLINE_THICKNESS])
+	RenderingUtils.has_uniforms(self, [INSTANCE_UNIFORM_BASE_SCALE, UNIFORM_CAPS_STARTS_AT_LOCAL_Z,
+			UNIFORM_OUTLINE_THICKNESS, UNIFORM_SATURATION])
 
 
 func set_scale(new_scale: float) -> CapsuleStickMaterial:
@@ -36,6 +39,14 @@ func set_hovered(in_is_hovered: bool) -> CapsuleStickMaterial:
 func set_caps_starts_at_local_z(in_start_distance: float) -> CapsuleStickMaterial:
 	set_shader_parameter(UNIFORM_CAPS_STARTS_AT_LOCAL_Z, in_start_distance)
 	return self
+
+
+func desaturate() -> void:
+	set_shader_parameter(UNIFORM_SATURATION, LOW_SATURATION)
+
+
+func saturate() -> void:
+	set_shader_parameter(UNIFORM_SATURATION, NORMAL_SATURATION)
 
 
 func copy_state_from(_in_from_material: ShaderMaterial) -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -154,6 +154,18 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_material_bond_3.copy_state_from(old_order_3_material)
 
 
+func saturate() -> void:
+	_material_bond_1.saturate()
+	_material_bond_2.saturate()
+	_material_bond_3.saturate()
+
+
+func desaturate() -> void:
+	_material_bond_1.desaturate()
+	_material_bond_2.desaturate()
+	_material_bond_3.desaturate()
+
+
 func create_state_snapshot() -> Dictionary:
 	var snapshot: Dictionary = super.create_state_snapshot()
 	snapshot["_capsule_material.snapshot"] = _capsule_material.create_state_snapshot()

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/bond_cylinder.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/bond_cylinder.gdshader
@@ -100,6 +100,7 @@ void fragment() {
 	float curve_percent = texture(texture_color_curve, vec2(percent + 0.5)).r;
 	albedo = mix(albedo, custom_color, curve_percent);
 	ALBEDO = calculate_outline_color(albedo, COLOR);
+	ALBEDO.rgb = apply_saturation(ALBEDO.rgb);
 	EMISSION = albedo * emission_energy;
 	
 	//

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/bond_cylinder_material.tres
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/bond_cylinder_material.tres
@@ -15,6 +15,7 @@ render_priority = 0
 shader = ExtResource("2_m1wn2")
 shader_parameter/show_hydrogens = 1.0
 shader_parameter/is_selectable = 1.0
+shader_parameter/saturation = 1.0
 shader_parameter/selection_delta = Vector3(0, 0, 0)
 shader_parameter/gizmo_origin = null
 shader_parameter/gizmo_rotation = Projection(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/cylinder_stick_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/cylinder_stick_material.gd
@@ -7,12 +7,15 @@ const UNIFORM_GIZMO_ROTATION = &"gizmo_rotation"
 const UNIFORM_SELECTION_DELTA = &"selection_delta"
 const UNIFORM_OUTLINE_THICKNESS = &"outline_thickness"
 const UNIFORM_IS_HOVERED = &"is_hovered"
+const UNIFORM_SATURATION = &"saturation"
 
+const LOW_SATURATION = 0.0;
+const NORMAL_SATURATION = 1.0;
 
 func _init() -> void:
-	RenderingUtils.has_uniforms(self, [UNIFORM_ATOM_SCALE,
-			UNIFORM_SHOW_HYDROGENS, UNIFORM_IS_SELECTABLE, UNIFORM_GIZMO_ROTATION,
-			UNIFORM_GIZMO_ORIGIN, UNIFORM_OUTLINE_THICKNESS, UNIFORM_IS_HOVERED])
+	RenderingUtils.has_uniforms(self, [UNIFORM_ATOM_SCALE, UNIFORM_SHOW_HYDROGENS, UNIFORM_IS_SELECTABLE,
+			UNIFORM_GIZMO_ROTATION, UNIFORM_GIZMO_ORIGIN,UNIFORM_OUTLINE_THICKNESS, UNIFORM_IS_HOVERED,
+			UNIFORM_SATURATION])
 
 
 func set_atom_scale(new_scale: float) -> CylinderStickMaterial:
@@ -49,6 +52,14 @@ func set_gizmo_rotation(in_gizmo_rotation: Basis) -> CylinderStickMaterial:
 func set_selection_delta(in_selection_delta: Vector3) -> CylinderStickMaterial:
 	set_shader_parameter(UNIFORM_SELECTION_DELTA, in_selection_delta)
 	return self
+
+
+func desaturate() -> void:
+	set_shader_parameter(UNIFORM_SATURATION, LOW_SATURATION)
+
+
+func saturate() -> void:
+	set_shader_parameter(UNIFORM_SATURATION, NORMAL_SATURATION)
 
 
 func copy_state_from(in_from_material: ShaderMaterial) -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
@@ -49,6 +49,18 @@ func hydrogens_rendering_on() -> void:
 	_ensure_material_configured()
 
 
+func saturate() -> void:
+	_material_bond_1.saturate()
+	_material_bond_2.saturate()
+	_material_bond_3.saturate()
+
+
+func desaturate() -> void:
+	_material_bond_1.desaturate()
+	_material_bond_2.desaturate()
+	_material_bond_3.desaturate()
+
+
 func _ensure_material_configured() -> void:
 	_single_stick_multimesh.set_material_override(_material_bond_1)
 	_double_stick_multimesh.set_material_override(_material_bond_2)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sticks_single_atom_representation/sticks_and_single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sticks_single_atom_representation/sticks_and_single_atom_representation.gd
@@ -194,6 +194,16 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_single_atom_representation.apply_theme(in_theme)
 
 
+func saturate() -> void:
+	_stick_representation.saturate()
+	_single_atom_representation.saturate()
+
+
+func desaturate() -> void:
+	_stick_representation.desaturate()
+	_single_atom_representation.desaturate()
+
+
 func create_state_snapshot() -> Dictionary:
 	var snapshot: Dictionary = {}
 	snapshot["_single_atom_representation.snapshot"] = _single_atom_representation.create_state_snapshot()

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -181,6 +181,16 @@ func set_atomic_structure_material_overlay(in_structure: AtomicStructure, in_mat
 	atomic_structure_renderer.material_overlay = in_material_overlay
 
 
+func saturate_structure(in_structure: AtomicStructure) -> void:
+	var structure_renderer: AtomicStructureRenderer = _get_renderer_for_atomic_structure(in_structure)
+	structure_renderer.saturate()
+
+
+func desaturate_structure(in_structure: AtomicStructure) -> void:
+	var structure_renderer: AtomicStructureRenderer = _get_renderer_for_atomic_structure(in_structure)
+	structure_renderer.desaturate()
+
+
 func is_renderer_for_atomic_structure_built(in_structure: AtomicStructure) -> bool:
 	if not enabled: return false
 	var structure_renderer_name: String = str(in_structure.int_guid)
@@ -273,6 +283,7 @@ func change_default_representation(in_representation: Rendering.Representation) 
 			continue
 		structure_renderer.change_representation(in_representation)
 	representation_changed.emit(in_representation)
+	_workspace_context.refresh_group_saturation()
 
 
 func refresh_atom_sizes() -> void:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -877,6 +877,19 @@ func _deselect_hydrogens(out_structure_context: StructureContext) -> void:
 	out_structure_context.deselect_bonds(bonds_to_deselect.keys())
 
 
+func refresh_group_saturation() -> void:
+	var all_structure_contexts: Array[StructureContext] = get_all_structure_contexts()
+	var renderer: Rendering = get_rendering()
+	for structure: StructureContext in all_structure_contexts:
+		if not structure.nano_structure is AtomicStructure:
+			continue
+			
+		if structure.is_editable():
+			renderer.saturate_structure(structure.nano_structure)
+		else:
+			renderer.desaturate_structure(structure.nano_structure)
+
+
 # # Selection
 # # # # # #
 func has_selection() -> bool:
@@ -1057,6 +1070,7 @@ func _emit_new_editable_structures() -> void:
 		if context.is_editable():
 			_editable_structure_contexts_ids.push_back(context.get_int_guid())
 	editable_structure_context_list_changed.emit(get_editable_structure_contexts())
+	refresh_group_saturation()
 
 
 func update(_delta: float) -> void:


### PR DESCRIPTION
This commit will make it obvious for the user which groups can be edited and which are non-editable
It accomplishes this by making non editable structures desaturated, grayscaled

-----------
Author: @kubecz3k 
I discovered this commit in https://github.com/MSEP-one/msep.one/pull/89 as part of an unrelated change and salvaged it.

- I also made a minumum change to it because i found a bug when changing the edited group from the Structure Selector Bar (Top-Left buttons in the viewport) it would not update the dimming of the structures
