### PR TITLE
Fix transform gizmo not appearing until next input event

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -107,7 +107,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 	if not (in_input_event is InputEventMouseButton and 
 			in_input_event.pressed and
 			in_input_event.button_index == MOUSE_BUTTON_LEFT):
-		return false
+		return is_shortcut_pressed
 	
 	var preview_atomic_number: int = get_workspace_context().create_object_parameters.get_new_atom_element()
 	var cannot_create_because_hydrogen: bool = not out_context.nano_structure.are_hydrogens_visible() \
@@ -116,7 +116,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 		return true
 	
 	if _hovered_candidate == null:
-		return false
+		return is_shortcut_pressed
 	
 	var atom_pos: Vector3 = _hovered_candidate.atom_position
 	var element_to_create: int = _element_selected
@@ -139,8 +139,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 func is_exclusive_input_consumer() -> bool:
 	if _is_shortcut_pressed():
 		return true
-	var rendering: Rendering = get_workspace_context().get_rendering()
-	return rendering.atom_autopose_get_hovered_candidate_or_null() != null
+	return _hovered_candidate != null
 
 
 func set_preview_position(_in_position: Vector3) -> void:

--- a/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
@@ -14,7 +14,6 @@ var _structure_context_2_initial_object_transforms: Dictionary = {
 }
 var _selection_initial_position: Vector3 = Vector3()
 var _is_grabbed: bool = false
-var _other_handler_has_exclusivity: bool = false
 
 # region: virtual
 
@@ -195,13 +194,11 @@ func handle_inputs_end() -> void:
 		_apply_selection_transform()
 		GizmoRoot.grab_mode = GizmoRoot.GrabMode.NONE
 	GizmoRoot.disable_gizmo()
-	_other_handler_has_exclusivity = true
 
 
 func handle_inputs_resume() -> void:
 	if get_workspace_context().has_transformable_selection():
 		GizmoRoot.enable_gizmo()
-	_other_handler_has_exclusivity = false
 
 
 ## Hides the transform gizmo when creating atoms chains
@@ -439,8 +436,9 @@ func _force_gizmo_update() -> void:
 		_selection_initial_position = _init_initial_positions_and_determine_center()
 		_helper.global_transform.basis = Basis()
 		_helper.global_position = _selection_initial_position
-	if _other_handler_has_exclusivity:
-		GizmoRoot.disable_gizmo()
+	if not is_exclusive_input_consumer():
+		if get_workspace_context().get_editor_viewport().has_exclusive_input_consumer():
+			GizmoRoot.disable_gizmo()
 
 
 func _hide_gizmo() -> void:


### PR DESCRIPTION
Fixes: BUG - Clicking to select an atom makes the transform gizmo disappear until mouse move

+ The transform gizmo visibility depends on the variable `_other_handler_has_exclusivity` which is not always up to date.
This is replaced with a call to the editor viewport instead.
+ The autoposing handler sometimes returns false in `forward_input` even when it has exclusivity, causing other inconsistencies. This was fixed too. 