### PR TITLE
Add support to cover or fill shapes with small molecules

### DIFF
--- a/godot_project/autoloads/PeriodicTable.gd
+++ b/godot_project/autoloads/PeriodicTable.gd
@@ -32,7 +32,7 @@ const NON_METALS = [1, 6, 7, 8, 9, 14, 15, 16, 17]
 var _elements : Dictionary
 var _elements_by_name : Dictionary
 var _elements_by_symbol : Dictionary
-var _unknown_element := ElementData.new("-1,0,0,,Unknown,,,,,,,,,,,,#FFFFFF,#FFFFFF,#FFFFFF,#000000,0.0")
+var _unknown_element := ElementData.new("-1,0,0,?,Unknown,,,,,,,,,,,,#FFFFFF,#FFFFFF,#FFFFFF,#000000,0.0")
 var _current_color_schema := ColorSchema.MSEP
 
 func _init() -> void:

--- a/godot_project/autoloads/ui_behavior/ui_behavior.gd
+++ b/godot_project/autoloads/ui_behavior/ui_behavior.gd
@@ -15,6 +15,8 @@ func _on_node_added(node: Node) -> void:
 	if node is LineEdit or node is SpinBox:
 		node.select_all_on_focus = SELECT_ALL_ON_FOCUS
 	if node is LineEdit:
+		if node.text_submitted.is_connected(_on_line_edit_text_submitted):
+			return
 		node.text_submitted.connect(_on_line_edit_text_submitted.bind(node), CONNECT_DEFERRED)
 
 func _on_line_edit_text_submitted(_new_text: String, in_line_edit: LineEdit) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.gd
@@ -5,6 +5,10 @@ extends ElementPickerBase
 ## Displays a "More types" button that opens the extended element picker popup.
 ## The extended element picker is instantiated on demand the first time "More Types" is clicked
 
+
+signal extended_element_picker_shown
+
+
 @onready var _extended_element_picker_placeholder: InstancePlaceholder = %ExtendedElementPicker
 @onready var _more_types_button: Button = $MoreTypesButton
 var _extended_element_picker: PopupPanel = null
@@ -27,6 +31,7 @@ func _on_more_types_button_pressed() -> void:
 			else:
 				_extended_element_picker.enable_element(atomic_number)
 	_extended_element_picker.popup_centered()
+	extended_element_picker_shown.emit()
 	EditorSfx.mouse_down()
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.tscn
@@ -69,6 +69,7 @@ element = 17
 
 [node name="MoreTypesButton" type="Button" parent="."]
 layout_mode = 2
