### PR TITLE
Hide autopose candidates while hilding any shortcut button mask that are not ALT

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -397,6 +397,8 @@ func _should_show(ignore_create_mode: bool = false) -> bool:
 		return false
 	if _is_shortcut_pressed():
 		return true
+	if _is_other_shortcut_pressed():
+		return false
 	return _workspace_context.workspace.representation_settings.get_display_auto_posing()
 
 
@@ -408,6 +410,13 @@ func _is_shortcut_pressed() -> bool:
 		not Input.is_key_pressed(KEY_META)
 	)
 
+
+func _is_other_shortcut_pressed() -> bool:
+	return (
+		Input.is_key_pressed(KEY_SHIFT) or
+		Input.is_key_pressed(KEY_CTRL) or
+		Input.is_key_pressed(KEY_META)
+	)
 
 func _is_valid_representation() -> bool:
 	var representation_settings: RepresentationSettings = _workspace_context.workspace.representation_settings

--- a/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
+++ b/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
@@ -83,6 +83,10 @@ func _update_preview() -> void:
 	var camera: Camera3D = get_viewport().get_camera_3d()
 	var dir_between_start_and_end: Vector3 = _first_pos.direction_to(_second_pos)
 	var up_vector: Vector3 = dir_between_start_and_end.cross(camera.global_transform.basis.y)
+	if up_vector.length_squared() == 0:
+		# When dir_between_start_and_end is the same as camera's Y axis, cross product will be ZERO
+		# lets use camera's X axis as fallback in this case
+		up_vector = dir_between_start_and_end.cross(camera.global_transform.basis.x)
 	var scale_factor: float = Representation.get_atom_scale_factor(_representation_settings)
 	var first_radius: float = Representation.get_atom_radius(first_data, _representation_settings) * scale_factor
 	var second_radius: float = Representation.get_atom_radius(second_data, _representation_settings) * scale_factor


### PR DESCRIPTION
- This removes the buttons in example while creating bonds using SHIFT

Task: SUGGESTION: Hide autopose candidates while holding Shift