### PR TITLE
Enable etc2 texture compression required for macos export

### DIFF
--- a/godot_project/autoloads/busy_indicator/sprites/spriteChain.svg.import
+++ b/godot_project/autoloads/busy_indicator/sprites/spriteChain.svg.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://bksfdiemg1kia"
 path.s3tc="res://.godot/imported/spriteChain.svg-1f7d7ab9a98568ba2d3559043fe76487.s3tc.ctex"
+path.etc2="res://.godot/imported/spriteChain.svg-1f7d7ab9a98568ba2d3559043fe76487.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://autoloads/busy_indicator/sprites/spriteChain.svg"
-dest_files=["res://.godot/imported/spriteChain.svg-1f7d7ab9a98568ba2d3559043fe76487.s3tc.ctex"]
+dest_files=["res://.godot/imported/spriteChain.svg-1f7d7ab9a98568ba2d3559043fe76487.s3tc.ctex", "res://.godot/imported/spriteChain.svg-1f7d7ab9a98568ba2d3559043fe76487.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/controls/ring_menu/nano_ring_menu/ring_menu_ui/ring_menu_3d/ring_inner_circle/assets/ring_inner_circle_back_glow.png.import
+++ b/godot_project/editor/controls/ring_menu/nano_ring_menu/ring_menu_ui/ring_menu_3d/ring_inner_circle/assets/ring_inner_circle_back_glow.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://b1048txw7wtv6"
 path.s3tc="res://.godot/imported/ring_inner_circle_back_glow.png-2fe924d9c1b8e79da1ae103b329fabc4.s3tc.ctex"
+path.etc2="res://.godot/imported/ring_inner_circle_back_glow.png-2fe924d9c1b8e79da1ae103b329fabc4.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/controls/ring_menu/nano_ring_menu/ring_menu_ui/ring_menu_3d/ring_inner_circle/assets/ring_inner_circle_back_glow.png"
-dest_files=["res://.godot/imported/ring_inner_circle_back_glow.png-2fe924d9c1b8e79da1ae103b329fabc4.s3tc.ctex"]
+dest_files=["res://.godot/imported/ring_inner_circle_back_glow.png-2fe924d9c1b8e79da1ae103b329fabc4.s3tc.ctex", "res://.godot/imported/ring_inner_circle_back_glow.png-2fe924d9c1b8e79da1ae103b329fabc4.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/controls/ring_menu/nano_ring_menu/ring_menu_ui/ring_menu_3d/side_button/assets/back_ico.png.import
+++ b/godot_project/editor/controls/ring_menu/nano_ring_menu/ring_menu_ui/ring_menu_3d/side_button/assets/back_ico.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dqlk3rj55mhbj"
 path.s3tc="res://.godot/imported/back_ico.png-77bfc9064701b3d037178e588a3866b6.s3tc.ctex"
+path.etc2="res://.godot/imported/back_ico.png-77bfc9064701b3d037178e588a3866b6.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/controls/ring_menu/nano_ring_menu/ring_menu_ui/ring_menu_3d/side_button/assets/back_ico.png"
-dest_files=["res://.godot/imported/back_ico.png-77bfc9064701b3d037178e588a3866b6.s3tc.ctex"]
+dest_files=["res://.godot/imported/back_ico.png-77bfc9064701b3d037178e588a3866b6.s3tc.ctex", "res://.godot/imported/back_ico.png-77bfc9064701b3d037178e588a3866b6.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/icons/icon_Atom.svg.import
+++ b/godot_project/editor/icons/icon_Atom.svg.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://b4uxqucqyx2eb"
 path.s3tc="res://.godot/imported/icon_Atom.svg-ca3fac062603b1669abc5ad3db9389e1.s3tc.ctex"
+path.etc2="res://.godot/imported/icon_Atom.svg-ca3fac062603b1669abc5ad3db9389e1.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/icons/icon_Atom.svg"
-dest_files=["res://.godot/imported/icon_Atom.svg-ca3fac062603b1669abc5ad3db9389e1.s3tc.ctex"]
+dest_files=["res://.godot/imported/icon_Atom.svg-ca3fac062603b1669abc5ad3db9389e1.s3tc.ctex", "res://.godot/imported/icon_Atom.svg-ca3fac062603b1669abc5ad3db9389e1.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/labels_representation_atlas.png.import
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/labels_representation_atlas.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://bop2i8h1ut1xd"
 path.bptc="res://.godot/imported/labels_representation_atlas.png-334fb94389fa1dda20cdd25b8495d1cb.bptc.ctex"
+path.astc="res://.godot/imported/labels_representation_atlas.png-334fb94389fa1dda20cdd25b8495d1cb.astc.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/labels_representation_atlas.png"
-dest_files=["res://.godot/imported/labels_representation_atlas.png-334fb94389fa1dda20cdd25b8495d1cb.bptc.ctex"]
+dest_files=["res://.godot/imported/labels_representation_atlas.png-334fb94389fa1dda20cdd25b8495d1cb.bptc.ctex", "res://.godot/imported/labels_representation_atlas.png-334fb94389fa1dda20cdd25b8495d1cb.astc.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/atom_noise_atlas.png.import
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/atom_noise_atlas.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://c5p7jdrmkycg1"
 path.s3tc="res://.godot/imported/atom_noise_atlas.png-ee024760392e00703c7d0b235ba88e63.s3tc.ctex"
+path.etc2="res://.godot/imported/atom_noise_atlas.png-ee024760392e00703c7d0b235ba88e63.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/atom_noise_atlas.png"
-dest_files=["res://.godot/imported/atom_noise_atlas.png-ee024760392e00703c7d0b235ba88e63.s3tc.ctex"]
+dest_files=["res://.godot/imported/atom_noise_atlas.png-ee024760392e00703c7d0b235ba88e63.s3tc.ctex", "res://.godot/imported/atom_noise_atlas.png-ee024760392e00703c7d0b235ba88e63.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/inner_rim.png.import
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/inner_rim.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://cu5nnpewjlepr"
 path.s3tc="res://.godot/imported/inner_rim.png-56ef5af6564aa1efb18dc647fcd8a911.s3tc.ctex"
+path.etc2="res://.godot/imported/inner_rim.png-56ef5af6564aa1efb18dc647fcd8a911.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/inner_rim.png"
-dest_files=["res://.godot/imported/inner_rim.png-56ef5af6564aa1efb18dc647fcd8a911.s3tc.ctex"]
+dest_files=["res://.godot/imported/inner_rim.png-56ef5af6564aa1efb18dc647fcd8a911.s3tc.ctex", "res://.godot/imported/inner_rim.png-56ef5af6564aa1efb18dc647fcd8a911.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain-alpha.png.import
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain-alpha.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://x4hnllteixvr"
 path.s3tc="res://.godot/imported/chain-alpha.png-59734154f1181e11d52a17e219f4a627.s3tc.ctex"
+path.etc2="res://.godot/imported/chain-alpha.png-59734154f1181e11d52a17e219f4a627.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain-alpha.png"
-dest_files=["res://.godot/imported/chain-alpha.png-59734154f1181e11d52a17e219f4a627.s3tc.ctex"]
+dest_files=["res://.godot/imported/chain-alpha.png-59734154f1181e11d52a17e219f4a627.s3tc.ctex", "res://.godot/imported/chain-alpha.png-59734154f1181e11d52a17e219f4a627.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_Material_Normal.png.import
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_Material_Normal.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://0tpjcm38osex"
 path.s3tc="res://.godot/imported/chain_Material_Normal.png-16702f282f6ea1a5f2582e5559dbfe14.s3tc.ctex"
+path.etc2="res://.godot/imported/chain_Material_Normal.png-16702f282f6ea1a5f2582e5559dbfe14.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_Material_Normal.png"
-dest_files=["res://.godot/imported/chain_Material_Normal.png-16702f282f6ea1a5f2582e5559dbfe14.s3tc.ctex"]
+dest_files=["res://.godot/imported/chain_Material_Normal.png-16702f282f6ea1a5f2582e5559dbfe14.s3tc.ctex", "res://.godot/imported/chain_Material_Normal.png-16702f282f6ea1a5f2582e5559dbfe14.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_Material_OcclusionRoughnessMetallic.png.import
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_Material_OcclusionRoughnessMetallic.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://wepi6a758afu"
 path.s3tc="res://.godot/imported/chain_Material_OcclusionRoughnessMetallic.png-1cbb1f3d48dcf748f7ccdab9deb4ac51.s3tc.ctex"
+path.etc2="res://.godot/imported/chain_Material_OcclusionRoughnessMetallic.png-1cbb1f3d48dcf748f7ccdab9deb4ac51.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_Material_OcclusionRoughnessMetallic.png"
-dest_files=["res://.godot/imported/chain_Material_OcclusionRoughnessMetallic.png-1cbb1f3d48dcf748f7ccdab9deb4ac51.s3tc.ctex"]
+dest_files=["res://.godot/imported/chain_Material_OcclusionRoughnessMetallic.png-1cbb1f3d48dcf748f7ccdab9deb4ac51.s3tc.ctex", "res://.godot/imported/chain_Material_OcclusionRoughnessMetallic.png-1cbb1f3d48dcf748f7ccdab9deb4ac51.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_chain.png.import
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_chain.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://4j7hqk2o5uuu"
 path.s3tc="res://.godot/imported/chain_chain.png-75c37c4f2837d5d4a2426f47c665da1a.s3tc.ctex"
+path.etc2="res://.godot/imported/chain_chain.png-75c37c4f2837d5d4a2426f47c665da1a.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={
@@ -15,7 +16,7 @@ generator_parameters={
 [deps]
 
 source_file="res://editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/assets/chain_chain.png"
-dest_files=["res://.godot/imported/chain_chain.png-75c37c4f2837d5d4a2426f47c665da1a.s3tc.ctex"]
+dest_files=["res://.godot/imported/chain_chain.png-75c37c4f2837d5d4a2426f47c665da1a.s3tc.ctex", "res://.godot/imported/chain_chain.png-75c37c4f2837d5d4a2426f47c665da1a.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/resources/white.png.import
+++ b/godot_project/editor/rendering/resources/white.png.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://bgborgp5aeeml"
 path.s3tc="res://.godot/imported/white.png-fc04b2bebdb1a23ad3a3416983703b95.s3tc.ctex"
+path.etc2="res://.godot/imported/white.png-fc04b2bebdb1a23ad3a3416983703b95.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/resources/white.png"
-dest_files=["res://.godot/imported/white.png-fc04b2bebdb1a23ad3a3416983703b95.s3tc.ctex"]
+dest_files=["res://.godot/imported/white.png-fc04b2bebdb1a23ad3a3416983703b95.s3tc.ctex", "res://.godot/imported/white.png-fc04b2bebdb1a23ad3a3416983703b95.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/virtual_motor_renderer/asset/linear_sprite.svg.import
+++ b/godot_project/editor/rendering/virtual_motor_renderer/asset/linear_sprite.svg.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://vgwaelryj6lw"
 path.s3tc="res://.godot/imported/linear_sprite.svg-4f3b0539bfc66b44f30c6c495156b3d4.s3tc.ctex"
+path.etc2="res://.godot/imported/linear_sprite.svg-4f3b0539bfc66b44f30c6c495156b3d4.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/virtual_motor_renderer/asset/linear_sprite.svg"
-dest_files=["res://.godot/imported/linear_sprite.svg-4f3b0539bfc66b44f30c6c495156b3d4.s3tc.ctex"]
+dest_files=["res://.godot/imported/linear_sprite.svg-4f3b0539bfc66b44f30c6c495156b3d4.s3tc.ctex", "res://.godot/imported/linear_sprite.svg-4f3b0539bfc66b44f30c6c495156b3d4.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/virtual_motor_renderer/asset/rotary_sprite.svg.import
+++ b/godot_project/editor/rendering/virtual_motor_renderer/asset/rotary_sprite.svg.import
@@ -4,15 +4,16 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://6ej6w86sx6f1"
 path.s3tc="res://.godot/imported/rotary_sprite.svg-f4f0fd68f7eabdf8537478722075dcb6.s3tc.ctex"
+path.etc2="res://.godot/imported/rotary_sprite.svg-f4f0fd68f7eabdf8537478722075dcb6.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://editor/rendering/virtual_motor_renderer/asset/rotary_sprite.svg"
-dest_files=["res://.godot/imported/rotary_sprite.svg-f4f0fd68f7eabdf8537478722075dcb6.s3tc.ctex"]
+dest_files=["res://.godot/imported/rotary_sprite.svg-f4f0fd68f7eabdf8537478722075dcb6.s3tc.ctex", "res://.godot/imported/rotary_sprite.svg-f4f0fd68f7eabdf8537478722075dcb6.etc2.ctex"]
 
 [params]
 

--- a/godot_project/editor/rendering/virtual_motor_renderer/motor_link_renderer/assets/MotorLink_dashed-line.png.import
+++ b/godot_project/editor/rendering/virtual_motor_renderer/motor_link_renderer/assets/MotorLink_dashed-line.png.import
@@ -4,8 +4,9 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://b6orqvlvykjnq"
 path.s3tc="res://.godot/imported/MotorLink_dashed-line.png-01e1b7ee265af0e5452eadce894d0c11.s3tc.ctex"
+path.etc2="res://.godot/imported/MotorLink_dashed-line.png-01e1b7ee265af0e5452eadce894d0c11.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
+"imported_formats": ["s3tc_bptc", "etc2_astc"],
 "vram_texture": true
 }
 generator_parameters={
@@ -15,7 +16,7 @@ generator_parameters={
 [deps]
 
 source_file="res://editor/rendering/virtual_motor_renderer/motor_link_renderer/assets/MotorLink_dashed-line.png"
-dest_files=["res://.godot/imported/MotorLink_dashed-line.png-01e1b7ee265af0e5452eadce894d0c11.s3tc.ctex"]
+dest_files=["res://.godot/imported/MotorLink_dashed-line.png-01e1b7ee265af0e5452eadce894d0c11.s3tc.ctex", "res://.godot/imported/MotorLink_dashed-line.png-01e1b7ee265af0e5452eadce894d0c11.etc2.ctex"]
 
 [params]
 

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -346,6 +346,7 @@ limits/debugger/max_chars_per_second.editor=3000000
 
 [rendering]
 
+textures/vram_compression/import_etc2_astc=true
 textures/vram_compression/import_s3tc_bptc.macos=true
 
 [shader_globals]


### PR DESCRIPTION
Export to MacOS is blocked if this setting is disabled.
Enabling it only for macos using the feature field in the export options doesn't work, so this is enabled project wide.