+theme_type_variation = &"CrystalButton"
 text = "More Types ..."
 
 [node name="ExtendedElementPicker" parent="MoreTypesButton" instance_placeholder="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/extended_element_picker.tscn"]

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.gd
@@ -1,0 +1,30 @@
+class_name CompactElementPickerPopup extends PopupPanel
+
+var _element_picker: CompactElementPicker
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_SCENE_INSTANTIATED:
+		_element_picker = $ElementPicker as CompactElementPicker
+		_element_picker.extended_element_picker_shown.connect(_on_element_picker_extended_element_picker_shown)
+
+
+func popup_attached_to_control(in_control: Control) -> void:
+	var screen_size: Vector2 = in_control.get_window().size
+	var popup_separation: int = 4
+	var button_rect: Rect2 = in_control.get_global_rect().grow(popup_separation)
+	var desired_position: Vector2 = button_rect.end - Vector2(button_rect.size.x, 0)
+	if desired_position.x + size.x > screen_size.x:
+		desired_position.x -= (size.x - button_rect.size.x)
+	if desired_position.y + size.y > screen_size.y:
+		desired_position.y -= button_rect.size.y + size.y
+	position = desired_position
+	popup()
+
+
+func get_element_picker() -> CompactElementPicker:
+	return _element_picker
+
+
+func _on_element_picker_extended_element_picker_shown() -> void:
+	hide()

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.gd.uid
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.gd.uid
@@ -1,0 +1,1 @@
+uid://ydi0cw2wy2v0

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=3 uid="uid://dyadiqebvvyti"]
+
+[ext_resource type="Script" uid="uid://ydi0cw2wy2v0" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.gd" id="1_beye0"]
+[ext_resource type="PackedScene" uid="uid://djdtnhc6tuvrh" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.tscn" id="1_ia0ww"]
+
+[node name="CompactElementPickerPopup" type="PopupPanel"]
+size = Vector2i(224, 215)
+visible = true
+script = ExtResource("1_beye0")
+
+[node name="ElementPicker" parent="." instance=ExtResource("1_ia0ww")]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 214.0
+offset_bottom = 205.0

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/element_preview.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/element_preview.gd
@@ -36,7 +36,8 @@ extends Control
 		if !is_instance_valid(label_render_warning):
 			await ready
 		_update_unknown_vdw_radii_notice()
-
+@export var visible_allow_unknown_element: bool = false
+@export_subgroup("")
 
 @onready var number: Label = %Number
 @onready var symbol: Label = %Symbol
@@ -44,7 +45,10 @@ extends Control
 @onready var mass: Label = %Mass
 @onready var label_render_warning: Label = %LabelRenderWarning
 
-var _atomic_number: int
+# _atomic_number is editor only property, not saved to tscn
+@export_custom(PROPERTY_HINT_RANGE,"0,118,1", PROPERTY_USAGE_EDITOR)
+var _atomic_number: int:
+	set = set_element_number
 var _is_render_radii_known: bool = true
 var _is_vdw_radii_known: bool = true
 var _current_color_schema: PeriodicTable.ColorSchema = PeriodicTable.get_current_color_schema()
@@ -54,7 +58,11 @@ func set_element_number(in_atomic_number: int) -> void:
 	if !is_instance_valid(number):
 		await ready
 	number.text = str(_atomic_number)
-	set_element_data(PeriodicTable.get_by_atomic_number(_atomic_number))
+	if in_atomic_number <= 0:
+		assert(visible_allow_unknown_element)
+		set_element_data(PeriodicTable._unknown_element)
+	else:
+		set_element_data(PeriodicTable.get_by_atomic_number(_atomic_number))
 
 
 func set_element_data(in_data: ElementData) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/extended_element_picker.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/extended_element_picker.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://c0uyh0jlgutcy" path="res://editor/icons/icon_search.svg" id="3_5b588"]
 
 [node name="ExtendedElementPicker" type="PopupPanel"]
-size = Vector2i(960, 579)
+size = Vector2i(972, 591)
 visible = true
 script = ExtResource("1_rmh0f")
 
@@ -13,10 +13,10 @@ script = ExtResource("1_rmh0f")
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 4.0
-offset_top = 4.0
-offset_right = 956.0
-offset_bottom = 575.0
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 962.0
+offset_bottom = 581.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/margin_left = 10

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
@@ -160,7 +160,7 @@ func _on_create_from_small_molecules_pressed() -> void:
 	_small_molecules_picker.popup()
 
 
-func _on_small_molecules_picker_molecule_selected(in_path: String) -> void:
+func _on_small_molecules_picker_molecule_selected(in_path: String, _in_preview: Texture2D) -> void:
 	assert(is_instance_valid(_workspace_context))
 	var unpacked_mol_path: String = WorkspaceUtils.unpack_mol_file_and_get_path(in_path)
 	var absolute_path: String = ProjectSettings.globalize_path(unpacked_mol_path)

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.gd
@@ -213,9 +213,23 @@ func _on_small_molecules_picker_molecule_selected(in_path: String, in_preview: T
 	var unpacked_mol_path: String = WorkspaceUtils.unpack_mol_file_and_get_path(in_path)
 	var absolute_path: String = ProjectSettings.globalize_path(unpacked_mol_path)
 	_selected_small_molecule = await WorkspaceUtils.get_nano_structure_from_file(_workspace_context, absolute_path, false, false, false)
+	_center_template_on_origin(_selected_small_molecule)
 	_selected_small_molecule.set_structure_name(in_path.get_file().get_basename().capitalize())
 	_refresh_ui()
-	
+
+
+func _center_template_on_origin(out_template: AtomicStructure) -> void:
+	var center: Vector3 = out_template.get_aabb().get_center()
+	if center.is_equal_approx(Vector3.ZERO):
+		return
+	var atoms: PackedInt32Array = out_template.get_valid_atoms()
+	var positions: PackedVector3Array = []
+	for atom_id: int in atoms:
+		var new_pos: Vector3 = out_template.atom_get_position(atom_id) - center
+		positions.push_back(new_pos)
+	out_template.start_edit()
+	out_template.atoms_set_positions(atoms, positions)
+	out_template.end_edit()
 
 
 func _on_tree_delete_button_clicked(_item: TreeItem, _column: int, id: int, _mouse_button_index: int) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.gd
@@ -2,13 +2,20 @@ extends DynamicContextControl
 
 
 const DELETE_ICON: Texture2D = preload("res://editor/controls/menu_bar/menu_edit/icons/icon_delete.svg")
-const NO_ATOM_TYPE_SELECTED: int = -1
+const NO_ATOM_TYPE_SELECTED: int = 0
 
 
 var _workspace_context: WorkspaceContext
 var _selected_type: int = NO_ATOM_TYPE_SELECTED
+var _selected_small_molecule: AtomicStructure = null
 var _current_contact_radius: float = -1.0
 var _current_atom_radius: float = -1.0
+
+
+enum ApplyingWhat {
+	ATOMS,
+	SMALL_MOLECULES,
+}
 
 
 enum _warning_message_keys { 
@@ -18,7 +25,12 @@ enum _warning_message_keys {
 	SHORTER_THAN_EQUILIBRIUM_DISTANCE, 
 }
 
-var _warning_messages : Dictionary = {
+var _small_molecules_warning_messages : Dictionary = {
+	_warning_message_keys.NO_CONTENT_SELECTED: "[color=tomato]Select a molecule to fill the shape first[/color]",
+	_warning_message_keys.NO_WARNING: "Distance is additional separation between molecules",
+}
+
+var _atom_warning_messages : Dictionary = {
 	_warning_message_keys.NO_CONTENT_SELECTED: "[color=tomato]Select an atom to fill the shape first[/color]",
 	_warning_message_keys.NO_WARNING: "Distance is adequate for [color=green][b]unbonded[/b][/color] atoms",
 	_warning_message_keys.SHORTER_THAN_ATOMIC_RADIUS: "[color=tomato]Distance is too short! [b]Atoms will overlap[/b][/color]",
@@ -26,8 +38,16 @@ var _warning_messages : Dictionary = {
 }
 
 
-@onready var _element_picker: VBoxContainer = %ElementPicker
+@onready var _apply_atoms_button: Button = %ApplyAtomsButton
+@warning_ignore("unused_private_class_variable")
+@onready var _apply_small_molecules_button: Button = %ApplySmallMoleculesButton
+@onready var _element_preview: AspectRatioContainer = %ElementPreview
+@onready var _small_molecules_preview: TextureRect = %SmallMoleculesPreview
 @onready var _tree: Tree = %Tree
+@onready var _select_popup_menu_button: Button = %SelectPopupMenuButton
+@onready var _small_molecules_picker: SmallMoleculesPicker = %SmallMoleculesPicker
+@onready var _compact_element_picker_popup: CompactElementPickerPopup = %CompactElementPickerPopup
+@onready var _element_picker: ElementPickerBase = _compact_element_picker_popup.get_element_picker()
 @onready var _reset_distance_button: Button = %ResetDistanceButton as Button
 @onready var _spinbox_distance: SpinBoxSlider = $PanelContainerDistance/VBoxContainer/HBoxContainer/SpinBoxSlider
 @onready var _label_warnings: RichTextLabel = $PanelContainerDistance/VBoxContainer/Label
@@ -35,13 +55,23 @@ var _warning_messages : Dictionary = {
 @onready var _button_fill: Button = %ButtonFill
 
 
+var _applying_what: ApplyingWhat:
+	set = _set_apply_type
+
+
 func _ready() -> void:
+	_apply_atoms_button.button_group.pressed.connect(_on_what_to_apply_button_pressed)
 	_reset_distance_button.pressed.connect(_on_atomic_radius_button_pressed)
 	_button_cover.pressed.connect(_on_cover_button_pressed)
 	_button_fill.pressed.connect(_on_fill_button_pressed)
-	_element_picker.atom_type_change_requested.connect(_on_element_picker_atom_type_change_requested)
 	_tree.button_clicked.connect(_on_tree_delete_button_clicked)
+	_element_picker.atom_type_change_requested.connect(_on_element_picker_atom_type_change_requested)
+	_small_molecules_picker.molecule_selected.connect(_on_small_molecules_picker_molecule_selected)
+	_select_popup_menu_button.pressed.connect(_on_select_popup_menu_button_pressed)
 	_spinbox_distance.value_changed.connect(_refresh_warning_message)
+	_element_preview.set_element_number(_selected_type)
+	_small_molecules_preview.texture = preload("uid://njg8vo87cuus")
+	_small_molecules_preview.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	_refresh_ui()
 
 
@@ -62,6 +92,28 @@ func should_show(in_workspace_context: WorkspaceContext) -> bool:
 	return false
 
 
+func _on_what_to_apply_button_pressed(in_button: BaseButton) -> void:
+	_applying_what = (
+		ApplyingWhat.ATOMS
+		if in_button == _apply_atoms_button
+		else ApplyingWhat.SMALL_MOLECULES
+	)
+
+
+func _set_apply_type(in_what_to_apply: ApplyingWhat) -> void:
+	if in_what_to_apply == _applying_what:
+		return
+	_applying_what = in_what_to_apply
+	_clear_selected_object()
+	match _applying_what:
+		ApplyingWhat.ATOMS:
+			_element_preview.show()
+			_small_molecules_preview.hide()
+		ApplyingWhat.SMALL_MOLECULES:
+			_small_molecules_preview.show()
+			_element_preview.hide()
+
+
 func _refresh_ui() -> void:
 	_refresh_tree_selection_filters()
 	_refresh_buttons_visibility()
@@ -70,20 +122,29 @@ func _refresh_ui() -> void:
 
 func _refresh_tree_selection_filters() -> void:
 	_tree.clear()
-	assert(_selected_type != 0, "Selected Type value is invalid")
 	var atom_type_has_been_selected: bool = _selected_type > NO_ATOM_TYPE_SELECTED
-	_tree.visible = atom_type_has_been_selected
+	var small_molecule_has_been_selected: bool = _selected_small_molecule != null
+	_tree.visible = atom_type_has_been_selected or small_molecule_has_been_selected
 	var root: TreeItem = _tree.create_item()
 	if atom_type_has_been_selected:
 		var tree_item: TreeItem = _tree.create_item(root)
 		var element_data: ElementData = PeriodicTable.get_by_atomic_number(_selected_type)
 		tree_item.set_text(0, element_data.name)
 		tree_item.add_button(0, DELETE_ICON, _selected_type)
+	if small_molecule_has_been_selected:
+		var tree_item: TreeItem = _tree.create_item(root)
+		tree_item.set_text(0, _selected_small_molecule.get_structure_name())
+		# Instance ID of small molecule object is used as ID of delete button
+		tree_item.add_button(0, DELETE_ICON, _selected_small_molecule.get_instance_id())
 	_tree.update_minimum_size()
 
 
 func _refresh_buttons_visibility() -> void:
-	var no_types_selected: bool = _selected_type == NO_ATOM_TYPE_SELECTED
+	var no_types_selected: bool
+	if _applying_what == ApplyingWhat.ATOMS:
+		no_types_selected = _selected_type == NO_ATOM_TYPE_SELECTED
+	elif _applying_what == ApplyingWhat.SMALL_MOLECULES:
+		no_types_selected = _selected_small_molecule == null
 	_reset_distance_button.disabled = no_types_selected
 	_spinbox_distance.editable = not no_types_selected
 	if no_types_selected:
@@ -114,19 +175,30 @@ func _refresh_warning_message(in_distance_value: float) -> void:
 	var msg: String = ""
 	var contact_diameter: float = _current_contact_radius * 2.0
 	var atom_diameter: float = _current_atom_radius * 2.0
-	if _selected_type == NO_ATOM_TYPE_SELECTED:
-		msg = _warning_messages[_warning_message_keys.NO_CONTENT_SELECTED]
-	elif in_distance_value >= contact_diameter:
-		msg = _warning_messages[_warning_message_keys.NO_WARNING]
-	elif in_distance_value >= atom_diameter:
-		msg = _warning_messages[_warning_message_keys.SHORTER_THAN_EQUILIBRIUM_DISTANCE]
-	elif in_distance_value < atom_diameter:
-		msg = _warning_messages[_warning_message_keys.SHORTER_THAN_ATOMIC_RADIUS]
+	if _applying_what == ApplyingWhat.ATOMS:
+		if _selected_type == NO_ATOM_TYPE_SELECTED:
+			msg = _atom_warning_messages[_warning_message_keys.NO_CONTENT_SELECTED]
+		elif in_distance_value >= contact_diameter:
+			msg = _atom_warning_messages[_warning_message_keys.NO_WARNING]
+		elif in_distance_value >= atom_diameter:
+			msg = _atom_warning_messages[_warning_message_keys.SHORTER_THAN_EQUILIBRIUM_DISTANCE]
+		elif in_distance_value < atom_diameter:
+			msg = _atom_warning_messages[_warning_message_keys.SHORTER_THAN_ATOMIC_RADIUS]
+	elif _applying_what == ApplyingWhat.SMALL_MOLECULES:
+		if _selected_small_molecule == null:
+			msg = _small_molecules_warning_messages[_warning_message_keys.NO_CONTENT_SELECTED]
+		else:
+			msg = _small_molecules_warning_messages[_warning_message_keys.NO_WARNING]
+	else:
+		assert(false, "Untracked content type " + ApplyingWhat.find_key(_applying_what))
+		msg = ""
 	_label_warnings.text = tr(msg)
 
 
 func _on_element_picker_atom_type_change_requested(element: int) -> void:
 	_selected_type = element
+	_element_preview.set_element_number(_selected_type)
+	_compact_element_picker_popup.hide()
 	var element_data: ElementData = PeriodicTable.get_by_atomic_number(_selected_type)
 	_current_atom_radius = element_data.get(ElementData.PROPERTY_NAME_RENDER_RADIUS)
 	_current_contact_radius = element_data.get(ElementData.PROPERTY_NAME_CONTACT_RADIUS)
@@ -134,13 +206,45 @@ func _on_element_picker_atom_type_change_requested(element: int) -> void:
 	_refresh_ui()
 
 
-func _on_tree_delete_button_clicked(_item: TreeItem, _column: int, id: int, _mouse_button_index: int) -> void:
-	if _selected_type == id:
-		_selected_type = NO_ATOM_TYPE_SELECTED
-		_current_atom_radius = -1.0
-		_current_contact_radius = -1.0
-		_spinbox_distance.value = 0.0
+func _on_small_molecules_picker_molecule_selected(in_path: String, in_preview: Texture2D) -> void:
+	_small_molecules_preview.texture = in_preview
+	_small_molecules_preview.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+	assert(is_instance_valid(_workspace_context))
+	var unpacked_mol_path: String = WorkspaceUtils.unpack_mol_file_and_get_path(in_path)
+	var absolute_path: String = ProjectSettings.globalize_path(unpacked_mol_path)
+	_selected_small_molecule = await WorkspaceUtils.get_nano_structure_from_file(_workspace_context, absolute_path, false, false, false)
+	_selected_small_molecule.set_structure_name(in_path.get_file().get_basename().capitalize())
 	_refresh_ui()
+	
+
+
+func _on_tree_delete_button_clicked(_item: TreeItem, _column: int, id: int, _mouse_button_index: int) -> void:
+	if _applying_what == ApplyingWhat.ATOMS and _selected_type == id:
+		_clear_selected_object()
+	# Instance ID of small molecule object is used as ID of delete button
+	elif _applying_what == ApplyingWhat.SMALL_MOLECULES \
+			and _selected_small_molecule != null \
+			and _selected_small_molecule.get_instance_id() == id:
+		_clear_selected_object()
+
+
+func _clear_selected_object() -> void:
+	_selected_type = NO_ATOM_TYPE_SELECTED
+	_element_preview.set_element_number(_selected_type)
+	_selected_small_molecule = null
+	_small_molecules_preview.texture = preload("uid://njg8vo87cuus")
+	_small_molecules_preview.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	_current_atom_radius = -1.0
+	_current_contact_radius = -1.0
+	_spinbox_distance.value = 0.0
+	_refresh_ui()
+
+
+func _on_select_popup_menu_button_pressed() -> void:
+	if _applying_what == ApplyingWhat.ATOMS:
+		_compact_element_picker_popup.popup_attached_to_control(_select_popup_menu_button)
+	else:
+		_small_molecules_picker.popup_attached_to_control(_select_popup_menu_button)
 
 
 func _on_workspace_context_selection_in_structures_changed(_contexts: Array[StructureContext]) -> void:
@@ -160,6 +264,13 @@ func _on_atomic_radius_button_pressed() -> void:
 
 
 func _on_cover_button_pressed() -> void:
+	if _applying_what == ApplyingWhat.ATOMS:
+		_cover_shape_with_atoms()
+	elif _applying_what == ApplyingWhat.SMALL_MOLECULES:
+		_cover_shape_with_molecules()
+
+
+func _cover_shape_with_atoms() -> void:
 	var target_element_data: ElementData = PeriodicTable.get_by_atomic_number(_selected_type)
 	
 	var editable_structure_contexts: Array[StructureContext] = \
@@ -173,9 +284,26 @@ func _on_cover_button_pressed() -> void:
 		var atom_diameter: float = \
 			_get_atom_diameter(target_element_data, nano_shape.get_representation_settings())
 		var minimum_distance_between_atoms: float = max(atom_diameter, _spinbox_distance.value)
-		_cover_shape_surface(minimum_distance_between_atoms, target_element_data.number, structure_context)
+		_cover_shape_surface(minimum_distance_between_atoms, structure_context)
 	
 	_workspace_context.snapshot_moment("Cover shape with atoms")
+
+
+func _cover_shape_with_molecules() -> void:
+	var molecule_aabb: AABB = _selected_small_molecule.get_aabb(AtomicStructure.AABB_BoundsType.ContactRadius)
+	molecule_aabb = molecule_aabb.grow(_spinbox_distance.value)
+	var molecule_diameter: float = molecule_aabb.get_longest_axis_size()
+	
+	var editable_structure_contexts: Array[StructureContext] = \
+		_workspace_context.get_editable_structure_contexts()
+	var selected_shapes_contexts: Array[StructureContext] = \
+		_get_selected_shapes_contexts(editable_structure_contexts)
+	
+	for structure_context: StructureContext in selected_shapes_contexts:
+		assert(structure_context.nano_structure is NanoShape, "Selected context is not a shape!")
+		_cover_shape_surface(molecule_diameter, structure_context)
+	
+	_workspace_context.snapshot_moment("Cover shape with molecules")
 
 
 func _get_selected_shapes_contexts(in_editable_structure_contexts: Array[StructureContext]) -> Array[StructureContext]:
@@ -189,7 +317,6 @@ func _get_selected_shapes_contexts(in_editable_structure_contexts: Array[Structu
 
 func _cover_shape_surface(
 	in_minimum_distance_between_atoms: float, 
-	in_element_number: int, 
 	out_structure_context: StructureContext) -> void:
 	assert(out_structure_context.nano_structure is NanoShape, "Selected context is not a shape!")
 	var nano_shape: NanoShape = out_structure_context.nano_structure as NanoShape
@@ -201,8 +328,11 @@ func _cover_shape_surface(
 			in_minimum_distance_between_atoms, FILL_WHOLE_SHAPE
 		)
 	
-	var new_atom_ids: PackedInt32Array = \
-		_create_atoms(new_atom_positions, in_element_number, nano_shape.get_transform(), target_structure)
+	var new_atom_ids: PackedInt32Array
+	if _applying_what == ApplyingWhat.ATOMS:
+		new_atom_ids = _create_atoms(new_atom_positions, _selected_type, nano_shape.get_transform(), target_structure)
+	elif _applying_what == ApplyingWhat.SMALL_MOLECULES:
+		new_atom_ids = _create_molecules(new_atom_positions, _selected_small_molecule, nano_shape.get_transform(), target_structure)
 	_set_new_selection(new_atom_ids, target_context)
 
 
@@ -238,11 +368,42 @@ func _create_atoms(
 	return new_atom_ids
 
 
+func _create_molecules(
+	in_centroid_positions: PackedVector3Array, 
+	in_template: AtomicStructure, 
+	in_nano_shape_transform: Transform3D,
+	out_target_structure: AtomicStructure) -> PackedInt32Array:
+	out_target_structure.start_edit()
+	var new_atom_ids: PackedInt32Array = []
+	for mol_pos: Vector3 in in_centroid_positions:
+		var mol_instance_atom_map: Dictionary[int, int] = {}
+		for atom_id: int in in_template.get_valid_atoms():
+			var atomic_number: int = in_template.atom_get_atomic_number(atom_id)
+			var atom_pos: Vector3 = mol_pos + in_template.atom_get_position(atom_id)
+			var new_atom_id: int = out_target_structure.add_atom(
+				NanoMolecularStructure.AddAtomParameters.new(
+					atomic_number, in_nano_shape_transform * atom_pos
+				)
+			)
+			mol_instance_atom_map[atom_id] = new_atom_id
+			new_atom_ids.push_back(new_atom_id)
+		for bond_id: int in in_template.get_valid_bonds():
+			var bond_data: Vector3i = in_template.get_bond(bond_id)
+			var atom_a: int = mol_instance_atom_map[bond_data[0]]
+			var atom_b: int = mol_instance_atom_map[bond_data[1]]
+			var bond_order: int = bond_data[2]
+			out_target_structure.add_bond(atom_a, atom_b, bond_order)
+	out_target_structure.end_edit()
+	EditorSfx.create_object()
+	return new_atom_ids
+	
+
+
 func _set_new_selection(
 	in_atom_ids: PackedInt32Array,
 	out_target_context: StructureContext) -> void:
 	if out_target_context == _workspace_context.get_current_structure_context():
-		out_target_context.select_atoms(in_atom_ids)
+		out_target_context.select_atoms_and_get_auto_selected_bonds(in_atom_ids)
 	else:
 		# Handle the case where atoms are added to a subgroup
 		# the entire subgroup should be selected as well
@@ -250,6 +411,13 @@ func _set_new_selection(
 
 
 func _on_fill_button_pressed() -> void:
+	if _applying_what == ApplyingWhat.ATOMS:
+		_fill_shape_with_atoms()
+	elif _applying_what == ApplyingWhat.SMALL_MOLECULES:
+		_fill_shape_with_molecules()
+
+
+func _fill_shape_with_atoms() -> void:
 	var target_element_data: ElementData = PeriodicTable.get_by_atomic_number(_selected_type)
 	var editable_structure_contexts: Array[StructureContext] = \
 		_workspace_context.get_editable_structure_contexts()
@@ -262,14 +430,30 @@ func _on_fill_button_pressed() -> void:
 		var atom_diameter: float = \
 			_get_atom_diameter(target_element_data, nano_shape.get_representation_settings())
 		var minimum_distance_between_atoms: float = max(atom_diameter, _spinbox_distance.value)
-		_fill_shape(minimum_distance_between_atoms, target_element_data.number, structure_context)
+		_fill_shape(minimum_distance_between_atoms, structure_context)
 	
 	_workspace_context.snapshot_moment("Fill shape with atoms")
 
 
+func _fill_shape_with_molecules() -> void:
+	var molecule_aabb: AABB = _selected_small_molecule.get_aabb(AtomicStructure.AABB_BoundsType.ContactRadius)
+	molecule_aabb = molecule_aabb.grow(_spinbox_distance.value)
+	var molecule_diameter: float = molecule_aabb.get_longest_axis_size()
+	
+	var editable_structure_contexts: Array[StructureContext] = \
+		_workspace_context.get_editable_structure_contexts()
+	var selected_shapes_contexts: Array[StructureContext] = \
+		_get_selected_shapes_contexts(editable_structure_contexts)
+	
+	for structure_context: StructureContext in selected_shapes_contexts:
+		assert(structure_context.nano_structure is NanoShape, "Selected context is not a shape!")
+		_fill_shape(molecule_diameter, structure_context)
+	
+	_workspace_context.snapshot_moment("Fill shape with molecules")
+
+
 func _fill_shape(
-	in_minimum_distance_between_atoms: float, 
-	in_element_number: int, 
+	in_minimum_distance_between_atoms: float,
 	out_structure_context: StructureContext) -> void:
 	assert(out_structure_context.nano_structure is NanoShape, "Selected context is not a shape!")
 	var nano_shape: NanoShape = out_structure_context.nano_structure as NanoShape
@@ -284,7 +468,10 @@ func _fill_shape(
 		if nano_shape.get_shape().has_method("get_fill_atoms_positions") else \
 		nano_shape.get_shape().get_cover_atoms_positions(in_minimum_distance_between_atoms, FILL_WHOLE_SHAPE)
 	
-	var new_atom_ids: PackedInt32Array = \
-		_create_atoms(new_atom_positions, in_element_number, nano_shape.get_transform(), target_structure)
+	var new_atom_ids: PackedInt32Array = []
+	if _applying_what == ApplyingWhat.ATOMS:
+		new_atom_ids = _create_atoms(new_atom_positions, _selected_type, nano_shape.get_transform(), target_structure)
+	elif _applying_what == ApplyingWhat.SMALL_MOLECULES:
+		new_atom_ids = _create_molecules(new_atom_positions, _selected_small_molecule, nano_shape.get_transform(), target_structure)
 	
 	_set_new_selection(new_atom_ids, target_context)

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.tscn
@@ -1,39 +1,119 @@
-[gd_scene load_steps=4 format=3 uid="uid://ct60a47xpcr5q"]
+[gd_scene load_steps=10 format=3 uid="uid://ct60a47xpcr5q"]
 
 [ext_resource type="Script" uid="uid://do5wwid7ys6tl" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/apply_atoms_to_shape.gd" id="1_1hka1"]
-[ext_resource type="PackedScene" uid="uid://djdtnhc6tuvrh" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.tscn" id="2_wxv1h"]
+[ext_resource type="PackedScene" uid="uid://dx1gn0krp0avh" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/element_preview.tscn" id="3_tinpt"]
 [ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="3_wm30c"]
+[ext_resource type="PackedScene" uid="uid://dp606sfgxdepk" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/small_molecules_picker/small_molecules_picker.tscn" id="5_twgh8"]
+[ext_resource type="PackedScene" uid="uid://dyadiqebvvyti" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.tscn" id="6_tinpt"]
+
+[sub_resource type="ButtonGroup" id="ButtonGroup_yoend"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_17qfi"]
+resource_local_to_scene = true
+content_margin_left = 10.0
+content_margin_top = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 10.0
+bg_color = Color(1, 1, 1, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.545098, 0, 0, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_bnevn"]
+resource_local_to_scene = true
+line_spacing = 0.0
+font_color = Color(0, 0, 0, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_bbcq5"]
+resource_local_to_scene = true
+line_spacing = 0.0
+font_size = 48
+font_color = Color(0, 0, 0, 1)
 
 [node name="ApplyAtomsToShape" type="VBoxContainer"]
 offset_left = 5.0
 offset_top = 5.0
-offset_right = 219.0
-offset_bottom = 375.0
+offset_right = 265.0
+offset_bottom = 455.0
 size_flags_vertical = 0
-theme_override_constants/separation = 20
 script = ExtResource("1_1hka1")
 
-[node name="LabelChooseAtom" type="Label" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
-theme_type_variation = &"HeaderSmall"
-text = "Choose Atom Type"
 
-[node name="PanelContainerElement" type="PanelContainer" parent="."]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 0
+theme_override_constants/separation = 0
+alignment = 1
+
+[node name="ApplyAtomsButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"StructureSelectorButton"
+toggle_mode = true
+button_pressed = true
+button_group = SubResource("ButtonGroup_yoend")
+text = "Atoms"
+
+[node name="ApplySmallMoleculesButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"StructureSelectorMoreButton"
+toggle_mode = true
+button_group = SubResource("ButtonGroup_yoend")
+text = "Small Molecules"
+
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer"]
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
 
-[node name="ElementPicker" parent="PanelContainerElement" instance=ExtResource("2_wxv1h")]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/PanelContainer"]
+layout_mode = 2
+
+[node name="ElementPreview" parent="VBoxContainer/PanelContainer/VBoxContainer" instance=ExtResource("3_tinpt")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 4
+background_stylebox = SubResource("StyleBoxFlat_17qfi")
+general_label_settings = SubResource("LabelSettings_bnevn")
+symbol_label_settings = SubResource("LabelSettings_bbcq5")
+visible_element_name = false
+visible_mass = false
+visible_allow_unknown_element = true
 
-[node name="Tree" type="Tree" parent="."]
+[node name="SmallMoleculesPreview" type="TextureRect" parent="VBoxContainer/PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+custom_minimum_size = Vector2(0, 113)
+layout_mode = 2
+expand_mode = 1
+stretch_mode = 6
+
+[node name="Tree" type="Tree" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 2
 hide_root = true
 scroll_horizontal_enabled = false
 scroll_vertical_enabled = false
+
+[node name="SelectPopupMenuButton" type="Button" parent="VBoxContainer/PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_type_variation = &"CrystalButton"
+text = "Select"
+
+[node name="SmallMoleculesPicker" parent="VBoxContainer/PanelContainer/VBoxContainer/SelectPopupMenuButton" instance=ExtResource("5_twgh8")]
+unique_name_in_owner = true
+visible = false
+
+[node name="CompactElementPickerPopup" parent="VBoxContainer/PanelContainer/VBoxContainer/SelectPopupMenuButton" instance=ExtResource("6_tinpt")]
+unique_name_in_owner = true
+visible = false
 
 [node name="LabelDistance" type="Label" parent="."]
 layout_mode = 2
@@ -82,10 +162,12 @@ vertical_alignment = 1
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
+theme_type_variation = &"CrystalButton"
 text = "Cover Surface with Atoms"
 
 [node name="ButtonFill" type="Button" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
+theme_type_variation = &"CrystalButton"
 text = "Fill Shape Volume with Atoms"

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.gd
@@ -8,8 +8,8 @@ const _METADATA_ID_ELEMENT: int = 1
 @onready var _tree: Tree = %Tree
 @onready var _selection_description: Label = %SelectionDescription
 @onready var _button_change_to: Button = %ButtonChangeTo
-@onready var _element_picker_popup: PopupPanel = %ElementPickerPopup
-@onready var _element_picker: VBoxContainer = %ElementPicker
+@onready var _element_picker_popup: CompactElementPickerPopup = %CompactElementPickerPopup
+@onready var _element_picker: CompactElementPicker = _element_picker_popup.get_element_picker()
 
 
 var _workspace_context: WorkspaceContext
@@ -43,17 +43,7 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 
 
 func _on_button_change_to_pressed() -> void:
-	var screen_rect: Rect2i = DisplayServer.screen_get_usable_rect()
-	var desired_position: Vector2 = DisplayServer.window_get_position()
-	var popup_separation: int = 4
-	var button_rect: Rect2 = _button_change_to.get_global_rect().grow(popup_separation)
-	desired_position += button_rect.end - Vector2(button_rect.size.x, 0)
-	if desired_position.x + _element_picker_popup.size.x > screen_rect.size.x:
-		desired_position.x -= (_element_picker_popup.size.x - button_rect.size.x)
-	if desired_position.y + _element_picker_popup.size.y > screen_rect.size.y:
-		desired_position.y -= button_rect.size.y + _element_picker_popup.size.y
-	_element_picker_popup.position = desired_position
-	_element_picker_popup.popup()
+	_element_picker_popup.popup_attached_to_control(_button_change_to)
 
 
 func _on_element_picker_atom_type_change_requested(in_to_element: int) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://df1wehgky7mt5"]
 
 [ext_resource type="Script" uid="uid://dxgv6t3xlxtfv" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.gd" id="1_538ej"]
-[ext_resource type="PackedScene" uid="uid://djdtnhc6tuvrh" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.tscn" id="2_rc0wb"]
+[ext_resource type="PackedScene" uid="uid://dyadiqebvvyti" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.tscn" id="2_pru4w"]
 
 [node name="ChangeAtomType" type="VBoxContainer"]
 anchors_preset = 10
@@ -39,13 +39,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Change To ..."
 
-[node name="ElementPickerPopup" type="PopupPanel" parent="."]
+[node name="CompactElementPickerPopup" parent="." instance=ExtResource("2_pru4w")]
 unique_name_in_owner = true
-size = Vector2i(212, 191)
-
-[node name="ElementPicker" parent="ElementPickerPopup" instance=ExtResource("2_rc0wb")]
-unique_name_in_owner = true
-offset_left = 4.0
-offset_top = 4.0
-offset_right = 208.0
-offset_bottom = 187.0
+visible = false

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/small_molecules_picker/small_molecules_picker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/small_molecules_picker/small_molecules_picker.gd
@@ -1,7 +1,7 @@
 class_name SmallMoleculesPicker extends PopupPanel
 
 
-signal molecule_selected(filepath: String)
+signal molecule_selected(filepath: String, preview: Texture2D)
 
 
 const FRAGMENTS_FOLDER: String = "res://chemical_structures/"
@@ -25,6 +25,19 @@ func _notification(what: int) -> void:
 		_small_molecules_tree.mouse_exited.connect(_on_small_molecules_tree_mouse_exited)
 		_init_list()
 		hide()
+
+
+func popup_attached_to_control(in_control: Control) -> void:
+	var screen_size: Vector2 = in_control.get_window().size
+	var popup_separation: int = 4
+	var button_rect: Rect2 = in_control.get_global_rect().grow(popup_separation)
+	var desired_position: Vector2 = button_rect.end - Vector2(button_rect.size.x, 0)
+	if desired_position.x + size.x > screen_size.x:
+		desired_position.x -= (size.x - button_rect.size.x)
+	if desired_position.y + size.y > screen_size.y:
+		desired_position.y -= button_rect.size.y + size.y
+	position = desired_position
+	popup()
 
 
 func _on_search_line_edit_text_changed(in_text: String) -> void:
@@ -52,7 +65,7 @@ func _on_small_molecules_tree_item_selected() -> void:
 	var selected: TreeItem = _small_molecules_tree.get_selected()
 	var path: String = selected.get_meta(META_PATH, String())
 	if not path.is_empty():
-		molecule_selected.emit(path)
+		molecule_selected.emit(path, _preview_texture.texture)
 		hide()
 
 

--- a/godot_project/project_workspace/structs/atomic_structure.gd
+++ b/godot_project/project_workspace/structs/atomic_structure.gd
@@ -3,6 +3,14 @@ class_name AtomicStructure extends NanoStructure
 ## Common class representing structure that directy consists of bonds and atoms
 
 
+enum AABB_BoundsType {
+	AtomsPositions, # get_aabb will not grow based on the size of atoms
+	VisualRadius,   # get_aabb will grow based on how big atoms are rendered
+	CovalentRadius, # get_aabb will grow based on each atom's covalent radius
+	ContactRadius,  # get_aabb will grow based on each atom's contact radius
+}
+
+
 signal atoms_visibility_changed(atoms: PackedInt32Array)
 signal bonds_visibility_changed(bonds: PackedInt32Array)
 signal springs_visibility_changed(springs: PackedInt32Array)
@@ -906,6 +914,11 @@ func has_hidden_atoms_bonds_springs_or_motor_links() -> bool:
 
 func get_readable_type() -> String:
 	return get_structure_name()
+
+
+func get_aabb(_in_bounds_type := AABB_BoundsType.AtomsPositions) -> AABB:
+	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
+	return AABB()
 
 
 func create_state_snapshot() -> Dictionary:

--- a/godot_project/project_workspace/structs/lmdb_nano_struct.gd
+++ b/godot_project/project_workspace/structs/lmdb_nano_struct.gd
@@ -325,17 +325,33 @@ func clear() -> void:
 	_molecule_id = _lmdb.create_molecule()
 
 
-func get_aabb() -> AABB:
+func get_aabb(in_bounds_type := AABB_BoundsType.AtomsPositions) -> AABB:
 	var aabb: AABB = AABB()
 	var atoms: PackedInt32Array = _lmdb.get_atoms(_molecule_id)
 	if atoms.is_empty():
 		return aabb
+	var elements_radius: Dictionary[int, float]
 	var is_first: bool = true
 	for atom_id: int in atoms:
 		var atom: AtomSnapshot = _lmdb.get_atom(_molecule_id, atom_id)
+		var atom_aabb := AABB(atom.position, Vector3.ZERO)
+		if in_bounds_type != AABB_BoundsType.AtomsPositions and not atom.type in elements_radius:
+			var element_data: ElementData = PeriodicTable.get_by_atomic_number(atom.atomic_number)
+			match in_bounds_type:
+				AABB_BoundsType.VisualRadius:
+					elements_radius[atom.type] = (
+						Representation.get_atom_radius(element_data, get_representation_settings()) \
+						* Representation.get_atom_scale_factor(get_representation_settings())
+					)
+				AABB_BoundsType.CovalentRadius:
+					elements_radius[atom.type] = element_data.covalent_radius[1]
+				AABB_BoundsType.ContactRadius:
+					elements_radius[atom.type] = element_data.contact_radius
+		atom_aabb = atom_aabb.grow(elements_radius.get(atom.atomic_number, 0.0)).abs()
 		if is_first:
-			aabb.position = atom.position
+			aabb = atom_aabb
 			is_first = false
 		else:
-			aabb = aabb.expand(atom.position)
+			aabb = aabb.expand(atom_aabb.position)
+			aabb = aabb.expand(atom_aabb.end)
 	return aabb.abs()

--- a/godot_project/project_workspace/structs/nano_molecular_structure.gd
+++ b/godot_project/project_workspace/structs/nano_molecular_structure.gd
@@ -1,6 +1,8 @@
 class_name NanoMolecularStructure extends AtomicStructure
 
 
+
+
 @export var _atoms: Array[NanoAtomLegacy] = [] : set = _set_atoms
 
 #TODO: should not be needed
@@ -713,18 +715,34 @@ func clear() -> void:
 	atoms_cleared.emit()
 
 
-func get_aabb() -> AABB:
+func get_aabb(in_bounds_type := AABB_BoundsType.AtomsPositions) -> AABB:
 	var aabb: AABB = AABB()
 	if _atoms.is_empty():
 		return aabb
+	var elements_radius: Dictionary[int, float]
 	var is_first: bool = true
 	for atom: NanoAtomLegacy in _atoms:
 		if atom.valid:
+			var atom_aabb := AABB(atom.position, Vector3.ZERO)
+			if in_bounds_type != AABB_BoundsType.AtomsPositions and not atom.atomic_number in elements_radius:
+				var element_data: ElementData = PeriodicTable.get_by_atomic_number(atom.atomic_number)
+				match in_bounds_type:
+					AABB_BoundsType.VisualRadius:
+						elements_radius[atom.atomic_number] = (
+							Representation.get_atom_radius(element_data, get_representation_settings()) \
+							* Representation.get_atom_scale_factor(get_representation_settings())
+						)
+					AABB_BoundsType.CovalentRadius:
+						elements_radius[atom.atomic_number] = element_data.covalent_radius[1]
+					AABB_BoundsType.ContactRadius:
+						elements_radius[atom.atomic_number] = element_data.contact_radius
+			atom_aabb = atom_aabb.grow(elements_radius.get(atom.atomic_number, 0.0)).abs()
 			if is_first:
-				aabb.position = atom.position
+				aabb = atom_aabb
 				is_first = false
 			else:
-				aabb = aabb.expand(atom.position)
+				aabb = aabb.expand(atom_aabb.position)
+				aabb = aabb.expand(atom_aabb.end)
 	return aabb.abs()
 
 

--- a/godot_project/theme/theme.tres
+++ b/godot_project/theme/theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=91 format=3 uid="uid://d3fnr4sbrd6ik"]
+[gd_resource type="Theme" load_steps=92 format=3 uid="uid://d3fnr4sbrd6ik"]
 
 [ext_resource type="FontFile" uid="uid://b3jkav4yxw06w" path="res://theme/Gidole-Regular.ttf" id="1_8indu"]
 [ext_resource type="Texture2D" uid="uid://bh1ju2ymvv1co" path="res://theme/icons/icon_on.svg" id="1_n28s0"]
@@ -351,6 +351,22 @@ corner_radius_top_left = 5
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_of1wl"]
+content_margin_left = 10.0
+content_margin_top = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 10.0
+bg_color = Color(0.184314, 0.101961, 0.34902, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.730677, 0.685245, 0.830401, 1)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_r6qfk"]
 content_margin_left = 20.0
@@ -1011,6 +1027,7 @@ PanelContainer/styles/panel = SubResource("StyleBoxFlat_udr83")
 PanelContainerCrystal/base_type = &"PanelContainer"
 PanelContainerCrystal/styles/panel = SubResource("StyleBoxFlat_6l1ye")
 PopupMenu/colors/font_disabled_color = Color(0.733333, 0.729412, 0.729412, 0.8)
+PopupPanel/styles/panel = SubResource("StyleBoxFlat_of1wl")
 RichTextLabel/fonts/bold_font = ExtResource("5_4ytkp")
 RoundedWindow/base_type = &"AcceptDialog"
 RoundedWindow/styles/panel = SubResource("StyleBoxFlat_r6qfk")


### PR DESCRIPTION
- The UI can now select individual atoms from periodic tables or small moleculers from our library
- AtomicStructure.get_aabb now has an additional argument to consider the size of the atoms
- When applying molecules to a shape, the longest side of it's AABB is used as a radius or a sphere, then uses the same algorithm for positioning as for atoms

Task: ENHANCEMENT: Support for filling a reference shape with instances of the Small Molecules library besides unbonded atoms



https://github.com/user-attachments/assets/7aba4738-d9f7-43d7-8b29-040bbe8ca4cb


https://github.com/user-attachments/assets/28bfc949-ac41-497a-8d2a-917c99942510

