### PR TITLE
Add a forced limit to minimum distance when applying atoms to shapes

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.tscn
@@ -59,8 +59,10 @@ flat = true
 
 [node name="SpinBoxSlider" parent="PanelContainerDistance/VBoxContainer/HBoxContainer" instance=ExtResource("3_wm30c")]
 layout_mode = 2
+min_value = 0.05
 max_value = 1.0
 step = 0.005
+value = 0.05
 allow_greater = true
 suffix = "nm"
 


### PR DESCRIPTION
- Can no longer set a number bellow 0.05 (the bond length of hidrogen)

Task: BUG - Program incorrectly reports that 0 is a valid length for bonds