### PR TITLE
Fix incorrect atom suggestions and bond order

### DIFF
--- a/godot_project/editor/rendering/atom_autopose_preview/atom_autopose_preview.gd
+++ b/godot_project/editor/rendering/atom_autopose_preview/atom_autopose_preview.gd
@@ -4,6 +4,7 @@ class_name AtomAutoposePreview extends Control
 class AtomCandidate:
 	var structrure_id: int
 	var atom_ids: PackedInt32Array
+	var atom_free_valence: PackedInt32Array
 	var atom_position: Vector3
 	var total_free_valence: int
 	var pos_2d_cache: Vector2 = Vector2.ONE * -15


### PR DESCRIPTION
Fix: BUG - Suggestion can suggest connecting 1 hydrogen to 2 different atoms

The `total_free_valences` was also wrong in the case of merged candidates, causing issues later when the final bond order was calculated.