### PR TITLE
Fix crash on atom radius change

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -177,6 +177,8 @@ func refresh_atoms_atomic_number(in_atoms_and_atomic_numbers: Array[Vector2i]) -
 
 
 func refresh_atoms_sizes(in_update_atoms_radii: bool = false) -> void:
+	if not _segmented_multimesh.is_visible():
+		return
 	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
 	var scale_factor: float = Representation.get_atom_scale_factor(related_nanostructure.get_representation_settings())
 	_apply_scale_factor(scale_factor)

--- a/godot_project/utils/segmented_multimesh/segmented_multi_mesh.gd
+++ b/godot_project/utils/segmented_multimesh/segmented_multi_mesh.gd
@@ -228,6 +228,10 @@ func hide() -> void:
 	_set_visible(false)
 
 
+func is_visible() -> bool:
+	return _visible
+
+
 func _set_visible(in_visible: bool) -> void:
 	_visible = in_visible
 	for segment: Segment in _id_to_segment_map.values():


### PR DESCRIPTION
Fixes: CRASH - Changing Visualized Radius setting settings while in Enhanced Sticks mode

`BallsAndStickRepresentation` is listening directly to the `balls_and_sticks_size_source_changed` signal, which will trigger the radius update whether the representation is active or not. And if the representation is not active, it can be outdated, meaning the underlying representation doesn't match the structure contents.

It would be better to do this check in `BallsAndStickRepresentation` instead of in `SphereRepresentation` but there's no easy way to tell if a given representation is active or not.