### PR TITLE
When excluding an autoposing candidates because minimum distance…

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -238,13 +238,22 @@ func _update_candidates() -> void:
 			if not other_context.nano_structure is AtomicStructure:
 				continue
 			var atomic_structure: AtomicStructure = other_context.nano_structure
+			var group_id: int = atomic_structure.int_guid
 			for atom_id: int in atomic_structure.get_valid_atoms():
 				var atom_position: Vector3 = atomic_structure.atom_get_position(atom_id)
-				_atom_grid.add_item(atom_position, atom_id)
+				_atom_grid.add_item(atom_position, Vector2i(group_id, atom_id))
 	var index: int = 0
 	while index < _candidates.size():
 		var candidate: AtomCandidate = _candidates[index]
-		if _atom_grid.has_any_closer_than(candidate.atom_position, MIN_DISTANCE_TO_ATOMS):
+		const Item = SpatialHashGrid.Item
+		var atoms_unique_ids: Array[Vector2i]
+		for linked_atom_id: int in candidate.atom_ids:
+			atoms_unique_ids.append(Vector2i(context.get_int_guid(), linked_atom_id))
+		var exceptions: Array[Item] = _atom_grid.get_all_items().filter(
+			func(item: Item) -> bool:
+				return item.user_data in atoms_unique_ids
+		)
+		if _atom_grid.has_any_closer_than(candidate.atom_position, MIN_DISTANCE_TO_ATOMS, exceptions):
 			_candidates.remove_at(index)
 		else:
 			index += 1

--- a/godot_project/utils/spatial_hash_grid/spatial_hash_grid.gd
+++ b/godot_project/utils/spatial_hash_grid/spatial_hash_grid.gd
@@ -182,13 +182,15 @@ func get_user_data_closer_than(distance: float) -> Array[Array]:
 	return result
 
 
-func has_any_closer_than(point: Vector3, distance: float) -> bool:
+func has_any_closer_than(point: Vector3, distance: float, in_exceptions: Array[Item] = []) -> bool:
 	var distance_squared: float = pow(distance, 2.0)
 	var center_cell: Vector3 = snapped(point, _snap)
 	var neighbor_cells := get_neighbor_cells(center_cell)
 	neighbor_cells.push_front(center_cell)
 	for cell: Vector3 in neighbor_cells:
 		for item: Item in _grid.get(cell, []):
+			if item in in_exceptions:
+				continue
 			if item.position.distance_squared_to(point) < distance_squared:
 				return true
 	return false


### PR DESCRIPTION
… is close to another atom, exclude atoms that are meant to be bonded to the candidate
- This fixes the possibility to create H2 atoms with autoposing

Task: BUG: Autoposing does not offer candidates for H2 molecules