### PR TITLE
Fix the bottom ring menu button not closing the ring menu

### DIFF
--- a/godot_project/editor/controls/workspace_view/controls/toggle_ring_menu_button.tscn
+++ b/godot_project/editor/controls/workspace_view/controls/toggle_ring_menu_button.tscn
@@ -12,6 +12,7 @@ theme_override_colors/icon_normal_color = Color(1, 1, 1, 0.356863)
 theme_override_colors/icon_pressed_color = Color(1, 1, 1, 1)
 theme_override_colors/icon_hover_color = Color(1, 1, 1, 0.737255)
 theme_override_colors/icon_hover_pressed_color = Color(1, 1, 1, 1)
+action_mode = 0
 icon = ExtResource("1_t1q0r")
 flat = true
 expand_icon = true


### PR DESCRIPTION
Fixes: Clicking on the "action ring icon" while the Action Ring is up should lower the Action Ring

If the ring menu is open, any click outside the ring will close it, and forward the even to the control behind the cursor.

If the cursor is over the bottom right button, the ring menu will still close, but the button will catch the click (and release), and trigger the `toggle_ring_menu` action, causing the menu to open again.

This is because the button press is triggered on the mouse release (like every other button), but that release happens several frames after the menu was closed, but before the close animation is complete, which makes it look like the button isn't working.

This PR changes the `action_mode` from `released` to `pressed` so the button is triggered immediately, when the ring menu is still active, so it triggers a close rather than an open.

If this is not desired, we can solve the issue with a lot more code in the `ToggleRingMenuButton` script. 
