### PR TITLE
Handle a corner case when changing selection of objects at the same time as applying selection

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
@@ -217,7 +217,7 @@ func _ensure_workspace_initialized(out_workspace_context: WorkspaceContext) -> v
 		out_workspace_context.structure_about_to_remove.connect(_on_nano_structure_removed)
 		out_workspace_context.workspace.structure_reparented.connect(_on_workspace_structure_reparented)
 		out_workspace_context.current_structure_context_changed.connect(_on_workspace_context_current_structure_context_changed)
-		out_workspace_context.selection_in_structures_changed.connect(_on_workspace_context_selection_in_structures_changed, CONNECT_DEFERRED)
+		out_workspace_context.selection_in_structures_changed.connect(_on_workspace_context_selection_in_structures_changed)
 		out_workspace_context.history_snapshot_applied.connect(_on_workspace_context_history_snapshot_applied)
 		_rebuild()
 
@@ -384,10 +384,27 @@ func _on_workspace_context_current_structure_context_changed(in_structure_contex
 
 
 func _on_workspace_context_selection_in_structures_changed(in_structure_contexts: Array[StructureContext]) -> void:
+	# Structure contexts can be added, removed, or recreated
+	# between this moment and the time we can efectively change the selection of the tree item
+	# This is because apply_simulation_state add and remove many groups all at once
+	# To ensure we dont lose track of objects we will reference them by ID
+	var groups_to_update := PackedInt32Array()
 	for context: StructureContext in in_structure_contexts:
-		var item: TreeItem = _get_structure_tree_item_or_null(context.nano_structure.int_guid)
-		if not item:
+		groups_to_update.push_back(context.get_int_guid())
+	if _workspace_context.is_applying_simulation_state():
+		await _workspace_context.simulation_state_applied
+	_update_structure_selection.call_deferred(groups_to_update)
+
+func _update_structure_selection(in_groups_to_update: PackedInt32Array) -> void:
+	for group_id: int in in_groups_to_update:
+		if not _workspace_context.workspace.has_structure_with_int_guid(group_id):
+			# group has been removed
 			continue
+		var nano_structure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(group_id)
+		if not _can_appear_in_tree(nano_structure):
+			continue
+		var context: StructureContext = _workspace_context.get_nano_structure_context(nano_structure)
+		var item: TreeItem = _get_structure_tree_item(group_id)
 		if context.has_atom_selection(true):
 			item.select(_TREE_COLUMN_0)
 		else:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -22,6 +22,7 @@ signal atoms_relaxation_finished(error_description_or_empty: String)
 signal simulation_started()
 signal simulation_finished()
 signal about_to_apply_simulation()
+signal simulation_state_applied()
 
 signal async_work_started()
 signal async_work_finished()
@@ -81,6 +82,7 @@ var _modified_structure_contexts: Dictionary #[int, true]
 var _selection_modified_structure_contexts: Dictionary #[int, true]
 var _simulation: SimulationData = null
 var _is_simulation_playback_running: bool = false
+var _is_applying_simulation_state: bool = false
 var _current_create_object_template: NanoStructure = null
 var _current_create_object_structure_context: StructureContext = null
 var _structure_contexts_holder: NodeHolder
@@ -1343,13 +1345,15 @@ func snapshot_moment(in_operation_name: String) -> void:
 	# workaround for part of the state for this workspace_context being inside ScriptUtils (this will apply that state)
 	get_editable_structure_contexts()
 	
-	# apply overdue signals, ensure snapshots contain up to date state
-	_emit_selection_in_structures_changed()
-	_emit_structure_content_changed()
-	
 	# Apply simulation if the operation modified the structure of the project
 	if is_simulating() and not History.is_operation_whitelisted_during_simulation(in_operation_name):
+		_is_applying_simulation_state = true
 		about_to_apply_simulation.emit()
+		
+		# apply overdue signals, ensure snapshots contain up to date state
+		_emit_selection_in_structures_changed()
+		_emit_structure_content_changed()
+		
 		UIBlocker.start_blocking_input_events(self)
 		# We need to split the next snapshot in two separate steps:
 		# + Applying the simulation
@@ -1387,7 +1391,15 @@ func snapshot_moment(in_operation_name: String) -> void:
 		# Add the user operation back to the history stack
 		_history.push_and_apply_snapshot(final_snapshot, in_operation_name)
 		UIBlocker.stop_blocking_input_events(self)
+
+		_is_applying_simulation_state = false
+		simulation_state_applied.emit()
+
 		return
+	
+	# apply overdue signals, ensure snapshots contain up to date state
+	_emit_selection_in_structures_changed()
+	_emit_structure_content_changed()
 	
 	if not is_simulating():
 		_history.create_snapshot(in_operation_name)
@@ -1402,6 +1414,10 @@ func snapshot_moment(in_operation_name: String) -> void:
 	seek_simulation(0.0)
 	_history.create_snapshot(in_operation_name)
 	seek_simulation(current_simulation_time)
+
+
+func is_applying_simulation_state() -> bool:
+	return _is_applying_simulation_state
 
 
 func register_snapshotable(in_system: Object) -> void:


### PR DESCRIPTION

- When applying selection as a result of creating an object, the apply_simulation process will take several frames to work, and at the end of the first one, the newly created object does not exist, meaning the Groups UI cannot know if it is selected. Because of this, the Groups UI needs a way to wait until the apply_simulation process finished before doing it's job

- This is a counter proposal of https://github.com/MSEP-one/msep.one/pull/288