### PR TITLE
Fix a crash when changing an emitter's parameters during a simulation

### DIFF
--- a/godot_project/project_workspace/structs/nano_particle_emitter.gd
+++ b/godot_project/project_workspace/structs/nano_particle_emitter.gd
@@ -334,7 +334,7 @@ func apply_state_snapshot(in_state_snapshot: Dictionary, in_with_instances: bool
 		_instances_group = group_structure_context.nano_structure as AtomicStructure
 		_instances_group.apply_state_snapshot(in_state_snapshot["_instances_group_state"])
 		group_structure_context.get_collision_engine().rebuild(group_structure_context)
-		var workspace_cotext: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-		var rendering: Rendering = workspace_cotext.get_rendering()
+		var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
+		var rendering: Rendering = workspace_context.get_rendering()
 		var renderer := rendering._get_renderer_for_atomic_structure(_instances_group)
 		renderer.apply_state_snapshot(in_state_snapshot["_instances_group_renderer_state"])

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1336,6 +1336,8 @@ func snapshot_moment(in_operation_name: String) -> void:
 		# + Applying the user operation
 		# If we don't, hitting undo will revert the user action and the simulation at the same time.
 		
+		end_simulation_if_running()
+		
 		# Store the final snapshot containing both the applied state and the last action
 		var final_snapshot: Dictionary = _history.create_snapshot(in_operation_name)
 		var current_simulation_time: float = _simulation.get_last_seeked_time()


### PR DESCRIPTION
Fixes: "CRASH: Application can crash if making changes to particle emitter while simulation is ongoing"

The issue was that snapshot_moment() is async when a simulation is running with emitters (because of the await process in the loop).
This means we were still receiving new frames from openmm when the simulation should have been stopped already.