### PR TITLE
Read godot version from Engine instead of hardcode it

### DIFF
--- a/godot_project/autoloads/about_msep_one/third_party_software/third_party_software.gd
+++ b/godot_project/autoloads/about_msep_one/third_party_software/third_party_software.gd
@@ -46,8 +46,9 @@ func _ready() -> void:
 			"MPL 2.0", "Mozilla Public License Version 2.0",
 			licences_texts["BSD-3-clause"])
 	_create_software_tree_item(zeromq_info)
+	
 	var godot_info := LicenseInfo.new(
-			"Godot Engine", "4.2.3-(custom)", "https://godotengine.org/",
+			"Godot Engine", Engine.get_version_info().string, "https://godotengine.org/",
 			"MIT", "Massachusetts Institute of Technology",
 			Engine.get_license_text())
 	_create_software_tree_item(godot_info)


### PR DESCRIPTION
Task: BUG: In "About MSEP -> Thirdparty" dialog, GodotEngine version still says 4.2.3-(custom) instead of 4.4.1-(custom)