### PR TITLE
Fixes the selection logic

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
@@ -20,7 +20,6 @@ var _structure_id_to_tree_item: Dictionary = {
 }
 var _edited_structure_tree_item: TreeItem = null: set = _set_edited_structure_tree_item
 var _changing_selection: bool = false
-var _multiselect_served_at_frame: int = -1
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_SCENE_INSTANTIATED:
@@ -34,8 +33,6 @@ func _notification(what: int) -> void:
 		_structures_tree.button_clicked.connect(_on_structures_tree_button_clicked)
 		_structures_tree.item_edited.connect(_on_structures_tree_item_edited)
 		_structures_tree.item_collapsed.connect(_on_structures_tree_item_collapsed)
-		_structures_tree.cell_selected.connect(_on_structure_tree_cell_selected, CONNECT_DEFERRED)
-		
 	if what == NOTIFICATION_READY:
 		var groups_docker: GroupsDocker = _find_docker()
 		assert(groups_docker, "Could not find GroupsDocker")
@@ -269,44 +266,27 @@ func _on_structures_tree_gui_input(in_event: InputEvent) -> void:
 
 func _on_structures_tree_multi_selected(out_item: TreeItem, _in_column: int, in_is_selected: bool, in_snapshot_name: String = "") -> void:
 	if _changing_selection or not in_is_selected: return
-	_multiselect_served_at_frame = Engine.get_process_frames()
 	var workspace_context: WorkspaceContext = get_workspace_context()
+	
 	var structure_id: int = _structure_id_to_tree_item.find_key(out_item)
-	var clicked_structure_context: StructureContext = workspace_context.get_structure_context(structure_id)
+	var nano_structure: NanoStructure = workspace_context.workspace.get_structure_by_int_guid(structure_id)
+	var clicked_structure_context: StructureContext = workspace_context.get_nano_structure_context(nano_structure)
 	if not clicked_structure_context.is_editable():
 		return
 	
 	_changing_selection = true
 	workspace_context.clear_all_selection()
 	clicked_structure_context.select_all(true)
+	var topmost_structure_context: StructureContext = clicked_structure_context
+	if clicked_structure_context != workspace_context.get_current_structure_context():
+		topmost_structure_context = \
+				workspace_context.get_toplevel_editable_context(clicked_structure_context)
+	topmost_structure_context.select_all(true)
 	_changing_selection = false
 	workspace_context.refresh_group_saturation()
 	if in_snapshot_name.is_empty():
 		in_snapshot_name = "Select Group"
 	workspace_context.snapshot_moment(in_snapshot_name)
-
-
-
-func _on_structure_tree_cell_selected() -> void:
-	if _changing_selection:
-		return
-	const NMB_OF_FRAMES_TO_IGNORE_AFTER_MULTISELECTED_SIGNAL = 3
-	var frame_delta: int = Engine.get_process_frames() - _multiselect_served_at_frame
-	if frame_delta < NMB_OF_FRAMES_TO_IGNORE_AFTER_MULTISELECTED_SIGNAL:
-		# workaround, we want for _on_structure_tree_cell_selected to never be called together with
-		# _on_structures_tree_multi_selected as a result of the same user click
-		return
-	var workspace_context: WorkspaceContext = get_workspace_context()
-	var tree_item: TreeItem = _structures_tree.get_selected()
-	if not is_instance_valid(tree_item):
-		return
-	
-	var structure_id: int = _structure_id_to_tree_item.find_key(tree_item)
-	var structure_context: StructureContext = workspace_context.get_structure_context(structure_id)
-	_changing_selection = true
-	workspace_context.clear_all_selection()
-	structure_context.select_all(true)
-	_changing_selection = false
 
 
 func _on_structures_tree_button_clicked(out_item: TreeItem, _in_column: int, in_id: int, mouse_button_index: int) -> void:

--- a/godot_project/editor/input_handlers/molecular_structures/dialog_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/dialog_input_handler.gd
@@ -20,7 +20,7 @@ func is_exclusive_input_consumer() -> bool:
 	return false
 
 
-func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, _in_context: StructureContext) -> bool:
+func forward_input(_in_input_event: InputEvent, _in_camera: Camera3D, _in_context: StructureContext) -> bool:
 	if is_exclusive_input_consumer():
 		return true
 	return false

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -229,7 +229,7 @@ func _screen_selection_logic(
 			if not need_to_create_snapshot:
 				snapshot_name = "Select Group"
 				need_to_create_snapshot = true
-			var affected_context: StructureContext = hit_context
+			var affected_context: StructureContext = _workspace_context.get_toplevel_editable_context(hit_context)
 			if affected_context.is_fully_selected() and is_multiselecting:
 				affected_context.clear_selection(true)
 			else:

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -240,6 +240,17 @@ func is_fully_selected() -> bool:
 			and _selection_db.get_selected_springs().size() == nano_structure.springs_count()
 
 
+func has_atom_selection(include_children: bool = true) -> bool:
+	if not get_selected_atoms().is_empty():
+		return true
+	if include_children:
+		for child_structure: NanoStructure in workspace_context.workspace.get_child_structures(nano_structure):
+			var structure_context: StructureContext = workspace_context.get_nano_structure_context(child_structure)
+			if structure_context.has_atom_selection(true):
+				return true
+	return false
+
+
 func is_empty_but_has_subgroups() -> bool:
 	return nano_structure is AtomicStructure and \
 			nano_structure.get_valid_atoms_count() == 0 and \


### PR DESCRIPTION
Fixes: "CRASH - Nesting Groups"

This PR ensures the selection logic works as Jonathan described it:

![image](https://github.com/user-attachments/assets/dda3d5b5-e852-4a8e-9ed7-969a83288a4e)

From the initial state:

+ When selecting the SmallBearing group:
> It selects small bearing and its children, as they are part of smallBearing.

+ When selecting Center1:
> If you click on center 1, because you are at the top level, you will select smallBearing. If you were inside smallBearing, clicking on center 1 would select center 1 and any children of center 1.

+ When selecting SingleAtom, then trying to multiselect Center1
> If you have singleAtom selected then multiselect center1, you would select smallBearing and all its children, along with singleatom.