### PR TITLE
Fix several object previews showing when entering selection mode after box selection

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
@@ -12,6 +12,8 @@ func _init(in_context: WorkspaceContext) -> void:
 	in_context.create_object_parameters.create_distance_method_changed.connect(_on_creation_distance_changed)
 	in_context.create_object_parameters.creation_distance_from_camera_factor_changed.connect(_on_creation_distance_changed)
 	_rendering = in_context.get_rendering()
+	var create_object_parameters: CreateObjectParameters = get_workspace_context().create_object_parameters
+	create_object_parameters.create_mode_enabled_changed.connect(_on_create_object_parameters_create_mode_enabled_changed)
 
 
 # region virtual
@@ -199,6 +201,11 @@ func _on_current_structure_context_changed(in_context: StructureContext) -> void
 
 func _on_creation_distance_changed(_arg: Variant) -> void:
 	update_preview_position()
+
+
+func _on_create_object_parameters_create_mode_enabled_changed(in_enabled: bool) -> void:
+	if not in_enabled:
+		_hide_preview()
 
 
 func _on_new_structure_changed(in_structure: NanoStructure) -> void:

--- a/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
@@ -66,11 +66,19 @@ func _init(in_context: WorkspaceContext) -> void:
 	super._init(in_context)
 	in_context.current_structure_context_changed.connect(_on_current_structure_context_changed)
 	in_context.register_snapshotable(self)
+	var create_object_parameters: CreateObjectParameters = get_workspace_context().create_object_parameters
+	create_object_parameters.create_mode_enabled_changed.connect(_on_create_object_parameters_create_mode_enabled_changed)
 
 
 func _on_current_structure_context_changed(in_context: StructureContext) -> void:
 	if in_context == null or in_context.nano_structure == null:
 		_gesture_reset()
+
+
+func _on_create_object_parameters_create_mode_enabled_changed(in_enabled: bool) -> void:
+	if not in_enabled:
+		_hide_anchor_and_spring_preview()
+		_hide_atom_and_bond_preview()
 
 
 ## When _handles_state(context, edit_mode) is true this method will be

--- a/godot_project/editor/input_handlers/molecular_structures/create_reference_shape_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_reference_shape_input_handler.gd
@@ -31,6 +31,8 @@ func _init(in_context: WorkspaceContext) -> void:
 	_on_current_structure_context_changed(in_context.get_current_structure_context())
 	_on_creation_distance_from_camera_factor_changed(in_context.create_object_parameters.get_creation_distance_from_camera_factor())
 	_on_selected_shape_for_new_objects_changed(in_context.create_object_parameters.get_selected_shape_for_new_objects())
+	var create_object_parameters: CreateObjectParameters = get_workspace_context().create_object_parameters
+	create_object_parameters.create_mode_enabled_changed.connect(_on_create_object_parameters_create_mode_enabled_changed)
 	var editor_viewport: WorkspaceEditorViewport = get_workspace_context().get_editor_viewport()
 	_rendering = editor_viewport.get_rendering() as Rendering
 	_rendering.shape_preview_set_nano_shape(_ghost_shape)
@@ -63,6 +65,11 @@ func _on_selected_shape_for_new_objects_changed(in_shape: PrimitiveMesh) -> void
 	in_shape.changed.connect(_on_tracked_shape_changed)
 	if should_show:
 		_ensure_shape_fits_in_work_area()
+
+
+func _on_create_object_parameters_create_mode_enabled_changed(in_enabled: bool) -> void:
+	if not in_enabled:
+		_ghost_shape.set_visible(false)
 
 
 func _on_tracked_shape_changed() -> void:

--- a/godot_project/editor/input_handlers/molecular_structures/create_virtual_motor_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_virtual_motor_input_handler.gd
@@ -37,6 +37,8 @@ func _init(in_context: WorkspaceContext) -> void:
 	_on_creation_distance_from_camera_factor_changed(in_context.create_object_parameters.get_creation_distance_from_camera_factor())
 	_on_selected_virtual_motor_parameters_changed(in_context.create_object_parameters.get_selected_virtual_motor_parameters())
 	_rendering.virtual_motor_preview_set_parameters(_new_motor_parameters)
+	var create_object_parameters: CreateObjectParameters = get_workspace_context().create_object_parameters
+	create_object_parameters.create_mode_enabled_changed.connect(_on_create_object_parameters_create_mode_enabled_changed)
 
 
 func _on_current_structure_context_changed(in_context: StructureContext) -> void:
@@ -50,6 +52,11 @@ func _on_selected_virtual_motor_parameters_changed(in_parameters: NanoVirtualMot
 	_rendering.virtual_motor_preview_set_parameters(in_parameters)
 	update_preview_position()
 	_rendering.virtual_motor_preview_show()
+
+
+func _on_create_object_parameters_create_mode_enabled_changed(in_enabled: bool) -> void:
+	if not in_enabled:
+		_rendering.virtual_motor_preview_hide()
 
 
 func _on_ring_menu_closed() -> void:


### PR DESCRIPTION
Tasks:
- SHIT+BOX_SELECT can show the ghost of a bond and new atom during one frame when commiting the selection
- BUG: Ghost Reference shape visible in selection mode

It was not reported, but i discovered the same behaviour occurred for Virtual Motors and Small Molecules, so they are fixed as well