### PR TITLE
Fix corner case when undoing deletion of a group

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
@@ -532,6 +532,11 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	_current_representation.apply_state_snapshot(in_snapshot["_current_representation.snapshot"])
 	_springs_representation.apply_state_snapshot(in_snapshot["_springs_representation.snapshot"])
 	_labels_representation.apply_state_snapshot(in_snapshot["_labels_representation.snapshot"])
+	var nano_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_nano_structure_id)
+	if not nano_structure.atoms_moved.is_connected(_on_nanostructure_atoms_moved):
+		# This can happen if the AtomicStructureRenderer was destroyed because
+		# a group was deleted, and a new one was created in it's place
+		_internal_build()
 	_refresh_label_visibility_state()
 	
 	#

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -580,7 +580,8 @@ func get_nano_structure_context(in_nano_structure: NanoStructure) -> StructureCo
 		_structure_contexts_holder.add_child_with_name(structure_context, in_nano_structure.get_structure_name().to_snake_case())
 		structure_context.selection_changed.connect(_on_structure_context_selection_changed.bind(structure_context.get_int_guid()))
 		structure_context.virtual_object_selection_changed.connect(_on_structure_context_virtual_object_selection_changed.bind(structure_context.get_int_guid()))
-		if structure_context.nano_structure is AtomicStructure:
+		if structure_context.nano_structure is AtomicStructure \
+				and not structure_context.nano_structure.atoms_moved.is_connected(_on_structure_context_atoms_moved):
 			structure_context.nano_structure.atoms_moved.connect(_on_structure_context_atoms_moved.bind(structure_context.get_int_guid()))
 			structure_context.nano_structure.atoms_added.connect(_on_structure_contents_modified_arg1.bind(structure_context.get_int_guid()))
 			structure_context.nano_structure.atoms_added.connect(_on_structure_context_atoms_added.bind(structure_context.get_int_guid()))


### PR DESCRIPTION
- Renderer was being recreated, but initialization code was not being run, causing it to be disconnected from the 'xxx_changed' signals of the original molecule
- Also fixed an annoyig bug where deleting a group and ondoing it would print a lot of errors about connecting signals which are already connected

Task: BUG - SIMULATION PUT IN BAD STATE
