### PR TITLE
Make user aware of the necesity of have escape velocity for particle emitters

### DIFF
--- a/godot_project/autoloads/openmm/openmm_payload.gd
+++ b/godot_project/autoloads/openmm/openmm_payload.gd
@@ -294,7 +294,7 @@ func add_emitter(in_emitter: NanoParticleEmitter) -> void:
 		var value: Variant = in_emitter.get_parameters().get(prop_info.name)
 		emitter_dict.parameters[prop_info.name] = value
 	# let's simplify the code in openmm side, calculating a time limit in here
-	emitter_dict.parameters[&"total_instance_count"] = in_emitter.calculate_total_molecule_instance_count()
+	emitter_dict.parameters[&"total_instance_count"] = in_emitter.get_total_molecule_instance_count()
 	var instance_atoms_ids: Array[PackedInt32Array] = in_emitter.get_instance_atoms_ids()
 	var payload_atom_ids: Array[PackedInt32Array] = []
 	# Before sending atoms ids to openmm server we need to remap them to the payload atom ids

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.tscn
@@ -27,6 +27,7 @@ metadata/_custom_type_script = "uid://3hjuxktmfb16"
 [node name="VBoxContainer" type="VBoxContainer" parent="ParticleEmitterParametersEditor"]
 layout_mode = 2
 size_flags_horizontal = 4
+theme_override_constants/separation = 6
 
 [node name="CreateFromSelectionButton" type="Button" parent="ParticleEmitterParametersEditor/VBoxContainer"]
 unique_name_in_owner = true
@@ -39,3 +40,14 @@ unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"CrystalButton"
 text = "Create From Small Molecules"
+
+[node name="EscapeVelocityWarningLabel" type="RichTextLabel" parent="ParticleEmitterParametersEditor"]
+unique_name_in_owner = true
+layout_mode = 2
+bbcode_enabled = true
+text = "[center]ℹ Initial speed may be not large enough to leave emission space without crowding the space.\\nThis could lead to a simulation Failure.\\nYou may want to increase the [b]Initial Speed[/b] or [b][/b][/center]"
+fit_content = true
+script = ExtResource("3_vh652")
+message = &"Initial speed may be not large enough to leave emission space without crowding the space.\\nThis could lead to a simulation Failure.\\nYou may want to increase the [b]Initial Speed[/b] or [b][/b]"
+effect = "none"
+metadata/_custom_type_script = "uid://3hjuxktmfb16"

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_particle_emitter_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_particle_emitter_panel.gd
@@ -3,15 +3,20 @@ extends DynamicContextControl
 
 var _select_one_info_label: InfoLabel
 var _particle_emitter_parameters_editor: ParticleEmitterParametersEditor
+var _escape_velocity_warning_label: InfoLabel
 
+var _workspace_context: WorkspaceContext
+var _tracked_emitter: NanoParticleEmitter
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_SCENE_INSTANTIATED:
 		_select_one_info_label = %SelectOneInfoLabel as InfoLabel
 		_particle_emitter_parameters_editor = %ParticleEmitterParametersEditor as ParticleEmitterParametersEditor
+		_escape_velocity_warning_label = %EscapeVelocityWarningLabel as InfoLabel
 
 
 func should_show(in_workspace_context: WorkspaceContext) -> bool:
+	_workspace_context = in_workspace_context
 	_particle_emitter_parameters_editor.ensure_undo_redo_initialized(in_workspace_context)
 	var check_particle_emitter_selected: Callable = func(in_structure_context: StructureContext) -> bool:
 		return in_structure_context.nano_structure is NanoParticleEmitter
@@ -28,11 +33,11 @@ func should_show(in_workspace_context: WorkspaceContext) -> bool:
 
 func _update_contents(in_selected_structures: Array[StructureContext] ) -> void:
 	var selected_emitters_count: int = 0
-	var parameters_to_track: NanoParticleEmitterParameters = null
+	var emitter_to_track: NanoParticleEmitter = null
 	for context: StructureContext in in_selected_structures:
 		if context.nano_structure is NanoParticleEmitter:
 			selected_emitters_count += 1
-			parameters_to_track = context.nano_structure.get_parameters()
+			emitter_to_track = context.nano_structure as NanoParticleEmitter
 			if selected_emitters_count > 1:
 				break # early stop
 	if selected_emitters_count > 1:
@@ -40,11 +45,46 @@ func _update_contents(in_selected_structures: Array[StructureContext] ) -> void:
 		_select_one_info_label.show()
 		_particle_emitter_parameters_editor.hide()
 		_particle_emitter_parameters_editor.track_parameters(null)
+		_escape_velocity_warning_label.hide()
+		emitter_to_track = null
 	elif selected_emitters_count == 0:
 		# Entire editor should not be shown, just stop tracking any parameter if this was the case
 		_particle_emitter_parameters_editor.track_parameters(null)
 	else:
 		# Selected unique linear emitter
 		_select_one_info_label.hide()
-		_particle_emitter_parameters_editor.track_parameters(parameters_to_track)
+		_particle_emitter_parameters_editor.track_parameters(emitter_to_track.get_parameters())
 		_particle_emitter_parameters_editor.show()
