### PR TITLE
Configure VSCode Workspace to debug Windows binaries with MingW64 compiler

### DIFF
--- a/msep.code-workspace
+++ b/msep.code-workspace
@@ -168,9 +168,9 @@
 			},
 			{
 				"name": "Windows: Play Msep (Windows)",
-				"type": "cppvsdbg",
-				"preLaunchTask": "Windows: Build Godot Editor Debug",
+				"type": "cppdbg",
 				"program": "${workspaceFolder:godot}/bin/godot.windows.editor.x86_64.exe",
+				"MIMode": "gdb",
 				"args": [],
 				"request": "launch",
 				"cwd": "${workspaceFolder:godot_project}",

--- a/scripts/build_editor_debug.windows.sh
+++ b/scripts/build_editor_debug.windows.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./build_editor_debug.sh use_mingw=yes separate_debug_symbols=yes arch=x86_64 module_upnp_enabled=no


### PR DESCRIPTION
- MingW is required in Windows by LMDB module

No Task