### PR TITLE
Fix the msep menu not closing when pressing the menu button

### DIFF
--- a/godot_project/editor/controls/workspace_view/controls/toggle_visual_menu_button.tscn
+++ b/godot_project/editor/controls/workspace_view/controls/toggle_visual_menu_button.tscn
@@ -10,6 +10,7 @@ offset_top = 33.0
 offset_right = 74.0
 offset_bottom = 81.0
 focus_mode = 0
+action_mode = 0
 icon = ExtResource("1_3kdb4")
 flat = true
 icon_alignment = 1


### PR DESCRIPTION
Fixes: BUG - Pressing the hamburger menu doesn't close the menu if it's already open

This is the same issue as #164 