### PR TITLE
Fixes to particle emitter

### DIFF
--- a/godot_project/autoloads/openmm/openmm_payload.gd
+++ b/godot_project/autoloads/openmm/openmm_payload.gd
@@ -289,16 +289,12 @@ func add_emitter(in_emitter: NanoParticleEmitter) -> void:
 				&"_limit_type",
 				&"_stop_emitting_after_count",
 				&"_stop_emitting_after_nanoseconds",
-				&"_instance_rate_time_in_nanoseconds"
 			]:
 			continue # lets give these ones special treatment
 		var value: Variant = in_emitter.get_parameters().get(prop_info.name)
 		emitter_dict.parameters[prop_info.name] = value
 	# let's simplify the code in openmm side, calculating a time limit in here
 	emitter_dict.parameters[&"total_instance_count"] = in_emitter.calculate_total_molecule_instance_count()
-	emitter_dict.parameters[&"_instance_rate_time_in_femtoseconds"] = TimeSpanPicker.unit_to_femtoseconds(
-		in_emitter.get_parameters().get_instance_rate_time_in_nanoseconds(), TimeSpanPicker.Unit.NANOSECOND
-	)
 	var instance_atoms_ids: Array[PackedInt32Array] = in_emitter.get_instance_atoms_ids()
 	var payload_atom_ids: Array[PackedInt32Array] = []
 	# Before sending atoms ids to openmm server we need to remap them to the payload atom ids

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
@@ -149,15 +149,15 @@ func _on_create_from_small_molecules_pressed() -> void:
 	var up_space := int(_create_from_small_molecules.global_position.y)
 	var down_space := int(get_tree().root.size.y - _create_from_small_molecules.get_global_rect().end.y)
 	if down_space >= _small_molecules_picker.size.y:
-		_put_small_molecules_picker_bellow()
+		_put_small_molecules_picker_below()
 	elif up_space >= _small_molecules_picker.size.y:
-		_put_small_molecules_picker_avobe()
+		_put_small_molecules_picker_above()
 	elif up_space > down_space:
 		_small_molecules_picker.size.y = up_space
-		_put_small_molecules_picker_avobe()
+		_put_small_molecules_picker_above()
 	else:
 		_small_molecules_picker.size.y = down_space
-		_put_small_molecules_picker_bellow()
+		_put_small_molecules_picker_below()
 
 	_small_molecules_picker.popup()
 
@@ -199,12 +199,12 @@ func _center_template_on_origin(out_template: AtomicStructure) -> void:
 	out_template.atoms_set_positions(atoms, positions)
 
 
-func _put_small_molecules_picker_avobe() -> void:
+func _put_small_molecules_picker_above() -> void:
 	_small_molecules_picker.position.y = \
 		int(_create_from_small_molecules.global_position.y - _small_molecules_picker.size.y)
 
 
-func _put_small_molecules_picker_bellow() -> void:
+func _put_small_molecules_picker_below() -> void:
 	_small_molecules_picker.position.y = \
 		int(_create_from_small_molecules.get_global_rect().end.y)
 

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -286,7 +286,7 @@ func _update_controls() -> void:
 func _has_valid_atoms() -> bool:
 	if not is_instance_valid(_workspace_context):
 		return false
-	return _workspace_context.has_valid_atoms()
+	return _workspace_context.has_valid_atoms() or _workspace_context.has_valid_particle_emitters()
 
 
 func _is_simulation_complete() -> bool:

--- a/godot_project/project_workspace/structs/nano_particle_emitter.gd
+++ b/godot_project/project_workspace/structs/nano_particle_emitter.gd
@@ -38,9 +38,9 @@ func calculate_total_molecule_instance_count() -> int:
 			emit_time = configured_time_femtoseconds - _parameters.get_initial_delay_in_nanoseconds()
 		elif _parameters.get_limit_type() == NanoParticleEmitterParameters.LimitType.NEVER:
 			emit_time = simulation_time_femtoseconds - _parameters.get_initial_delay_in_nanoseconds()
-		var instance_rante_femtoseconds: float = TimeSpanPicker.unit_to_femtoseconds(
+		var instance_rate_femtoseconds: float = TimeSpanPicker.unit_to_femtoseconds(
 				_parameters.get_instance_rate_time_in_nanoseconds(), TimeSpanPicker.Unit.NANOSECOND)
-		var instantation_count : int = floori(emit_time / instance_rante_femtoseconds)
+		var instantation_count : int = floori(emit_time / instance_rate_femtoseconds)
 		var total_instance_count: int = instantation_count * _parameters.get_molecules_per_instance()
 		return total_instance_count
 

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1186,6 +1186,17 @@ func has_motors() -> bool:
 	return false
 
 
+func has_valid_particle_emitters() -> bool:
+	for context: StructureContext in _structure_contexts.values():
+		if context.nano_structure is NanoParticleEmitter:
+			var emitter := context.nano_structure as NanoParticleEmitter
+			var parameters: NanoParticleEmitterParameters = emitter.get_parameters()
+			var template: AtomicStructure = null if parameters == null else parameters.get_molecule_template()
+			var atoms_count: int = 0 if template == null else template.get_valid_atoms_count()
+			if atoms_count > 0:
+				return true
+	return false
+
 func get_particle_emitters() -> Array[NanoParticleEmitter]:
 	var emitters: Array[NanoParticleEmitter] = []
 	for context: StructureContext in _structure_contexts.values():


### PR DESCRIPTION
- Fixed a copy paste mistake actually causing a crash when trying to simulate
- Fixed several typos
- Is now possible to start a simulation with only particle emitters in the project, no other atoms needed

Task: Molecular Emitter