### PR TITLE
Prevent simulation panels form enabling seek and cancel controls when simulation fails in the first frame

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -481,6 +481,8 @@ func _on_button_start_pause_pressed() -> void:
 				alert_dialog.set_detailed_message(new_simulation.start_promise.get_error())
 				Engine.get_main_loop().root.add_child(alert_dialog)
 				_status = Status.INACTIVE
+			elif new_simulation.was_aborted():
+				return
 			else:
 				var report_time_in_nanoseconds: float = TimeSpanPicker.femtoseconds_to_unit(
 						params.step_size_in_femtoseconds,


### PR DESCRIPTION
Task: When a simulation reports an error, the button "END SIMULATION" should automatically be disabled since the simulation has already ended