### PR TITLE
Dont apply snapshot state to a dying Reference Shape

### DIFF
--- a/godot_project/editor/rendering/reference_shape_renderer/reference_shape_renderer.gd
+++ b/godot_project/editor/rendering/reference_shape_renderer/reference_shape_renderer.gd
@@ -170,7 +170,6 @@ func create_state_snapshot() -> Dictionary:
 	snapshot["_workspace_context"] = _workspace_context
 	snapshot["color_selected"] = color_selected
 	snapshot["color_unselected"] = color_unselected
-	snapshot["_nano_shape_primitive_mesh"] = _nano_shape_primitive_mesh.duplicate(true)
 	snapshot["_shape_id"] = _shape_id
 	snapshot["_hover_enabled"] = _hover_enabled
 	snapshot["visible"] = visible

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -937,7 +937,8 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	for renderer_name: String in anchor_renderers:
 		var renderer: VirtualAnchorRenderer
 		var anchor_renderer_snapshot: Dictionary = anchor_renderes_snapshots[renderer_name]
-		if is_instance_valid(anchor_renderers[renderer_name]):
+		if is_instance_valid(anchor_renderers[renderer_name]) \
+				and not anchor_renderers[renderer_name].is_queued_for_deletion():
 			renderer = anchor_renderers[renderer_name]
 		else:
 			# create new one
@@ -951,7 +952,8 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	for renderer_name: String in motors_renderers:
 		var renderer: VirtualMotorRenderer
 		var motor_renderer_snapshot: Dictionary = motors_renderers_snapshots[renderer_name]
-		if is_instance_valid(motors_renderers[renderer_name]):
+		if is_instance_valid(motors_renderers[renderer_name]) \
+				and not motors_renderers[renderer_name].is_queued_for_deletion():
 			renderer = motors_renderers[renderer_name]
 		else:
 			# create new one
@@ -965,7 +967,8 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	for renderer_name: String in shapes_renderers:
 		var renderer: NanoShapeRenderer
 		var shape_renderer_snapshot: Dictionary = shapes_renderers_snapshots[renderer_name]
-		if is_instance_valid(shapes_renderers[renderer_name]):
+		if is_instance_valid(shapes_renderers[renderer_name]) \
+				and not shapes_renderers[renderer_name].is_queued_for_deletion():
 			renderer = shapes_renderers[renderer_name]
 		else:
 			# create new one


### PR DESCRIPTION
`is_instance_valid()` doesn't take into account if a node is queued for deletion.
Because of this, snapshot of ReferenceShape was applied to the reference shape being deleted instead of to the new duplicate being created
Also added similar guards for motors and anchors

Task: CRASH - Created invisible Torus, crashed trying to move it.
