### PR TITLE
Small fixes to 'Find atoms by type' feature

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/find_atoms_by_type.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/find_atoms_by_type.gd
@@ -76,7 +76,7 @@ func _add_groups_recursively(in_structure: AtomicStructure, in_parent_item: Tree
 
 func _count_found_atoms(in_structure: AtomicStructure) -> int:
 	var types := PackedInt32Array(_selected_types.keys())
-	return _workspace_context.get_structure_context(in_structure.int_guid).count_by_type(types)
+	return _workspace_context.get_structure_context(in_structure.int_guid).count_visible_atoms_by_type(types)
 
 
 func _on_element_picker_atom_type_change_requested(element: int) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_docker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_docker.gd
@@ -48,7 +48,7 @@ const _DYNAMIC_CONTEXT_CONTROLS: Dictionary = {
 				"res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_bond_type.tscn"
 			]
 		},
-	&"Find Atoms by Type":
+	&"Find Visible Atoms by Type":
 		{
 			header = true,
 			scroll = false,

--- a/godot_project/editor/ring_menu_levels/select_menu/ring_action_select_by_type.gd
+++ b/godot_project/editor/ring_menu_levels/select_menu/ring_action_select_by_type.gd
@@ -14,7 +14,7 @@ func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> voi
 	super._init(
 		tr("Select Atoms by Type"),
 		_execute_action,
-		tr("Select atoms by their atomic number")
+		tr("Select visible atoms by their atomic number")
 	)
 	with_validation(has_structure_with_atoms)
 
@@ -31,4 +31,4 @@ func has_structure_with_atoms() -> bool:
 
 func _execute_action() -> void:
 	_ring_menu.close()
-	MolecularEditorContext.request_workspace_docker_focus(DynamicContextDocker.UNIQUE_DOCKER_NAME, &"Select Atoms by Type")
+	MolecularEditorContext.request_workspace_docker_focus(DynamicContextDocker.UNIQUE_DOCKER_NAME, &"Find Visible Atoms by Type")

--- a/godot_project/project_workspace/structs/atomic_structure.gd
+++ b/godot_project/project_workspace/structs/atomic_structure.gd
@@ -354,7 +354,7 @@ func atom_get_remaining_valence(in_atom_id: int) -> int:
 	return valence_left
 
 
-func atoms_count_by_type(_types_to_count: PackedInt32Array) -> int:
+func atoms_count_visible_by_type(_types_to_count: PackedInt32Array) -> int:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
 	return 0
 

--- a/godot_project/project_workspace/structs/lmdb_nano_struct.gd
+++ b/godot_project/project_workspace/structs/lmdb_nano_struct.gd
@@ -133,7 +133,7 @@ func atom_find_bond_between(in_atom_id_a: int, in_atom_id_b: int) -> int:
 	return INVALID_BOND_ID
 
 
-func atoms_count_by_type(_types_to_count: PackedInt32Array) -> int:
+func atoms_count_visible_by_type(_types_to_count: PackedInt32Array) -> int:
 	assert(false, "FIXME: Unimplemented")
 	return 0
 

--- a/godot_project/project_workspace/structs/nano_molecular_structure.gd
+++ b/godot_project/project_workspace/structs/nano_molecular_structure.gd
@@ -626,10 +626,11 @@ func atom_has_motor_link(in_atom_id: int) -> bool:
 	return _motor_links.has(in_atom_id)
 
 
-func atoms_count_by_type(types_to_count: PackedInt32Array) -> int:
+func atoms_count_visible_by_type(types_to_count: PackedInt32Array) -> int:
 	var count: int = 0
-	for atom: NanoAtomLegacy in _atoms:
-		if atom.valid and atom.atomic_number in types_to_count:
+	for atom_id: int in _atoms.size():
+		var atom: NanoAtomLegacy = _atoms[atom_id]
+		if atom.valid and atom.atomic_number in types_to_count and is_atom_visible(atom_id):
 			count += 1
 	return count
 

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -294,10 +294,10 @@ func select_atoms_and_get_auto_selected_bonds(in_atoms_to_select: PackedInt32Arr
 	return _selection_db.select_atoms_and_get_auto_selected_bonds(in_atoms_to_select)
 
 
-func count_by_type(types_to_count: PackedInt32Array) -> int:
+func count_visible_atoms_by_type(types_to_count: PackedInt32Array) -> int:
 	if not nano_structure is AtomicStructure:
 		return 0
-	return nano_structure.atoms_count_by_type(types_to_count)
+	return nano_structure.atoms_count_visible_by_type(types_to_count)
 
 
 func select_by_type(types_to_select: PackedInt32Array) -> void:


### PR DESCRIPTION
- Clarify only visible atoms are searched
- Count of atoms per group only includes visible atoms
- RingMenu highlights the right panel when triggered

Task: BUG - Select Atom by Type allows partial selection of subgroups