### PR TITLE
Block all input while applying simulation state

### DIFF
--- a/godot_project/autoloads/ui_blocker/ui_blocker.gd
+++ b/godot_project/autoloads/ui_blocker/ui_blocker.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
 
 var _blocker: Control = null
-
+var _block_requests: Array[Object] = []
 
 func _ready() -> void:
 	_blocker = %BlockerRect as Control
@@ -9,6 +9,12 @@ func _ready() -> void:
 
 
 func _process(_in_delta: float) -> void:
+	for i in range(_block_requests.size()-1, -1, -1):
+		if not is_instance_valid(_block_requests[i]):
+			_block_requests.remove_at(i)
+		else:
+			# Something is blocking all inputs for undefined frames
+			return
 	_unblock_last_frame_input_events()
 
 
@@ -18,6 +24,17 @@ func is_blocking() -> bool:
 
 func block_current_frame_input_events() -> void:
 	_blocker.set_mouse_filter(_blocker.MOUSE_FILTER_STOP)
+
+
+func start_blocking_input_events(in_requester: Object) -> void:
+	if (not is_instance_valid(in_requester)) or _block_requests.has(in_requester):
+		return
+	_blocker.set_mouse_filter(_blocker.MOUSE_FILTER_STOP)
+	_block_requests.push_back(in_requester)
+
+
+func stop_blocking_input_events(in_requester: Object) -> void:
+	_block_requests.erase(in_requester)
 
 
 func _unblock_last_frame_input_events() -> void:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1344,6 +1344,7 @@ func snapshot_moment(in_operation_name: String) -> void:
 	# Apply simulation if the operation modified the structure of the project
 	if is_simulating() and not History.is_operation_whitelisted_during_simulation(in_operation_name):
 		about_to_apply_simulation.emit()
+		UIBlocker.start_blocking_input_events(self)
 		# We need to split the next snapshot in two separate steps:
 		# + Applying the simulation
 		# + Applying the user operation
@@ -1379,6 +1380,7 @@ func snapshot_moment(in_operation_name: String) -> void:
 		
 		# Add the user operation back to the history stack
 		_history.push_and_apply_snapshot(final_snapshot, in_operation_name)
+		UIBlocker.stop_blocking_input_events(self)
 		return
 	
 	if not is_simulating():


### PR DESCRIPTION
- This prevents creating a queue of commands to create more and more states every frame, eventually reaching a crash because of unstability

Task: CRASH: Application can crash if making changes to particle emitter while simulation is ongoing
