### PR TITLE
Fix temperature picker and TimeSpan picker miss informing last user selection

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/temperature_picker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/temperature_picker.gd
@@ -88,6 +88,7 @@ func _set_temperature_in_kelvins(in_temp: float) -> void:
 
 
 func _on_spin_box_slider_value_confirmed(in_new_value: float) -> void:
+	temperature_kelvins = unit_to_kelvin(in_new_value, current_unit)
 	temperature_changed.emit(in_new_value, current_unit)
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/time_span_picker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/time_span_picker.gd
@@ -62,6 +62,7 @@ func _set_time_span_in_femtoseconds(in_time: float) -> void:
 
 
 func _on_spin_box_slider_value_confirmed(in_new_value: float) -> void:
+	time_span_femtoseconds = unit_to_femtoseconds(in_new_value, current_unit)
 	time_span_changed.emit(in_new_value, current_unit)
 
 


### PR DESCRIPTION
Task: BUG: Toggling "Relax model before running simulation" resets temperature and time_step settings