### PR TITLE
Several fixes to Selection Preview

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/workspace_camera/workspace_camera.tscn
+++ b/godot_project/editor/controls/editor_viewport_container/workspace_camera/workspace_camera.tscn
@@ -14,6 +14,7 @@ far = 999999.0
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="Camera3D"]
 transform = Transform3D(0.0871558, 0.704416, -0.704416, 0, 0.707107, 0.707107, 0.996195, -0.0616285, 0.0616285, 11.2996, 0, 0)
+layers = 5
 light_energy = 1.5
 directional_shadow_mode = 0
 directional_shadow_split_1 = 0.2

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -74,8 +74,8 @@ func initialize(in_workspace_context: WorkspaceContext) -> void:
 	workspace.representation_settings.changed.connect(_on_workspace_settings_changed)
 	workspace.representation_settings.theme_changed.connect(_on_representation_settings_theme_changed.bind(weakref(workspace)))
 	workspace.representation_settings.color_schema_changed.connect(_on_representation_settings_color_schema_changed)
-	apply_theme(workspace.representation_settings.get_theme())
 	_selection_preview.init(_workspace_context)
+	apply_theme(workspace.representation_settings.get_theme())
 
 
 ## Returns whether it is initialized or not
@@ -347,6 +347,7 @@ func apply_theme(in_theme: Theme3D) -> void:
 	if _theme_in_use == in_theme:
 		_refresh_viewport_background()
 		_refresh_outline_color()
+		_selection_preview.refresh()
 		return
 	_theme_in_use = in_theme
 	_environment = in_theme.create_environment()
@@ -361,6 +362,7 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_ballstick_bond_preview.apply_theme(in_theme)
 	_refresh_viewport_background()
 	_refresh_outline_color()
+	_selection_preview.refresh()
 
 
 func _get_renderer_for_atomic_structure(in_structure: AtomicStructure) -> AtomicStructureRenderer:
@@ -878,6 +880,7 @@ func _on_representation_settings_color_schema_changed(in_new_color_schema: Perio
 	for structure_renderer: Node in structure_renderers:
 		if structure_renderer is AtomicStructureRenderer:
 			structure_renderer.rebuild()
+	_selection_preview.refresh()
 
 
 func create_state_snapshot() -> Dictionary:


### PR DESCRIPTION
- Make lighting affect Selection Preview
- Refresh Selection Preview when Workspace theme is changed
- Refresh Selection Preview when Workspace ColorSchema is changed

Task: BUG - Selection preview is no longer lit
(the rest of the bugs fixed here was not reported, was stuff i realized on the fly)