### PR TITLE
Invalidate the cached atom grid on history changed

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -443,6 +443,7 @@ func _on_representation_settings_changed() -> void:
 
 
 func _on_workspace_context_history_changed() -> void:
+	_atom_grid = null
 	_candidates_dirty = true
 	_update_candidates_if_needed()
 


### PR DESCRIPTION
Fixes: BUG - Undo removes the last clicked atom candidate

The `_atom_grid` is used to check if an atom candidate collides with existing atoms. This grid is cached and the cache is invalidated when any structure changes.

However, during undo redo, the `structure_contents_changed` signal is not emitted, and `_atom_grid` is not updated. So we're evaluating the new candidates against the old atoms, including the ones that doesn't exist anymore. 