### PR TITLE
Fix invalid highlight on hover

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
@@ -349,6 +349,8 @@ func handle_hover_structure_changed(in_toplevel_hovered_structure_context: Struc
 	if in_toplevel_hovered_structure_context != null:
 		is_hovered = (in_toplevel_hovered_structure_context == structure_context) \
 				or workspace.is_a_ancestor_of_b(in_toplevel_hovered_structure_context.nano_structure, structure_context.nano_structure)
+	if is_hovered and in_hovered_structure_context.nano_structure.int_guid == workspace.active_structure_int_guid:
+		is_hovered = false
 	var hovered_atom_id: int = -1 if in_hovered_structure_context != structure_context else in_atom_id
 	if hovered_atom_id != _hovered_atom_id:
 		_set_hovered_atom_id(hovered_atom_id)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -95,6 +95,8 @@ func handle_hover_structure_changed(_in_toplevel_hovered_structure_context: Stru
 	if not is_hovered and are_structures_valid:
 		is_hovered = workspace.is_a_ancestor_of_b(in_hovered_structure_context.nano_structure, \
 				structure_context.nano_structure)
+	if is_hovered and in_hovered_structure_context.nano_structure.int_guid == workspace.active_structure_int_guid:
+		is_hovered = false
 	var hovered_atom_id: int = -1 if in_hovered_structure_context != structure_context else in_atom_id
 	if hovered_atom_id != _hovered_atom_id:
 		_set_hovered_atom_id(hovered_atom_id)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
@@ -705,6 +705,8 @@ func handle_hover_structure_changed(_in_toplevel_hovered_structure_context: Stru
 	if not is_hovered and are_structures_valid:
 		is_hovered = workspace.is_a_ancestor_of_b(in_hovered_structure_context.nano_structure, \
 				structure_context.nano_structure)
+	if is_hovered and in_hovered_structure_context.nano_structure.int_guid == workspace.active_structure_int_guid:
+		is_hovered = false
 	_update_is_hovered_uniform(is_hovered)
 	if in_hovered_structure_context != structure_context:
 		in_bond_id = -1 # Hovered bond is not part of this structure, remove roll over if needed


### PR DESCRIPTION
Fixes: "BUG: When hovering an atom of the current edited group, the entire group highlights instead of only the atom (this is meant to happen only if atoms are grouped, wich is not the case)"

This PR prevents highlighting the whole structure if that structure is the current active group.