### PR TITLE
Simplify the UI to Apply atoms to shapes

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.gd
@@ -18,26 +18,23 @@ enum _warning_message_keys {
 }
 
 var _warning_messages : Dictionary = {
-	_warning_message_keys.NO_WARNING: "",
-	_warning_message_keys.SHORTER_THAN_ATOMIC_RADIUS: "Distance is too short! Atoms will overlap",
-	_warning_message_keys.SHORTER_THAN_EQUILIBRIUM_DISTANCE: "Distance is less than equilibrium distance! Only recommended for bonded atoms",
+	_warning_message_keys.NO_WARNING: "Distance is adequate for [color=green][b]unbonded[/b][/color] atoms",
+	_warning_message_keys.SHORTER_THAN_ATOMIC_RADIUS: "[color=coral]Distance is too short! [b]Atoms will overlap[/b][/color]",
+	_warning_message_keys.SHORTER_THAN_EQUILIBRIUM_DISTANCE: "Distance is adequate for [color=green][b]bonded[/b][/color] atoms",
 }
 
 
 @onready var _element_picker: VBoxContainer = %ElementPicker
 @onready var _tree: Tree = %Tree
-@onready var _button_atomic_radius: Button = $PanelContainerDistance/VBoxContainer/ButtonAtomicRadius
-@onready var _button_contact_radius: Button = $PanelContainerDistance/VBoxContainer/ButtonContactRadius
-@onready var _spinbox_distance: SpinBoxSlider = $PanelContainerDistance/VBoxContainer/SpinBoxSlider
-@onready var _checkbutton_whole_shape: CheckButton = $PanelContainerDistance/VBoxContainer/CheckButtonWholeShape
-@onready var _label_warnings: Label = $PanelContainerDistance/VBoxContainer/Label
+@onready var _reset_distance_button: Button = %ResetDistanceButton as Button
+@onready var _spinbox_distance: SpinBoxSlider = $PanelContainerDistance/VBoxContainer/HBoxContainer/SpinBoxSlider
+@onready var _label_warnings: RichTextLabel = $PanelContainerDistance/VBoxContainer/Label
 @onready var _button_cover: Button = %ButtonCover
 @onready var _button_fill: Button = %ButtonFill
 
 
 func _ready() -> void:
-	_button_atomic_radius.pressed.connect(_on_atomic_radius_button_pressed)
-	_button_contact_radius.pressed.connect(_on_contact_radius_button_pressed)
+	_reset_distance_button.pressed.connect(_on_atomic_radius_button_pressed)
 	_button_cover.pressed.connect(_on_cover_button_pressed)
 	_button_fill.pressed.connect(_on_fill_button_pressed)
 	_element_picker.atom_type_change_requested.connect(_on_element_picker_atom_type_change_requested)
@@ -84,9 +81,7 @@ func _refresh_tree_selection_filters() -> void:
 
 func _refresh_buttons_visibility() -> void:
 	var no_types_selected: bool = _selected_type == NO_ATOM_TYPE_SELECTED
-	_button_atomic_radius.disabled = no_types_selected
-	_button_contact_radius.disabled = no_types_selected
-	_checkbutton_whole_shape.disabled = no_types_selected
+	_reset_distance_button.disabled = no_types_selected
 	
 	if not is_instance_valid(_workspace_context):
 		return
@@ -152,10 +147,6 @@ func _on_atomic_radius_button_pressed() -> void:
 	_spinbox_distance.value = _current_atom_radius * 2.0
 
 
-func _on_contact_radius_button_pressed() -> void:
-	_spinbox_distance.value = _current_contact_radius * 2.0
-
-
 func _on_cover_button_pressed() -> void:
 	var target_element_data: ElementData = PeriodicTable.get_by_atomic_number(_selected_type)
 	
