### PR TITLE
Update structure highlight on group change

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
@@ -338,6 +338,10 @@ func handle_editable_structures_changed(_in_new_editable_structure_contexts: Arr
 		assert(ScriptUtils.is_queued_for_deletion_reqursive(self), "structure deleted, this rendering instance is about to be deleted")
 		return
 	_update_is_selectable_uniform()
+	# Active structure have changed, remove highlight if needed
+	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
+	if structure_context.nano_structure.int_guid == _workspace_context.workspace.active_structure_int_guid:
+		_material.set_hovered(false)
 
 
 func handle_hover_structure_changed(in_toplevel_hovered_structure_context: StructureContext,

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -81,6 +81,10 @@ func build(in_structure_context: StructureContext) -> void:
 
 func handle_editable_structures_changed(_in_new_editable_structure_contexts: Array[StructureContext]) -> void:
 	_update_is_selectable_uniform()
+	# Active structure have changed, remove highlight if needed
+	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
+	if structure_context.nano_structure.int_guid == _workspace_context.workspace.active_structure_int_guid:
+		_material.set_hovered(false)
 
 
 func handle_hover_structure_changed(_in_toplevel_hovered_structure_context: StructureContext,

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
@@ -691,6 +691,10 @@ func handle_editable_structures_changed(_in_new_editable_structure_contexts: Arr
 		assert(ScriptUtils.is_queued_for_deletion_reqursive(self), "structure deleted, this rendering instance is about to be deleted")
 		return
 	_update_is_selectable_uniform()
+	# Active structure have changed, remove highlight if needed
+	var structure_context: StructureContext = _workspace_context.get_structure_context(_related_structure_id)
+	if structure_context.nano_structure.int_guid == _workspace_context.workspace.active_structure_int_guid:
+		_update_is_hovered_uniform(false)
 
 
 func handle_hover_structure_changed(_in_toplevel_hovered_structure_context: StructureContext,


### PR DESCRIPTION
Follow up to #139 

The structure highlight is updated when the active structure changes.