### PR TITLE
Properly wait for snapshot to be applied before making further modifications when making changes in middle of a simulation

### DIFF
--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1280,7 +1280,7 @@ func snapshot_moment(in_operation_name: String) -> void:
 		var current_simulation_time: float = _simulation.get_last_seeked_time()
 		
 		# Go back just before starting the simulation
-		_history.apply_previous_snapshot()
+		await _history.apply_previous_snapshot()
 		
 		# Rewind simulation to the latest point and create a snapshot.
 		# This will drop the user operation (final_snapshot) from history. 


### PR DESCRIPTION
Task: CRASH - Deleting group after failed simulation