### PR TITLE
Prevent Simulation Tools Pannel from seeking simulation state while snapshot system is registering states in history

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -68,6 +68,7 @@ func should_show(out_workspace_context: WorkspaceContext)-> bool:
 func _ensure_workspace_initialized(out_workspace_context: WorkspaceContext) -> void:
 	if _workspace_context != out_workspace_context:
 		_workspace_context = out_workspace_context
+		out_workspace_context.about_to_apply_simulation.connect(_on_workspace_context_about_to_apply_simulation)
 		out_workspace_context.alerts_panel_visibility_changed.connect(_on_workspace_context_alerts_panel_visibility_changed)
 		_open_mm_failure_tracker.set_workspace_context(out_workspace_context)
 		# Initialize UI
@@ -135,6 +136,12 @@ func _notification(in_what: int) -> void:
 		_button_end.pressed.connect(_on_button_end_pressed)
 		_button_view_alerts.pressed.connect(_on_button_view_alerts_pressed)
 		_open_mm_failure_tracker.results_collected.connect(_on_open_mm_failure_tracker_results_collected)
+
+
+func _on_workspace_context_about_to_apply_simulation() -> void:
+	if _status == Status.PLAYING:
+		# This ensures _physics_process won't try to seek simulation
+		_status = Status.PAUSED
 
 
 func _on_workspace_context_alerts_panel_visibility_changed(in_is_visible: bool) -> void:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -21,6 +21,7 @@ signal atoms_relaxation_started()
 signal atoms_relaxation_finished(error_description_or_empty: String)
 signal simulation_started()
 signal simulation_finished()
+signal about_to_apply_simulation()
 
 signal async_work_started()
 signal async_work_finished()
@@ -1331,6 +1332,7 @@ func snapshot_moment(in_operation_name: String) -> void:
 	
 	# Apply simulation if the operation modified the structure of the project
 	if is_simulating() and not History.is_operation_whitelisted_during_simulation(in_operation_name):
+		about_to_apply_simulation.emit()
 		# We need to split the next snapshot in two separate steps:
 		# + Applying the simulation
 		# + Applying the user operation


### PR DESCRIPTION
Task: CRASH: Particle Emitter: Crash changing representation mode in middle of simulation