### PR TITLE
Add support to set Particle Emitter's Molecule Template from selected atoms and bonds

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/particle_emitter_parameters_editor.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/particle_emitter_parameters_editor.gd
@@ -244,6 +244,7 @@ func _on_load_molecule_from_selection_button_pressed() -> void:
 				if atom1 in atoms and atom2 in atoms:
 					var order: int = bond_data.z
 					template.add_bond(atom_map[atom1], atom_map[atom2], order)
+		_center_template_on_origin(template)
 		template.end_edit()
 		template.set_structure_name("Template")
 		template.set_representation_settings(workspace_context.workspace.representation_settings)
@@ -289,8 +290,23 @@ func _on_small_molecules_picker_molecule_selected(in_path: String) -> void:
 	var structure: NanoStructure = await WorkspaceUtils.get_nano_structure_from_file(workspace_context, absolute_path, false, false, false)
 	structure.set_structure_name(in_path.get_file().get_basename())
 	structure.set_representation_settings(workspace_context.workspace.representation_settings)
+	structure.start_edit()
+	_center_template_on_origin(structure)
+	structure.end_edit()
 	_parameters.set_molecule_template(structure)
 	_take_snapshot_if_configured(tr(&"Molecule Template"))
+
+
+func _center_template_on_origin(out_template: AtomicStructure) -> void:
+	var center: Vector3 = out_template.get_aabb().get_center()
+	if center.is_equal_approx(Vector3.ZERO):
+		return
+	var atoms: PackedInt32Array = out_template.get_valid_atoms()
+	var positions: PackedVector3Array = []
+	for atom_id: int in atoms:
+		var new_pos: Vector3 = out_template.atom_get_position(atom_id) - center
+		positions.push_back(new_pos)
+	out_template.atoms_set_positions(atoms, positions)
 
 
 func _put_small_molecules_picker_avobe() -> void:

--- a/godot_project/project_workspace/structs/nano_particle_emitter_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_particle_emitter_parameters.gd
@@ -22,8 +22,8 @@ enum LimitType {
 func set_molecule_template(out_molecule: AtomicStructure) -> void:
 	assert(out_molecule == null or out_molecule.int_guid == Workspace.INVALID_STRUCTURE_ID,
 		"Should not assign a structure directly from workspace, create a duplicate instead")
-	if out_molecule != null and not out_molecule.get_aabb().get_center().is_equal_approx(Vector3.ZERO):
-		push_warning("Molecule Template is not roughtly centered in the origin")
+	assert(out_molecule == null or out_molecule.get_aabb().get_center().is_equal_approx(Vector3.ZERO),
+		"Molecule Template is not roughtly centered in the origin")
 	_molecule = out_molecule
 	emit_changed()
 

--- a/godot_project/project_workspace/structs/nano_particle_emitter_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_particle_emitter_parameters.gd
@@ -20,9 +20,9 @@ enum LimitType {
 
 
 func set_molecule_template(out_molecule: AtomicStructure) -> void:
-	assert(out_molecule.int_guid == Workspace.INVALID_STRUCTURE_ID,
+	assert(out_molecule == null or out_molecule.int_guid == Workspace.INVALID_STRUCTURE_ID,
 		"Should not assign a structure directly from workspace, create a duplicate instead")
-	if not out_molecule.get_aabb().get_center().is_equal_approx(Vector3.ZERO):
+	if out_molecule != null and not out_molecule.get_aabb().get_center().is_equal_approx(Vector3.ZERO):
 		push_warning("Molecule Template is not roughtly centered in the origin")
 	_molecule = out_molecule
 	emit_changed()


### PR DESCRIPTION
- Also allows to clear the template when nothing is selected
- When assigning a molecule template to ParticleEmitter ensure is centered in the origin of coordinates
DEPENDS ON
#200
#203
#204
#205
#206
#207
Task: Molecular Emitter