### PR TITLE
Fix crash when initializing the WorkspaceCamera

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/workspace_camera/workspace_camera.gd
+++ b/godot_project/editor/controls/editor_viewport_container/workspace_camera/workspace_camera.gd
@@ -12,6 +12,7 @@ func _notification(what: int) -> void:
 		_camera = $Camera3D as Camera3D
 		_camera.set_script(Tracker)
 		MolecularEditorContext.msep_editor_settings.changed.connect(_on_editor_settings_changed)
+	if what == NOTIFICATION_READY:
 		_on_editor_settings_changed.call_deferred()
 
 


### PR DESCRIPTION
This was an oversight on https://github.com/MSEP-one/msep.one/pull/297

Task: Lines of Virtual Objects not visible from inside the object