### PR TITLE
Several fixes to NanoGroupPicker and NanoGroupPickerPopup

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.gd
@@ -57,7 +57,7 @@ func _ensure_workspace_initialized(out_workspace_context: WorkspaceContext) -> v
 		out_workspace_context.structure_added.connect(_on_nano_structure_added)
 		out_workspace_context.selection_in_structures_changed.connect(_on_workspace_context_selection_in_structures_changed)
 		out_workspace_context.structure_about_to_remove.connect(_on_workspace_context_structure_about_to_remove)
-		out_workspace_context.history_snapshot_applied.connect(_on_workspace_context_history_snapshot_applied)
+		out_workspace_context.history_changed.connect(_on_workspace_context_history_changed)
 		_update_controls()
 		_update_apply_button_state()
 
@@ -72,7 +72,7 @@ func _on_nano_structure_added(in_nano_structure: NanoStructure) -> void:
 		return
 	var need_to_update_structure_name: bool = \
 			_line_edit_new_structure_name.text == _generate_new_structure_name()
-	_highest_index += 1
+	_highest_index = _workspace_context.workspace.get_nmb_of_structures()
 	if need_to_update_structure_name:
 		_line_edit_new_structure_name.text = _generate_new_structure_name()
 	ScriptUtils.call_deferred_once(_update_controls)
@@ -87,9 +87,18 @@ func _on_workspace_context_structure_about_to_remove(_in_structure: NanoStructur
 	ScriptUtils.call_deferred_once(_update_apply_button_state)
 
 
-func _on_workspace_context_history_snapshot_applied() -> void:
+func _on_workspace_context_history_changed() -> void:
 	_update_controls()
 	_update_apply_button_state()
+	_nano_structure_picker_new_structure_parent.rebuild_if_needed(_workspace_context)
+	_nano_structure_picker_assign_existing.rebuild_if_needed(_workspace_context)
+	var was_default_group_name: bool = _line_edit_new_structure_name.text == _generate_new_structure_name()
+	var was_group_added_or_removed: bool =_highest_index != _workspace_context.workspace.get_nmb_of_structures()
+	if was_group_added_or_removed:
+		# Update _highest_index if a group was added or removed by this action
+		_highest_index = _workspace_context.workspace.get_nmb_of_structures()
+		if was_default_group_name:
+			_line_edit_new_structure_name.text = _generate_new_structure_name()
 
 
 func _on_check_box_add_to_new_toggled(in_button_pressed: bool) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker.gd
@@ -25,8 +25,17 @@ func initialize(out_workspace_context: WorkspaceContext) -> void:
 		_on_current_structure_context_changed)
 
 
-func rebuild(in_workspace_context: WorkspaceContext) -> void:
-	initialize(in_workspace_context)
+func rebuild_if_needed(in_workspace_context: WorkspaceContext) -> void:
+	if _nano_structure_picker_popup_panel.is_outdated(in_workspace_context):
+		var prev_selected: int = _nano_structure_picker_popup_panel.selected_id
+		_nano_structure_picker_popup_panel.clear()
+		_nano_structure_picker_popup_panel.initialize(in_workspace_context)
+		if in_workspace_context.has_nano_structure_context_id(prev_selected):
+			_nano_structure_picker_popup_panel.selected_id = prev_selected
+		else:
+			_nano_structure_picker_popup_panel.selected_id = \
+				in_workspace_context.get_current_structure_context().get_int_guid()
+		text = _nano_structure_picker_popup_panel.get_selected_structure_name()
 
 
 func _set_selected_id(in_selected_id: int) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker_popup_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker_popup_panel.gd
@@ -25,10 +25,30 @@ func _notification(what: int) -> void:
 		hide()
 
 
+func is_outdated(in_workspace_context: WorkspaceContext) -> bool:
+	var contexts: Array[StructureContext] = in_workspace_context.get_all_structure_contexts()
+	var structures: Array = contexts.map(func(in_ctx: StructureContext) -> NanoStructure:
+		return in_ctx.nano_structure
+	)
+	var groups: Array = structures.filter(_can_contain_children)
+	if groups.size() != _structure_id_to_tree_item.size():
+		return true
+	for structure: NanoStructure in groups:
+		if !is_instance_valid(_structure_id_to_tree_item.get(structure.int_guid, null)):
+			return true
+	return false
+
+
+func clear() -> void:
+	_tree.clear()
+	_structure_id_to_tree_item.clear()
+	selected_id = -1
+
+
 func initialize(in_workspace_context: WorkspaceContext) -> void:
 	_workspace_context = in_workspace_context
 	assert(_structure_id_to_tree_item.is_empty(), "Already initialized")
-	_tree.clear()
+	clear()
 	var root: TreeItem = _tree.create_item(null, _WORKSPACE_GROUP_ID)
 	_structure_id_to_tree_item[_WORKSPACE_GROUP_ID] = root
 	var structures: Array = in_workspace_context.workspace.get_structures()


### PR DESCRIPTION
- Fix a crash when undoing creating of group and then attempting to create new groups again
- Fixed name generated for new groups not updated when undoing creation of a group

Task: BUG: Group Unclickable
