### PR TITLE
Pause playback of simulations while switching to another tab

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -750,6 +750,8 @@ func _on_open_mm_failure_tracker_results_collected() -> void:
 
 
 func _physics_process(_delta: float) -> void:
+	if not _workspace_context.is_active():
+		return
 	_playback_delta += _spin_box_timeline.step * _playback_speed_picker.get_playback_speed()
 	if _playback_delta >= _spin_box_timeline.step:
 		_spin_box_timeline.set_value(min(_spin_box_timeline.value + _playback_delta, _spin_box_timeline.max_value))

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -166,6 +166,10 @@ func notify_activated() -> void:
 		rendering.apply_theme(workspace.representation_settings.get_theme())
 
 
+func is_active() -> bool:
+	return is_instance_valid(workspace_main_view) and workspace_main_view.is_visible_in_tree()
+
+
 func _on_workspace_main_view_ready() -> void:
 	var viewport_container: SubViewportContainer = get_editor_viewport_container()
 	viewport_container.workspace_context = self


### PR DESCRIPTION
- This does not pause the processing of the simulation, just the playback, which the user cannot see anyway

Task: ENHANCEMENT: Pause playback of simulations while another workspace is active