### PR TITLE
Add an 'Apply Simulation' button to the simulation panel

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -40,6 +40,7 @@ var _label_error_notice: Label = null
 var _label_empty_notice: Label = null
 var _button_revert: Button = null
 var _button_end: Button = null
+var _button_apply: Button = null
 var _button_view_alerts: Button = null
 var _open_mm_failure_tracker: OpenMMFailureTracker = null
 var _motors_warning_dialog: NanoAcceptDialog = null
@@ -110,6 +111,7 @@ func _notification(in_what: int) -> void:
 		_label_empty_notice = %LabelEmptyNotice as Label
 		_button_revert = %ButtonRevert as Button
 		_button_end = %ButtonEnd as Button
+		_button_apply = %ButtonApply as Button
 		_button_view_alerts = %ButtonViewAlerts as Button
 		_open_mm_failure_tracker = %OpenMMFailureTracker as OpenMMFailureTracker
 		_motors_warning_dialog = %MotorsWarningDialog as NanoAcceptDialog
@@ -134,6 +136,7 @@ func _notification(in_what: int) -> void:
 		_option_button_timeline_unit.item_selected.connect(_on_option_button_timeline_unit_item_selected)
 		_button_revert.pressed.connect(_on_button_revert_pressed)
 		_button_end.pressed.connect(_on_button_end_pressed)
+		_button_apply.pressed.connect(_on_button_apply_pressed)
 		_button_view_alerts.pressed.connect(_on_button_view_alerts_pressed)
 		_open_mm_failure_tracker.results_collected.connect(_on_open_mm_failure_tracker_results_collected)
 
@@ -220,6 +223,7 @@ func _update_controls() -> void:
 			_slider_timeline.editable = false
 			_button_revert.disabled = true
 			_button_end.disabled = true
+			_button_apply.disabled = true
 		Status.PREWARMING:
 			_temperature_picker.editable = false
 			_time_span_picker.editable = false
@@ -255,6 +259,7 @@ func _update_controls() -> void:
 			_spin_box_timeline.editable = true
 			_slider_timeline.editable = true
 			_button_revert.disabled = false
+			_button_apply.disabled = false
 		Status.PLAYING:
 			_temperature_picker.editable = false
 			_time_span_picker.editable = false
@@ -269,6 +274,7 @@ func _update_controls() -> void:
 			_spin_box_timeline.editable = true
 			_slider_timeline.editable = true
 			_button_revert.disabled = false
+			_button_apply.disabled = false
 		Status.ERROR:
 			_temperature_picker.editable = false
 			_time_span_picker.editable = false
@@ -288,6 +294,7 @@ func _update_controls() -> void:
 			_spin_box_timeline.editable = true
 			_button_revert.disabled = false
 			_button_end.disabled = true
+			_button_apply.disabled = false
 
 
 func _has_valid_atoms() -> bool:
@@ -717,6 +724,14 @@ func _on_button_end_pressed() -> void:
 	
 	if _status == Status.PLAYING:
 		_status = Status.PAUSED
+
+
+func _on_button_apply_pressed() -> void:
+	if not is_instance_valid(_workspace_context):
+		return
+	
+	_workspace_context.apply_simulation_if_running()
+	_status = Status.INACTIVE
 
 
 func _on_button_view_alerts_pressed() -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://b3gggkyj2olxa"]
+[gd_scene load_steps=15 format=3 uid="uid://b3gggkyj2olxa"]
 
 [ext_resource type="Script" uid="uid://c7m37bfygxf4g" path="res://editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd" id="1_8vt2h"]
 [ext_resource type="PackedScene" uid="uid://cvtq2ps52eix3" path="res://editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/temperature_picker.tscn" id="2_kk1ae"]
@@ -11,6 +11,7 @@
 [ext_resource type="Texture2D" uid="uid://d1uqi1065c7ba" path="res://editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/icons/icon_stop.svg" id="9_1gfm6"]
 [ext_resource type="PackedScene" uid="uid://43m5k0qxrqiu" path="res://editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/openmm_failure_tracker.tscn" id="9_6sv07"]
 [ext_resource type="Script" uid="uid://bedfpdhraymiu" path="res://editor/controls/general/nano_accept_dialog.gd" id="10_84as7"]
+[ext_resource type="Texture2D" uid="uid://0vc3s1b68mgy" path="res://editor/icons/icon_validate_bonds_16px.svg" id="10_oh1f7"]
 
 [sub_resource type="Animation" id="Animation_k5o5r"]
 resource_name = "idle"
@@ -246,6 +247,15 @@ disabled = true
 text = "End Simulation
 "
 icon = ExtResource("9_1gfm6")
+
+[node name="ButtonApply" type="Button" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+disabled = true
+text = "Apply Simulation
+"
+icon = ExtResource("10_oh1f7")
 
 [node name="ButtonViewAlerts" type="Button" parent="VBoxContainer"]
 unique_name_in_owner = true


### PR DESCRIPTION
Fixes: "End Simulation" button not offered at conclusion of simulation

To keep it consistent and not give two different responsibilities to a single button, a new button `Apply Simulation` was added, rather than making `End Simulation` to apply when openmm is done processing the simulation (like described in the card)
 