### PR TITLE
Update list of whitelisted actions during simulation

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/openmm_failure_tracker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/openmm_failure_tracker.gd
@@ -187,4 +187,4 @@ class InvalidValenceMetadata extends ErrorMetadata:
 
 		var focus_aabb: AABB = WorkspaceUtils.get_selected_objects_aabb(out_workspace_context)
 		WorkspaceUtils.focus_camera_on_aabb(out_workspace_context, focus_aabb)
-		out_workspace_context.snapshot_moment("Select atoms")
+		out_workspace_context.snapshot_moment("Select Atoms")

--- a/godot_project/project_workspace/workspace_context/history/history.gd
+++ b/godot_project/project_workspace/workspace_context/history/history.gd
@@ -16,6 +16,7 @@ const ACTION_WHITELIST_DURING_SIMULATION: Dictionary = {
 	"Box Selection" : true,
 	"Box Deselection" : true,
 	"Select Atom" : true,
+	"Select Atoms" : true,
 	"Select Bond" : true,
 	"Select Shape" : true,
 	"Select Motor" : true,
@@ -24,6 +25,7 @@ const ACTION_WHITELIST_DURING_SIMULATION: Dictionary = {
 	"Select Spring" : true,
 	"Select Group" : true,
 	"Deselect Atom" : true,
+	"Deselect Atoms" : true,
 	"Deselect Bond" : true,
 	"Deselect Shape" : true,
 	"Deselect Motor" : true,
@@ -35,8 +37,10 @@ const ACTION_WHITELIST_DURING_SIMULATION: Dictionary = {
 	"Select All" : true,
 	"Deselect All" : true,
 	"Select Connected Atoms" : true,
+	"Select Atoms by Type" : true,
 	"Grow Selection" : true,
 	"Shrink Selection" : true,
+	"Invert Selection" : true,
 	"Change Hydrogen Visibility" : true,
 	"Show Bonds" : true,
 	"Hide Bonds" : true,
@@ -44,11 +48,21 @@ const ACTION_WHITELIST_DURING_SIMULATION: Dictionary = {
 	"Hide Atom Labels" : true,
 	"Hide Selected Objects" : true,
 	"Show Hidden Objects" : true,
+	"Update Visibility" : true,
 	"Set Color Override" : true,
 	"Reset Color Override" : true,
+	"Theme Changed" : true,
+	"Color Schema Changed" : true,
+	"Change Background Color" : true,
+	"Reset background color" : true,
+	"Change Custom Selection Outline Color" : true,
+	"Set Description" : true,
+	"Set Authors" : true,
+	
 }
 const ACTION_BEGINNING_WITH_WHITELIST_DURING_SIMULATION: Dictionary = {
 	"Representation change to " : true,
+	"Group Renamed" : true,
 }
 
 const REDUNDANT_ACTION_WHITELIST := {


### PR DESCRIPTION
Added:
- Select Atoms (plural)
- Deselect Atoms (plural)
- Select Atoms by Type
- Invert Selection
- Update Visibility (this happens when selecting from alerts pannel and some atoms are hidden)
- Theme Changed
- Color Schema Changed
- Change Background Color
- Reset background color
- Change Custom Selection Outline Color
- Set Description (workspace tab)
- Set Authors (workspace tab)
- (actions starting with:) "Group Renamed"

Task: BUG - Changing visual representation during a simulation stops the simulation