### PR TITLE
Replace some preloading for loading to avoid cyclic dependencies after export

### DIFF
--- a/godot_project/autoloads/PeriodicTable.gd
+++ b/godot_project/autoloads/PeriodicTable.gd
@@ -13,6 +13,15 @@ enum ColorSchema {
 	PUBCHEM,
 }
 
+static var PALETTES: Dictionary = {
+	ColorSchema.MSEP: load("res://autoloads/data/color_palettes/MSEP.tres"),
+	ColorSchema.COREY: load("res://autoloads/data/color_palettes/Corey.tres"),
+	ColorSchema.KOLTUN: load("res://autoloads/data/color_palettes/Koltun.tres"),
+	ColorSchema.JMOL: load("res://autoloads/data/color_palettes/JMol.tres"),
+	ColorSchema.RASMOL: load("res://autoloads/data/color_palettes/Rasmol.tres"),
+	ColorSchema.PUBCHEM: load("res://autoloads/data/color_palettes/PubChem.tres"),
+}
+
 const INVALID_ATOMIC_NUMBER = -1
 const NON_METALS = [1, 6, 7, 8, 9, 14, 15, 16, 17]
 #				   [H, C, N, O, F, Si,  P,  S, Cl]
@@ -46,17 +55,10 @@ func get_current_color_schema() -> ColorSchema:
 	return _current_color_schema
 
 
+
 func load_schema(in_which: ColorSchema) -> void:
 	if _current_color_schema == in_which:
 		return
-	const PALETTES: Dictionary = {
-		ColorSchema.MSEP: preload("res://autoloads/data/color_palettes/MSEP.tres"),
-		ColorSchema.COREY: preload("res://autoloads/data/color_palettes/Corey.tres"),
-		ColorSchema.KOLTUN: preload("res://autoloads/data/color_palettes/Koltun.tres"),
-		ColorSchema.JMOL: preload("res://autoloads/data/color_palettes/JMol.tres"),
-		ColorSchema.RASMOL: preload("res://autoloads/data/color_palettes/Rasmol.tres"),
-		ColorSchema.PUBCHEM: preload("res://autoloads/data/color_palettes/PubChem.tres"),
-	}
 	var palette := PALETTES[in_which] as PeriodicTableColorPalette 
 	for i in range(1, MAX_ATOMIC_NUMBER+1):
 		var element_data: ElementData = _elements[i]

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
@@ -5,7 +5,7 @@ const BASE_SCALE = 1.0;
 const NMB_OF_KNOWN_ATOMS = 118
 const SCALE_FACTOR = 4.0 # tweak to modify relation relation between atom size and label size
 
-const HydrogensMaterial: ShaderMaterial = preload("res://editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/labels_representation_material.tres")
+static var HydrogensMaterial: ShaderMaterial = load("res://editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/labels_representation_material.tres")
 
 const UNIFORM_SCALE = &"scale"
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
@@ -2,7 +2,7 @@ class_name SingleAtomRepresentation extends Representation
 
 const BASE_SCALE = 0.022;
 
-const SingleAtomMaterial: ShaderMaterial = preload("res://editor/rendering/atomic_structure_renderer/representation/single_atom_representation/assets/single_atom_representation_material.tres")
+static var SingleAtomMaterial: ShaderMaterial = load("res://editor/rendering/atomic_structure_renderer/representation/single_atom_representation/assets/single_atom_representation_material.tres")
 
 
 var _structure_id: int

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -5,7 +5,7 @@ signal rendering_ready
 const BASE_SCALE = 1.0;
 const HIGHLIGHT_FACTOR = 3.0;
 
-const MultimeshAtomMaterial: SphereMaterial = preload("res://editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/multimesh_atom_material.tres")
+static var MultimeshAtomMaterial: SphereMaterial = load("res://editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/multimesh_atom_material.tres")
 
 @onready var _segmented_multimesh: SegmentedMultimesh = $SegmentedMultiMesh
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -1,6 +1,6 @@
 class_name CapsuleStickRepresentation extends StickRepresentation
 
-const CapsuleMaterial: ShaderMaterial = preload("res://editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.tres")
+static var CapsuleMaterial: ShaderMaterial = load("res://editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.tres")
 
 const _SHADER_SINGLE_BOND_MESH_CAPS_STARTS_AT_LOCAL_Z = 0.44
 const _SHADER_DOUBLE_BOND_MESH_CAPS_STARTS_AT_LOCAL_Z = 0.44

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
@@ -18,7 +18,7 @@ const _SINGLE_BOND_RADIUS_FACTOR = _BOND_TO_ATOM_WIDTH * 0.33
 # Note: Currently all three cylinder models, have exactly the same radius
 const CYLINDER_MODEL_RADIUS = 0.023054
 
-const CylinderMaterial: CylinderStickMaterial = preload("res://editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/bond_cylinder_material.tres")
+static var CylinderMaterial: CylinderStickMaterial = load("res://editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/bond_cylinder_material.tres")
 
 
 func _initialize() -> void:

--- a/godot_project/editor/rendering/world_environment.gd
+++ b/godot_project/editor/rendering/world_environment.gd
@@ -1,8 +1,8 @@
 extends WorldEnvironment
 
 
-const DarkBackgroundSky = preload("res://editor/rendering/resources/background_sky.tres")
-const LightBackgroundSky = preload("res://editor/rendering/resources/sky.tres")
+static var DarkBackgroundSky: Sky = load("res://editor/rendering/resources/background_sky.tres")
+static var LightBackgroundSky: Sky = load("res://editor/rendering/resources/sky.tres")
 
 
 func _ready() -> void:


### PR DESCRIPTION
Task: CRASH: MSEP doesn't work efter exporting with Godot 4.4.1