### PR TITLE
Fix typo in the particle emitter panel

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/particle_emitter_parameters_editor.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/particle_emitter_parameters_editor.tscn
@@ -65,7 +65,7 @@ suffix = "Molecules per emission"
 custom_minimum_size = Vector2(0, 38)
 layout_mode = 2
 size_flags_horizontal = 3
-text = " ・ Emmit every"
+text = " ・ Emit every"
 vertical_alignment = 1
 
 [node name="InstanceRateTimePicker" parent="PanelContainer/VBoxContainer/RotaryMotorParametersEditor" instance=ExtResource("1_74ssd")]


### PR DESCRIPTION
Fixes: BUG - Misspelling of "Emit" as "Emmit"