### PR TITLE
Make atoms suggestions only appear in balls and sticks representation

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -78,12 +78,13 @@ func _on_current_structure_context_changed(in_context: StructureContext) -> void
 func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context: StructureContext) -> bool:
 	var rendering: Rendering = out_context.workspace_context.get_rendering()
 	var is_shortcut_pressed: bool = _check_input_event_can_bind(in_input_event)
-	if not is_shortcut_pressed and not _should_show():
+	
+	if is_shortcut_pressed and _should_show(true):
+		# Auto enable create mode if we're in selection mode but all the other conditions are met
+		_ensure_create_mode()
+	elif not _should_show():
 		rendering.atom_autopose_preview_hide()
 		return false
-	
-	if is_shortcut_pressed:
-		_ensure_create_mode()
 	
 	update_preview_position()
 	_update_candidates_if_needed()
@@ -138,7 +139,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 
 
 func is_exclusive_input_consumer() -> bool:
-	if _is_shortcut_pressed():
+	if _is_shortcut_pressed() and _should_show(true):
 		return true
 	return _hovered_candidate != null
 
@@ -350,13 +351,15 @@ func _ensure_create_mode() -> void:
 
 ## Returns true if create mode is ON and the auto posing visualization is enabled.
 ## This setting is controlled from the visibility panel in the workspace docker.
-func _should_show() -> bool:
+func _should_show(ignore_create_mode: bool = false) -> bool:
 	var parameters: CreateObjectParameters = _workspace_context.create_object_parameters
 	if _workspace_context.is_simulating():
 		return false
-	if not parameters.get_create_mode_enabled():
+	if not ignore_create_mode and not parameters.get_create_mode_enabled():
 		return false
 	if parameters.get_create_mode_type() != CreateObjectParameters.CreateModeType.CREATE_ATOMS_AND_BONDS:
+		return false
+	if not _is_valid_representation():
 		return false
 	if _is_shortcut_pressed():
 		return true
@@ -370,6 +373,15 @@ func _is_shortcut_pressed() -> bool:
 		not Input.is_key_pressed(KEY_CTRL) and
 		not Input.is_key_pressed(KEY_META)
 	)
+
+
+func _is_valid_representation() -> bool:
+	var representation_settings: RepresentationSettings = _workspace_context.workspace.representation_settings
+	const VALID_REPRESENTATIONS := [
+		Rendering.Representation.BALLS_AND_STICKS,
+		Rendering.Representation.ENHANCED_STICKS_AND_BALLS,
+	]
+	return VALID_REPRESENTATIONS.has(representation_settings.get_rendering_representation())
 
 
 ## Input handlers will execute _forward_input_* in an order dictated by this parameter


### PR DESCRIPTION
Fix: BUG - Changing views with atom selected can continue to show atom position suggestions

