### PR TITLE
Re-encode the video tutorials using yuv444p pixel format

### DIFF
--- a/godot_project/documentation/video_tutorials/1_create_spinning_molecule.ogv
+++ b/godot_project/documentation/video_tutorials/1_create_spinning_molecule.ogv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abe5bc8f5aafeb1c87aae10189f97932dbc018c7ccd5702e1235825ab1d2ba8b
-size 27381641
+oid sha256:7920ca54bfbe0b473443b11cd8ab9c9042eaa78d8879221d909d19901930e12a
+size 41523773

--- a/godot_project/documentation/video_tutorials/2_build_meshing_gears.ogv
+++ b/godot_project/documentation/video_tutorials/2_build_meshing_gears.ogv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ecba6b98898e69fade38484c067d4b3ed4b706c3177b9d5d07f829fb7893e7da
-size 152836976
+oid sha256:6412798d8f83bc2f67b59990592fc24f14e667ac5ae14b5263e55e9d4f25395c
+size 102427819


### PR DESCRIPTION
Fixes: 
+ BUG: Video Tutorial 1 shows compression glitches in the gizmo tutorial
+ BUG: "Create spining Molecule" videotutorial has some intrusive pixels at the bottom not belonging to the application