### PR TITLE
Prevent a freeze when simulating a structure with incomplete valence

### DIFF
--- a/godot_project/autoloads/openmm/openmm.gd
+++ b/godot_project/autoloads/openmm/openmm.gd
@@ -862,6 +862,8 @@ func _handle_request_error(
 
 func _dispose_thread_when_done(out_promise: Promise, out_thread: Thread) -> void:
 	await out_promise.wait_for_fulfill()
+	while out_thread.is_alive():
+		await get_tree().process_frame
 	out_thread.wait_to_finish()
 	_threads.erase(out_thread)
 


### PR DESCRIPTION
Fixes: CRASH - Rotating Nested Groups

This is more of a band aid fix than a proper patch, as I can't figure out the root cause of the issue.
The simulation `start_promise` is fulfilled while the thread is still running, causing the `wait_to_finish()` call to freeze the application, but doing so also prevents the thread from finishing somehow.

I suspect there's some mutexes interlocking somewhere but this is bad enough that this fix might be necessary while we figure this out.   