### PR TITLE
Change the initial_info_screen panel to match the about_msep panel colors

### DIFF
--- a/godot_project/autoloads/initial_info_screen/initial_info_screen.tscn
+++ b/godot_project/autoloads/initial_info_screen/initial_info_screen.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=8 format=3 uid="uid://dxr8wwnkafu0b"]
+[gd_scene load_steps=7 format=3 uid="uid://dxr8wwnkafu0b"]
 
 [ext_resource type="Script" uid="uid://rox2byn31qs3" path="res://autoloads/initial_info_screen/initial_info_screen.gd" id="1_1nwna"]
 [ext_resource type="Shader" uid="uid://cehfsfju1x4m5" path="res://autoloads/initial_info_screen/initial_info_screen.gdshader" id="2_k0y41"]
-[ext_resource type="Theme" uid="uid://d3fnr4sbrd6ik" path="res://theme/theme.tres" id="3_lpwn0"]
 [ext_resource type="Texture2D" uid="uid://bm36o6fo1evuo" path="res://logo.png" id="4_4ravn"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_g7c2g"]
@@ -44,7 +43,6 @@ grow_vertical = 2
 
 [node name="Label" type="Label" parent="VBoxContainer"]
 layout_mode = 2
-theme = ExtResource("3_lpwn0")
 theme_type_variation = &"HeaderLarge"
 theme_override_colors/font_shadow_color = Color(0.176876, 0.0964739, 0.336584, 1)
 theme_override_constants/shadow_offset_x = 0
@@ -82,7 +80,7 @@ stretch_mode = 6
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
-theme_type_variation = &"CollapsableCategoryPanel"
+theme_type_variation = &"PanelContainerCrystal"
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/PanelContainer"]
 layout_mode = 2

--- a/godot_project/theme/theme.tres
+++ b/godot_project/theme/theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=89 format=3 uid="uid://d3fnr4sbrd6ik"]
+[gd_resource type="Theme" load_steps=90 format=3 uid="uid://d3fnr4sbrd6ik"]
 
 [ext_resource type="FontFile" uid="uid://b3jkav4yxw06w" path="res://theme/Gidole-Regular.ttf" id="1_8indu"]
 [ext_resource type="Texture2D" uid="uid://bh1ju2ymvv1co" path="res://theme/icons/icon_on.svg" id="1_n28s0"]
@@ -339,6 +339,17 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6l1ye"]
+content_margin_left = 10.0
+content_margin_top = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 10.0
+bg_color = Color(0.5, 0.5, 0.5, 0.470588)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_r6qfk"]
 content_margin_left = 20.0
@@ -996,6 +1007,8 @@ OptionButton/styles/pressed = SubResource("StyleBoxFlat_cvnwt")
 OptionButton/styles/pressed_mirrored = SubResource("StyleBoxFlat_4y3vi")
 Panel/styles/panel = SubResource("StyleBoxFlat_b5xkc")
 PanelContainer/styles/panel = SubResource("StyleBoxFlat_udr83")
+PanelContainerCrystal/base_type = &"PanelContainer"
+PanelContainerCrystal/styles/panel = SubResource("StyleBoxFlat_6l1ye")
 PopupMenu/colors/font_disabled_color = Color(0.733333, 0.729412, 0.729412, 0.8)
 RoundedWindow/base_type = &"AcceptDialog"
 RoundedWindow/styles/panel = SubResource("StyleBoxFlat_r6qfk")


### PR DESCRIPTION
Follow-up to #193 

Note: Opening this scene in the editor makes it crash, but if you edit the tscn file manually and remove this line under the `ButtonClose` section: 

`theme_type_variation = &"CrystalButton"`

then it works. No issues when running the actual project though.