### PR TITLE
Fix missing atom candidate when adding hydrogens

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -3,7 +3,7 @@ extends InputHandlerCreateObjectBase
 
 const MAX_MERGE_DISTANCE: float = 0.06
 const MAX_ATOMS_FOR_AUTO_POSING: int = 50
-const MIN_DISTANCE_TO_ATOMS: float = 0.14
+const MIN_DISTANCE_TO_ATOMS: float = 0.135
 const AtomCandidate = AtomAutoposePreview.AtomCandidate
 
 


### PR DESCRIPTION
Fix: BUG - Recommends 1 to few atoms when hydrogens are selected

The minimum distance between candidates and existing atoms happens to be exactly the default hydrogen bond length. Because of floating point precision, it would sometimes consider a valid candidate to be too close from its source atom, and be removed.
This PR lower the minimum distance slightly to avoid this issue.