### PR TITLE
Add support for copy & paste emitters

### DIFF
--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -47,6 +47,8 @@ func copy(in_workspace_context: WorkspaceContext) -> void:
 				_copy_motor(structure_context, nano_structure, new_content)
 			&"AnchorPoint":
 				_copy_anchor(structure_context, nano_structure, new_content)
+			&"ParticleEmitter":
+				_copy_particle_emitter(structure_context, nano_structure, new_content)
 			_:
 				push_warning("Nano structure type not implemented for copy")
 	var root_group_id: int = -1
@@ -231,16 +233,23 @@ func _copy_reference_shape(
 
 func _copy_motor(
 	in_structure_context: StructureContext,
-	in_shape: NanoVirtualMotor,
+	in_motor: NanoVirtualMotor,
 	out_content: Array[Dictionary]) -> void:
-	_copy_structure(in_structure_context, in_shape, out_content)
+	_copy_structure(in_structure_context, in_motor, out_content)
 
 
 func _copy_anchor(
 	in_structure_context: StructureContext,
-	in_shape: NanoVirtualAnchor,
+	in_anchor: NanoVirtualAnchor,
 	out_content: Array[Dictionary]) -> void:
-	_copy_structure(in_structure_context, in_shape, out_content)
+	_copy_structure(in_structure_context, in_anchor, out_content)
+
+
+func _copy_particle_emitter(
+	in_structure_context: StructureContext,
+	in_emitter: NanoParticleEmitter,
+	out_content: Array[Dictionary]) -> void:
+	_copy_structure(in_structure_context, in_emitter, out_content)
 
 
 func cut(out_workspace_context: WorkspaceContext) -> void:


### PR DESCRIPTION
Turns out the emitters don't do anything out of the ordinary and can just reuse the existing code paths for copy paste.