### PR TITLE
Add a visual representation of simulation boundaries when area is constrained

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
@@ -4,6 +4,7 @@ class_name BondsSettings extends DynamicContextControl
 var _bonds_toggle: CheckButton
 var _labels_toggle: CheckButton
 var _hydrogens_toggle: CheckButton
+var _simulation_boundaries_toggle: CheckButton
 
 var _workspace_context: WorkspaceContext = null
 
@@ -13,7 +14,7 @@ func _notification(what: int) -> void:
 		_bonds_toggle = $Settings/PanelContainer/VBoxContainer/ShowBondsToggle
 		_labels_toggle = $Settings/PanelContainer/VBoxContainer/ShowLabelsToggle
 		_hydrogens_toggle = $Settings/PanelContainer/VBoxContainer/ShowHydrogensToggle
-
+		_simulation_boundaries_toggle = $Settings/PanelContainer/VBoxContainer/ShowSimulationBoundariesToggle
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	_workspace_context = in_workspace_context
@@ -31,6 +32,7 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	_bonds_toggle.set_pressed_no_signal(_workspace_context.are_bonds_visualised())
 	_labels_toggle.set_pressed_no_signal(_workspace_context.are_atom_labels_visualised())
 	_hydrogens_toggle.set_pressed_no_signal(_workspace_context.are_hydrogens_visualized())
+	_simulation_boundaries_toggle.set_pressed_no_signal(settings.get_display_simulation_boundaries())
 	
 	return true
 
@@ -87,3 +89,7 @@ func _on_show_hydrogens_toggle_toggled(button_pressed: bool) -> void:
 
 func _on_show_potential_atoms_toggle_toggled(button_pressed: bool) -> void:
 	_workspace_context.workspace.representation_settings.set_display_auto_posing(button_pressed)
+
+
+func _on_show_simulation_boundaries_toggle_toggled(button_pressed: bool) -> void:
+	_workspace_context.workspace.representation_settings.set_display_simulation_boundaries(button_pressed)

--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
@@ -46,7 +46,13 @@ layout_mode = 2
 button_pressed = true
 text = "Show Potential Atom Positions"
 
+[node name="ShowSimulationBoundariesToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer"]
+layout_mode = 2
+button_pressed = true
+text = "Show Simulation Boundaries"
+
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowBondsToggle" to="." method="_on_show_bonds_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowLabelsToggle" to="." method="_on_show_labels_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowHydrogensToggle" to="." method="_on_show_hydrogens_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowPotentialAtomsToggle" to="." method="_on_show_potential_atoms_toggle_toggled"]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowSimulationBoundariesToggle" to="." method="_on_show_simulation_boundaries_toggle_toggled"]

--- a/godot_project/editor/rendering/rendering.tscn
+++ b/godot_project/editor/rendering/rendering.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://cd8ybm2fs1ox"]
+[gd_scene load_steps=16 format=3 uid="uid://cd8ybm2fs1ox"]
 
 [ext_resource type="Script" uid="uid://c27b08chswrkq" path="res://editor/rendering/rendering.gd" id="1_vymcv"]
 [ext_resource type="PackedScene" uid="uid://cyy5lagn5jes7" path="res://editor/rendering/world_environment.tscn" id="2_vyad3"]
@@ -12,6 +12,7 @@
 [ext_resource type="PackedScene" uid="uid://4hk2achugjb2" path="res://editor/rendering/virtual_anchor_and_spring_renderer/virtual_anchor_preview.tscn" id="9_hs37s"]
 [ext_resource type="PackedScene" uid="uid://dmf7a8rad2ixj" path="res://editor/rendering/spring_preview/spring_preview.tscn" id="10_cxht2"]
 [ext_resource type="PackedScene" uid="uid://d38yfchnnwvt" path="res://editor/rendering/selection_preview/selection_preview.tscn" id="12_n4gg0"]
