### PR TITLE
Reorder the template library file list

### DIFF
--- a/godot_project/editor/controls/template_library_dialog/template_library_dialog.gd
+++ b/godot_project/editor/controls/template_library_dialog/template_library_dialog.gd
@@ -44,10 +44,9 @@ func _notification(what: int) -> void:
 
 func _load_library_contents() -> void:
 	var files_in_library_dir: PackedStringArray = DirAccess.get_files_at(LIBRARY_PATH)
-	
-	var content_in_library: PackedStringArray = Array(files_in_library_dir).filter(_is_valid_content)
-	content_in_library.sort()
-	for filename in content_in_library:
+	var content_in_library: Array = Array(files_in_library_dir).filter(_is_valid_content)
+	content_in_library.sort_custom(_library_content_sorter)
+	for filename: String in content_in_library:
 		var basename: = filename.get_basename()
 		var icon_path: = LIBRARY_PATH.path_join(basename) + "." + THUMBNAIL_EXTENSION
 		var item_icon: Texture2D = THUMBNAIL_FALLBACK
@@ -56,6 +55,18 @@ func _load_library_contents() -> void:
 		var idx: int = _item_list_library.add_item(basename.capitalize(), item_icon, true)
 		var path: String = LIBRARY_PATH.path_join(filename)
 		_item_list_library.set_item_metadata(idx, path)
+
+
+## Used to sort library templates alphabetically, but moves all msep1 files at
+## the begining of the list
+func _library_content_sorter(file_a: String, file_b: String) -> bool:
+	var extension_a: String = file_a.get_extension()
+	var extension_b: String = file_b.get_extension()
+	if extension_a == extension_b:
+		return file_a.naturalnocasecmp_to(file_b) < 0
+	if extension_a == &"msep1":
+		return true
+	return false
 
 
 func _is_valid_content(in_filepath: String) -> bool:


### PR DESCRIPTION
Fixes: "Move Star Gear to Top of Library list"

This PR keeps the alphabetical order of the `Import Template` dialog, but moves all msep files at the begining.

The alternative would have been to manually add a numbered prefix to every file (like "01_star_gears"), but that approach means every time we add a new file in the middle of the list, we need to rename everything that comes after.