### PR TITLE
Fix the particle emitter ring action name

### DIFF
--- a/godot_project/editor/ring_menu_levels/virtual_objects/ring_action_create_particle_emitter.gd
+++ b/godot_project/editor/ring_menu_levels/virtual_objects/ring_action_create_particle_emitter.gd
@@ -12,7 +12,7 @@ func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> voi
 	_workspace_context = in_workspace_context
 	_ring_menu = in_menu
 	super._init(
-		tr("Particle Emitter"),
+		tr("Particle Emitters"),
 		_execute_action,
 		tr("Create a particle emitter that will spawn new molecules at regular intervals.")
 	)


### PR DESCRIPTION
Fixes: BUG - Text in Action Ring should read "Particle Emitters"