### PR TITLE
Set mass of disabled particles (from particle emitter) to 0

### DIFF
--- a/godot_project/python/scripts/openmm_server.py
+++ b/godot_project/python/scripts/openmm_server.py
@@ -772,6 +772,7 @@ class ParticleEmitter:
 				atom_id: int = payload_to_openff_atom[payload_atom_id]
 				instance_openmm_atoms.append(atom_id)
 				mass = simulation.system.getParticleMass(atom_id)
+				simulation.system.setParticleMass(atom_id, 0)
 				parameters = out_nonbonded_force.getParticleParameters(atom_id)
 				position = positions[atom_id]
 				velocity = initial_velocities[atom_id]


### PR DESCRIPTION
i noticed i had forgotten this crucial step of having particles disabled, is important to ensure invisible particles dont affect visible particles

Task: Molecular Emitter