### PR TITLE
Fix the "Show hidden" shortcut not working when atom suggestions are enabled

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/viewport_input/viewport_input.gd
+++ b/godot_project/editor/controls/editor_viewport_container/viewport_input/viewport_input.gd
@@ -17,8 +17,10 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		_input_handlers.clear()
 
+
 func has_exclusive_input_consumer() -> bool:
 	return is_instance_valid(_exclusive_input_consumer) and _exclusive_input_consumer.is_exclusive_input_consumer()
+
 
 func forward_viewport_input(in_event: InputEvent, in_workspace_editor_viewport: WorkspaceEditorViewport,
 			in_structure_context: StructureContext) -> void:
@@ -46,7 +48,8 @@ func _on_exclusive_input_consumer(in_event: InputEvent, in_workspace_editor_view
 	if is_instance_valid(_exclusive_input_consumer):
 		if _exclusive_input_consumer.is_exclusive_input_consumer():
 			if _exclusive_input_consumer.forward_input(in_event, camera_3d, in_structure_context):
-				in_workspace_editor_viewport.set_input_as_handled()
+				if not _exclusive_input_consumer.forward_inputs_when_exclusive_consumer():
+					in_workspace_editor_viewport.set_input_as_handled()
 			if not _exclusive_input_consumer.is_exclusive_input_consumer():
 				# Input handler is no longer interested in consuming inputs
 				_notify_handlers_about_exclusive_input_ended_cycle()

--- a/godot_project/editor/controls/menu_bar/msep_popup_menu.gd
+++ b/godot_project/editor/controls/menu_bar/msep_popup_menu.gd
@@ -6,7 +6,7 @@ func _init() -> void:
 	MolecularEditorContext.workspace_activated.connect(_on_workspace_activated)
 	about_to_popup.connect(_on_about_to_popup)
 	popup_hide.connect(_on_popup_hide)
-	id_pressed.connect(_on_forward_id_pressed)
+	id_pressed.connect(_on_id_pressed)
 	InitialInfoScreen.visibility_changed.connect(_on_full_screen_popupup_visibility_changed)
 	BusyIndicator.visibility_changed.connect(_on_full_screen_popupup_visibility_changed)
 
@@ -62,16 +62,6 @@ func _set_all_is_disabled(out_menu:PopupMenu, in_disable: float) -> void:
 
 func _update_menu() -> void:
 	assert(false, "Implement this function in your specialized class")
-
-
-func _on_forward_id_pressed(in_id: int) -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context() as WorkspaceContext
-	if is_instance_valid(workspace_context):
-		if workspace_context.get_editor_viewport().has_exclusive_input_consumer():
-			# block menu activations (assumed from keyboard shortcuts)
-			# when viewport has an exclusive consumer
-			return
-	_on_id_pressed(in_id)
 
 
 func _on_id_pressed(_in_id: int) -> void:

--- a/godot_project/editor/input_handlers/input_handler_base.gd
+++ b/godot_project/editor/input_handlers/input_handler_base.gd
@@ -46,6 +46,12 @@ func is_exclusive_input_consumer() -> bool:
 	return false
 
 
+## When true, the shortcuts defined in the MSEP popup menu will be actived even if this handler
+## is an exclusive input consumer.
+func forward_inputs_when_exclusive_consumer() -> bool:
+	return false
+
+
 ## Can be used to react to the fact other InputHandlerBase has started to exclusively consuming inputs
 ## Usually used to clean up internal state and prepare for fresh input sequence
 func handle_inputs_end() -> void:

--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -146,6 +146,10 @@ func is_exclusive_input_consumer() -> bool:
 	return _hovered_candidate != null
 
 
+func forward_inputs_when_exclusive_consumer() -> bool:
+	return true
+
+
 func set_preview_position(_in_position: Vector3) -> void:
 	_update_candidates_if_needed()
 


### PR DESCRIPTION
Fixes: BUG: ALT+H shortcut doesn't work to unhide objects

This adds an option to let exclusive input handlers to pass the input up to the editor viewport. (Other inputs handlers are still blocked from processing this input) 