+		_escape_velocity_warning_label.show()
+	if emitter_to_track != _tracked_emitter:
+		if _tracked_emitter != null:
+			_tracked_emitter.get_parameters().changed.disconnect(_on_tracked_parameters_changed)
+			_tracked_emitter.transform_changed.disconnect(_on_tracked_emitter_transform_changed)
+		if emitter_to_track != null:
+			emitter_to_track.get_parameters().changed.connect(_on_tracked_parameters_changed)
+			emitter_to_track.transform_changed.connect(_on_tracked_emitter_transform_changed.unbind(1))
+	_tracked_emitter = emitter_to_track
+	_update_escape_velocity_warning()
+
+
+func _on_tracked_parameters_changed() -> void:
+	_update_escape_velocity_warning()
+
+
+func _on_tracked_emitter_transform_changed() -> void:
+	_update_escape_velocity_warning()
+
+
+func _update_escape_velocity_warning() -> void:
+	if _tracked_emitter == null:
+		_escape_velocity_warning_label.hide()
+		return
+	var emitter_parameters: NanoParticleEmitterParameters = _tracked_emitter.get_parameters()
+	var axis_direction: Vector3 = _tracked_emitter.get_transform().basis * Vector3.FORWARD
+	var template_aabb: AABB = emitter_parameters.get_molecule_template().get_aabb()
+	if WorkspaceUtils.is_particle_emitter_escape_velocity_safe(
+			_workspace_context, emitter_parameters, template_aabb, axis_direction):
+		_escape_velocity_warning_label.hide()
+	else:
+		_escape_velocity_warning_label.message = tr("Initial speed may be not large enough to leave emission space without crowding the space.\nThis could lead to a simulation Failure.\nYou may want to increase the [b]'Initial Speed'[/b] or [b]'Every'[/b] rate to ensure simulation doesn't fail")
+		_escape_velocity_warning_label.show()

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_particle_emitter_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_particle_emitter_panel.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://bgu0g4fbt5qq8"]
+[gd_scene load_steps=5 format=3 uid="uid://d3yw5rsvf2ipr"]
 
 [ext_resource type="Script" uid="uid://c3gjf6wxs1kep" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_particle_emitter_panel.gd" id="1_adc5y"]
 [ext_resource type="PackedScene" uid="uid://b2b25o2443x3b" path="res://editor/controls/general/info_label.tscn" id="2_u4o06"]
 [ext_resource type="PackedScene" uid="uid://c7itseuxfv2fj" path="res://editor/controls/dockers/workspace_docker/shared_controls/particle_emitter_parameters_editor.tscn" id="3_8cxog"]
+[ext_resource type="Script" uid="uid://3hjuxktmfb16" path="res://editor/controls/general/info_label.gd" id="4_8cxog"]
 
 [node name="EditParticleEmitterPanel" type="MarginContainer"]
 script = ExtResource("1_adc5y")
@@ -13,10 +14,21 @@ layout_mode = 2
 [node name="SelectOneInfoLabel" parent="VBoxContainer" instance=ExtResource("2_u4o06")]
 unique_name_in_owner = true
 layout_mode = 2
-text = "[center][wave start=4 length=14 freq=0.5 sat=0.8 val=0.8 connected=1]ℹ[/wave] Select only one particle emitter at a time to edit it[/center]"
+text = "[center][wave start=4 length=14 freq=0.5 sat=0.8 val=0.8 connected=1]ℹ[/wave] Select only one motor at a time to edit it[/center]"
 message = &"Select only one motor at a time to edit it"
 effect = "wave"
 
 [node name="ParticleEmitterParametersEditor" parent="VBoxContainer" instance=ExtResource("3_8cxog")]
 unique_name_in_owner = true
 layout_mode = 2
+
+[node name="EscapeVelocityWarningLabel" type="RichTextLabel" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+bbcode_enabled = true
+text = "[center]ℹ Warning message about escape velocity here[/center]"
+fit_content = true
+script = ExtResource("4_8cxog")
+message = &"Warning message about escape velocity here"
+effect = "none"
+metadata/_custom_type_script = "uid://3hjuxktmfb16"

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/particle_emitter_parameters_editor.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/particle_emitter_parameters_editor.tscn
@@ -85,11 +85,12 @@ unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "As soon as molecules are created, they will have this initial speed, in the direction of the Particle Emitter. This is necesary to prevent particles from crowding the area.
 See also: Spread Angle"
-max_value = 2.0
+max_value = 20.0
 step = 0.001
 value = 0.5
 allow_greater = true
 suffix = "nm/ps"
+custom_arrow_step = 0.1
 
 [node name="Label3" type="Label" parent="PanelContainer/VBoxContainer/RotaryMotorParametersEditor"]
 custom_minimum_size = Vector2(0, 38)

--- a/godot_project/project_workspace/structs/nano_particle_emitter_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_particle_emitter_parameters.gd
@@ -15,7 +15,7 @@ enum LimitType {
 @export var _limit_type := LimitType.NEVER
 @export_range(1, 100, 1, "or_greater") var _stop_emitting_after_count: int = 1
 @export var _stop_emitting_after_nanoseconds: float = TimeSpanPicker.femtoseconds_to_unit(150, TimeSpanPicker.Unit.NANOSECOND)
-@export var _instance_speed_nanometers_per_picosecond: float = 0.5
+@export var _instance_speed_nanometers_per_picosecond: float = 8.0
 @export_range(0, 180, 0.1) var _spread_angle: float = 0
 
 


### PR DESCRIPTION
- Particle emitters now shows a warning when the initial velocity is roughly not enough to escape the emit area before the next emission happens
- For new particle emitters is bassed on current selection, for emitters being edited is bassed on it's template
- It considers amount of particles being emitted at once, and also the total amount of particles emitted during it's lifetime

Task: Molecular Emitter

![image](https://github.com/user-attachments/assets/548e9c28-45a9-4970-bb71-9e232a3a0053)