+[ext_resource type="PackedScene" uid="uid://bamvuoulrst7s" path="res://editor/rendering/simulation_boundaries_representation/simulation_boundaries_representation.tscn" id="13_nh7yk"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_17w4n"]
 resource_local_to_scene = true
@@ -22,6 +23,9 @@ shading_mode = 0
 albedo_color = Color(0.168627, 0.172549, 0.580392, 1)
 albedo_texture = ExtResource("9_ey5dj")
 uv1_offset = Vector3(1, 0, 0)
+
+[sub_resource type="BoxMesh" id="BoxMesh_bgi63"]
+resource_local_to_scene = true
 
 [node name="Rendering" type="Node" groups=["Rendering"]]
 script = ExtResource("1_vymcv")
@@ -78,6 +82,10 @@ modulate = Color(0.168627, 0.172549, 0.580392, 1)
 [node name="SpringPreview" parent="." instance=ExtResource("10_cxht2")]
 
 [node name="SelectionPreview" parent="." instance=ExtResource("12_n4gg0")]
+
+[node name="SimulationBoundariesRepresentation" parent="." instance=ExtResource("13_nh7yk")]
+layers = 3
+mesh = SubResource("BoxMesh_bgi63")
 
 [editable path="VirtualMotorPreview"]
 [editable path="VirtualMotorPreview/motor3D_Gears00"]

--- a/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_material.tres
+++ b/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_material.tres
@@ -1,0 +1,8 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://g7untydkwewi"]
+
+[ext_resource type="Shader" uid="uid://ddo3tdkn3vd8l" path="res://editor/rendering/simulation_boundaries_representation/simulation_boundaries_shader.gdshader" id="1_yuh64"]
+
+[resource]
+render_priority = 0
+shader = ExtResource("1_yuh64")
+shader_parameter/wire_width = 0.8

--- a/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_representation.gd
+++ b/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_representation.gd
@@ -1,0 +1,9 @@
+class_name SimulationBoundariesRepresentation extends MeshInstance3D
+
+func _init() -> void:
+	hide()
+
+func setup(in_aabb: AABB) -> void:
+	var box: BoxMesh = mesh as BoxMesh
+	box.size = in_aabb.size
+	global_position = in_aabb.get_center()

--- a/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_representation.gd.uid
+++ b/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_representation.gd.uid
@@ -1,0 +1,1 @@
+uid://0xy4emqd1hf8

--- a/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_representation.tscn
+++ b/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_representation.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=4 format=3 uid="uid://bamvuoulrst7s"]
+
+[ext_resource type="Script" uid="uid://0xy4emqd1hf8" path="res://editor/rendering/simulation_boundaries_representation/simulation_boundaries_representation.gd" id="1_lmwa1"]
+[ext_resource type="Material" uid="uid://g7untydkwewi" path="res://editor/rendering/simulation_boundaries_representation/simulation_boundaries_material.tres" id="2_qvg88"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_0aovh"]
+resource_local_to_scene = true
+
+[node name="SimulationBoundariesRepresentation" type="MeshInstance3D"]
+material_override = ExtResource("2_qvg88")
+mesh = SubResource("BoxMesh_0aovh")
+script = ExtResource("1_lmwa1")

--- a/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_shader.gdshader
+++ b/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_shader.gdshader
@@ -1,0 +1,42 @@
+shader_type spatial;
+render_mode cull_back, unshaded;
+
+#include "res://editor/rendering/atomic_structure_renderer/representation/float_operations.gdshaderinc"
+#include "res://editor/rendering/atomic_structure_renderer/representation/constants.gdshaderinc"
+#include "res://editor/rendering/atomic_structure_renderer/representation/instance_state.gdshaderinc"
+
+// Wireframe shader with line thickness support.
+//
+// This shader only works on flat shaded meshes. The VERTEX_ID from the vertex()
+// function is not reliable with smooth meshes.
+//
+// Modified from https://godotshaders.com/shader/wireframe-shader-godot-4-0/
+
+uniform float wire_width : hint_range(0.0, 10.0) = 0.8;
+
+global uniform vec4 simulation_boundaries_wireframe_color;
+
+varying vec3 barys;
+
+
+void vertex() {
+	int index = VERTEX_ID % 3;
+	barys = vec3(0.0);
+	barys[index] = 1.0;
+	
+}
+
+
+void fragment() {
+	vec4 color = simulation_boundaries_wireframe_color;
+	ALBEDO = color.rgb;
+	
+	// For anti-aliasing purposes
+	float epsilon = fwidth(UV.x * UV.y);
+	
+	// Calculate which fragment is close enough to an edge and hide everything else
+	vec3 deltas = fwidth(barys);
+	vec3 barys_s = smoothstep(deltas * wire_width - epsilon, deltas * wire_width + epsilon, barys);
+	float is_wireframe = min(barys_s.x, min(barys_s.y, barys_s.z));
+	ALPHA = color.a * (1.0 - is_wireframe);
+}

--- a/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_shader.gdshader.uid
+++ b/godot_project/editor/rendering/simulation_boundaries_representation/simulation_boundaries_shader.gdshader.uid
@@ -1,0 +1,1 @@
+uid://ddo3tdkn3vd8l

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -387,3 +387,7 @@ is_bond_influence_highlight_enabled={
 "type": "float",
 "value": 0.0
 }
+simulation_boundaries_wireframe_color={
+"type": "color",
+"value": Color(0.0854945, 0.323129, 0.999996, 1)
+}

--- a/godot_project/project_workspace/structs/representation_settings.gd
+++ b/godot_project/project_workspace/structs/representation_settings.gd
@@ -14,6 +14,7 @@ const LABELS_VISIBLE_BY_DEFAULT = false
 const HYDROGENS_VISIBLE_BY_DEFAULT = true
 const BONDS_VISIBLE_BY_DEFAULT = true
 const ATOMS_AUTO_POSING_VISIBLE_BY_DEFAULT = true
+const SIMULATION_BOUNDARIES_VISIBLE_BY_DEFAULT = true
 
 enum UserAtomSizeSource {
 	PHYSICAL_RADIUS,
@@ -40,6 +41,7 @@ enum UserAtomSizeSource {
 
 @export var _display_auto_posing: bool = ATOMS_AUTO_POSING_VISIBLE_BY_DEFAULT
 
+@export var _display_simulation_boundaries: bool = SIMULATION_BOUNDARIES_VISIBLE_BY_DEFAULT
 
 @export var _custom_selection_outline_color_enabled: bool = false
 
@@ -115,6 +117,15 @@ func set_display_auto_posing(new_display_auto_posing: bool) -> void:
 
 func get_display_auto_posing() -> bool:
 	return _display_auto_posing
+
+
+func set_display_simulation_boundaries(new_display_simulation_boundaries: bool) -> void:
+	_display_simulation_boundaries = new_display_simulation_boundaries
+	emit_changed()
+
+
+func get_display_simulation_boundaries() -> bool:
+	return _display_simulation_boundaries
 
 
 func set_bond_visibility_and_notify(new_bond_visibility: bool) -> void:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -491,6 +491,20 @@ func start_simulating(in_simulation_data: SimulationData) -> void:
 	_simulation = in_simulation_data
 	simulation_started.emit()
 
+
+func get_simulation_boundaries() -> AABB:
+	assert(is_simulating(), "There's not an active simulation")
+	var aabb: AABB = _simulation.original_payload.calculated_aabb
+	if workspace != null:
+		var grow_factor: float = \
+			workspace.simulation_settings_advanced_constrained_simulation_box_size_percentage / 100.0
+		var grown_aabb := AABB()
+		grown_aabb.size = aabb.size * grow_factor
+		grown_aabb.position = aabb.get_center() - (grown_aabb.size * 0.5)
+		aabb = grown_aabb
+	return aabb
+
+
 # Plaback means the simulation is currently advancing every frame, this operation is very intensive
 # so some of the functionality is disabled during the playback and only refreshed after playback ends
 func set_simulation_playback_running(in_is_playback_running: bool) -> void:


### PR DESCRIPTION
- Also added a check button to Visibility section in WorkspaceSettings to toggle it on and off

Task: Show Simulation Bounding Cube Option