### PR TITLE
Fixes to 'Create Emitter from Small Molecules'

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/small_molecules_picker/small_molecules_picker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/small_molecules_picker/small_molecules_picker.gd
@@ -82,14 +82,14 @@ func _set_hovered_item(in_item: TreeItem) -> void:
 		else:
 			# Texture was already lazy loaded on a previous hover
 			texture = texture_or_path as Texture2D
-		# 2. Assign texture to preview
-		if texture == null:
-			# No texture, use a generic icon
-			_preview_texture.texture = preload("uid://njg8vo87cuus")
-			_preview_texture.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-		else:
-			_preview_texture.texture = texture
-			_preview_texture.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+	# 2. Assign texture to preview
+	if texture == null:
+		# No texture, use a generic icon
+		_preview_texture.texture = preload("uid://njg8vo87cuus")
+		_preview_texture.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	else:
+		_preview_texture.texture = texture
+		_preview_texture.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
 
 
 func _init_list() -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/small_molecules_picker/small_molecules_picker.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/small_molecules_picker/small_molecules_picker.tscn
@@ -60,3 +60,5 @@ stretch_mode = 5
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
+allow_reselect = true
+allow_search = false


### PR DESCRIPTION
- Small Molecule Picker was showing the las selected molecule when reopening, this was wrong
- Swlecting twice the same molecule would not work (because 'allow relesect' was disabled)
- When creating particle emitters was not unselecting all that was previously selected, this is not a problem when crating from selection, because selection is removed anyway, but if you create several emitters from small molecules they end up overlapping in the same spot and all selected, so trying to move them would make you think there's only 1 emitter
- Also unified to code to create particle emitter once the tempalte is generated

Task: BUG - Failure to make emitter from small molecule twice