### PR TITLE
Simulation frames are now send and stored using frame index instead of time in nanoseconds

### DIFF
--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -523,12 +523,12 @@ func is_simulating() -> bool:
 	return _simulation != null
 
 
-func seek_simulation(in_time: float) -> void:
+func seek_simulation(in_frame: float) -> void:
 	assert(is_simulating(), "There's not an active simulation")
-	var state: PackedVector3Array = _simulation.find_state(in_time)
+	var state: PackedVector3Array = _simulation.find_state(in_frame)
 	var payload: OpenMMPayload = _simulation.original_payload
 	for emitter: NanoParticleEmitter in get_particle_emitters():
-		emitter.seek_simulation(in_time)
+		emitter.seek_simulation(in_frame)
 	WorkspaceUtils.apply_simulation_state(self, payload, state)
 
 


### PR DESCRIPTION
- This silves issues with floating point presition
- Fixes an issue with particle emitter showing molecules in a wrong position the first frame

Tasks:
- STABILITY: OpenMM should send frame index instead of time to indicate animation frame
- Molecular Emitter