### PR TITLE
Fixes the small molecules previews and particle emitter previews

### DIFF
--- a/godot_project/editor/rendering/particle_emitter_renderer/particle_emitter_renderer.gd
+++ b/godot_project/editor/rendering/particle_emitter_renderer/particle_emitter_renderer.gd
@@ -102,6 +102,7 @@ func _set_structure_preview_count(in_count: int) -> void:
 			instance.top_level = true
 			add_child(instance)
 			instance.set_structure(template)
+			instance.set_auto_update(false)
 			instance.global_position = global_position + emitter.calculate_instance_offset(index)
 			instance.visible = self.visible
 			_structure_previews.push_back(instance)

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -484,6 +484,14 @@ func peek_object_being_created(in_callback: Callable) -> bool:
 	return in_callback.call(_current_create_object_template)
 
 
+func peek_context_of_object_being_created(in_callback: Callable) -> bool:
+	if !is_creating_object():
+		return false
+	if !in_callback.is_valid():
+		return false
+	return in_callback.call(_current_create_object_structure_context)
+
+
 # # Simulation
 # # # # # #
 


### PR DESCRIPTION
Follow up to #222 
Fixes: BUG - Preview of Small Molecules not Visible

Reverts commit e1436e02972f73c2fc6211ca3784ab519b3d22d2 and adds a new fix to the emitter preview issue.