### PR TITLE
Make more obvious you cannot replay an errored simulation when no frames have been received

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -271,10 +271,14 @@ func _update_controls() -> void:
 			_button_start_pause.icon = _ICONS.play_error
 			_button_start_pause.text = tr("Play")
 			_button_start_pause.disabled = false
+			_slider_timeline.editable = true
+			if _simulation_length_nanoseconds == 0:
+				# Cannot replay animation when no frames have been received
+				_button_start_pause.disabled = true
+				_slider_timeline.editable = false
 			_status_icon.texture = _ICONS.pause
 			_status_label.text = tr("❌Error")
 			_spin_box_timeline.editable = true
-			_slider_timeline.editable = true
 			_button_revert.disabled = false
 			_button_end.disabled = true
 


### PR DESCRIPTION

TASK: BUG - After a simulation failure, clicking the Play Simulation button twice makes it appear that the simulatoin is running

![image](https://github.com/user-attachments/assets/7f7e0867-87fa-4f85-ae36-00fd8ea0c0e5)