@@ -192,10 +183,10 @@ func _cover_shape_surface(
 	var nano_shape: NanoShape = out_structure_context.nano_structure as NanoShape
 	var target_context: StructureContext = _get_parent_structure_context(out_structure_context)
 	var target_structure: AtomicStructure = target_context.nano_structure
-	
+	const FILL_WHOLE_SHAPE: bool = true
 	var new_atom_positions: PackedVector3Array = \
 		nano_shape.get_shape().get_cover_atoms_positions(
-			in_minimum_distance_between_atoms, _checkbutton_whole_shape.button_pressed
+			in_minimum_distance_between_atoms, FILL_WHOLE_SHAPE
 		)
 	
 	var new_atom_ids: PackedInt32Array = \
@@ -275,10 +266,11 @@ func _fill_shape(
 	
 	# Fill Shape will fallback to Cover Shape
 	# This is because some shapes have no volume and cannot be filled
+	const FILL_WHOLE_SHAPE: bool = true
 	var new_atom_positions: PackedVector3Array = \
-		nano_shape.get_shape().get_fill_atoms_positions(in_minimum_distance_between_atoms, _checkbutton_whole_shape.button_pressed) \
+		nano_shape.get_shape().get_fill_atoms_positions(in_minimum_distance_between_atoms, FILL_WHOLE_SHAPE) \
 		if nano_shape.get_shape().has_method("get_fill_atoms_positions") else \
-		nano_shape.get_shape().get_cover_atoms_positions(in_minimum_distance_between_atoms, _checkbutton_whole_shape.button_pressed)
+		nano_shape.get_shape().get_cover_atoms_positions(in_minimum_distance_between_atoms, FILL_WHOLE_SHAPE)
 	
 	var new_atom_ids: PackedInt32Array = \
 		_create_atoms(new_atom_positions, in_element_number, nano_shape.get_transform(), target_structure)

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.tscn
@@ -47,37 +47,34 @@ theme_type_variation = &"SubcategoryPanel"
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainerDistance"]
 layout_mode = 2
 
-[node name="ButtonAtomicRadius" type="Button" parent="PanelContainerDistance/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainerDistance/VBoxContainer"]
+layout_mode = 2
+
+[node name="ResetDistanceButton" type="Button" parent="PanelContainerDistance/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
-text = "Atomic Diameter"
+tooltip_text = "Reset to Bond Length"
+text = "⟳"
+flat = true
 
-[node name="ButtonContactRadius" type="Button" parent="PanelContainerDistance/VBoxContainer"]
-unique_name_in_owner = true
+[node name="SpinBoxSlider" parent="PanelContainerDistance/VBoxContainer/HBoxContainer" instance=ExtResource("3_wm30c")]
 layout_mode = 2
-size_flags_horizontal = 3
-text = "Equilibrium Distance"
-
-[node name="SpinBoxSlider" parent="PanelContainerDistance/VBoxContainer" instance=ExtResource("3_wm30c")]
-layout_mode = 2
-max_value = 10.0
+max_value = 1.0
 step = 0.005
 allow_greater = true
 suffix = "nm"
 
-[node name="CheckButtonWholeShape" type="CheckButton" parent="PanelContainerDistance/VBoxContainer"]
-layout_mode = 2
-text = "Cover/Fill whole shape"
-
-[node name="Label" type="Label" parent="PanelContainerDistance/VBoxContainer"]
+[node name="Label" type="RichTextLabel" parent="PanelContainerDistance/VBoxContainer"]
 custom_minimum_size = Vector2(128, 2.08165e-12)
 layout_mode = 2
 size_flags_horizontal = 3
+bbcode_enabled = true
 text = "Distance is too short! Atoms will overlap"
+fit_content = true
+scroll_active = false
+autowrap_mode = 2
 horizontal_alignment = 1
 vertical_alignment = 1
-autowrap_mode = 2
 
 [node name="ButtonCover" type="Button" parent="."]
 unique_name_in_owner = true

--- a/godot_project/theme/theme.tres
+++ b/godot_project/theme/theme.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Theme" load_steps=90 format=3 uid="uid://d3fnr4sbrd6ik"]
+[gd_resource type="Theme" load_steps=91 format=3 uid="uid://d3fnr4sbrd6ik"]
 
 [ext_resource type="FontFile" uid="uid://b3jkav4yxw06w" path="res://theme/Gidole-Regular.ttf" id="1_8indu"]
 [ext_resource type="Texture2D" uid="uid://bh1ju2ymvv1co" path="res://theme/icons/icon_on.svg" id="1_n28s0"]
 [ext_resource type="Texture2D" uid="uid://cwvnqyph6q5kr" path="res://theme/icons/icon_on_grey.svg" id="2_sabx0"]
 [ext_resource type="Texture2D" uid="uid://8wpx171pm1pa" path="res://theme/icons/icon_off_grey.svg" id="3_6o8wf"]
 [ext_resource type="Texture2D" uid="uid://nt6xviu7bmr2" path="res://theme/icons/icon_off.svg" id="4_gc3ql"]
+[ext_resource type="FontFile" uid="uid://mw18m2voq6sc" path="res://theme/noto_sans/NotoSansNagMundari-Bold.ttf" id="5_4ytkp"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8pn60"]
 content_margin_left = 10.0
@@ -1010,6 +1011,7 @@ PanelContainer/styles/panel = SubResource("StyleBoxFlat_udr83")
 PanelContainerCrystal/base_type = &"PanelContainer"
 PanelContainerCrystal/styles/panel = SubResource("StyleBoxFlat_6l1ye")
 PopupMenu/colors/font_disabled_color = Color(0.733333, 0.729412, 0.729412, 0.8)
+RichTextLabel/fonts/bold_font = ExtResource("5_4ytkp")
 RoundedWindow/base_type = &"AcceptDialog"
 RoundedWindow/styles/panel = SubResource("StyleBoxFlat_r6qfk")
 SpinboxSlider/base_type = &"HSlider"


### PR DESCRIPTION
- There's now only a unique button to reset distance to bond length
- Removed the check button to fill the whole shape (will always behave as checked by default)
- Label shows a better description if distance is adecuate for being bonded, unbonded, or inadecuate

https://github.com/user-attachments/assets/5f132d70-5bf1-4b64-b994-e4ce5ea53935

Task: REVIEW and Address - Retest Fill / Cover Reference Shape with Atoms