### PR TITLE
Fix excesive count of default values for `LightningMemoryMappedDatabase::get_value`

### DIFF
--- a/modules/lmdb/lightning_memory_mapped_database.cpp
+++ b/modules/lmdb/lightning_memory_mapped_database.cpp
@@ -715,7 +715,7 @@ Variant LightningMemoryMappedDatabase::get_value(const Variant &in_key, const Va
 void LightningMemoryMappedDatabase::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("initialize", "database_file_path"), &LightningMemoryMappedDatabase::initialize);
 	ClassDB::bind_method(D_METHOD("put_value", "key", "value"), &LightningMemoryMappedDatabase::put_value);
-	ClassDB::bind_method(D_METHOD("get_value", "key", "default_value"), &LightningMemoryMappedDatabase::get_value, "default", &LightningMemoryMappedDatabase::get_value, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("get_value", "key", "default_value"), &LightningMemoryMappedDatabase::get_value, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("commit"), &LightningMemoryMappedDatabase::commit);
 	ClassDB::bind_method(D_METHOD("is_active"), &LightningMemoryMappedDatabase::is_active);
 	ClassDB::bind_method(D_METHOD("create_molecule"), &LightningMemoryMappedDatabase::create_molecule);


### PR DESCRIPTION
Task: BUG: when running verbose, Godot complains of a method with too many default arguments in LMDB module

![image](https://github.com/user-attachments/assets/5aa7aeb0-685f-42c3-a739-093a5dc402b9)
