### PR TITLE
Fix copypaste mistake causing uneditable objects not being dimmed out

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/label_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/assets/label_material.gd
@@ -15,7 +15,7 @@ func _init() -> void:
 
 func set_selectable(in_is_selectable: bool) -> LabelMaterial:
 	const SELECTABLE = 1.0
-	const NON_SELECTABLE = 1.0
+	const NON_SELECTABLE = 0.0
 	var value_to_apply: float = SELECTABLE if in_is_selectable else NON_SELECTABLE
 	set_shader_parameter(UNIFORM_IS_SELECTABLE, value_to_apply)
 	return self

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/sphere_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/sphere_material.gd
@@ -23,7 +23,7 @@ func _init() -> void:
 
 func set_selectable(in_is_selectable: bool) -> SphereMaterial:
 	const SELECTABLE = 1.0
-	const NON_SELECTABLE = 1.0
+	const NON_SELECTABLE = 0.0
 	var value_to_apply: float = SELECTABLE if in_is_selectable else NON_SELECTABLE
 	set_shader_parameter(UNIFORM_IS_SELECTABLE, value_to_apply)
 	return self

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.gd
@@ -25,7 +25,7 @@ func set_scale(new_scale: float) -> CapsuleStickMaterial:
 
 func set_selectable(in_is_selectable: bool) -> CapsuleStickMaterial:
 	const SELECTABLE = 1.0
-	const NON_SELECTABLE = 1.0
+	const NON_SELECTABLE = 0.0
 	var value_to_apply: float = SELECTABLE if in_is_selectable else NON_SELECTABLE
 	set_shader_parameter(UNIFORM_IS_SELECTABLE, value_to_apply)
 	return self

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/cylinder_stick_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/cylinder_stick_material.gd
@@ -29,7 +29,7 @@ func set_atom_scale(new_scale: float) -> CylinderStickMaterial:
 
 func set_selectable(in_is_selectable: bool) -> CylinderStickMaterial:
 	const SELECTABLE = 1.0
-	const NON_SELECTABLE = 1.0
+	const NON_SELECTABLE = 0.0
 	var value_to_apply: float = SELECTABLE if in_is_selectable else NON_SELECTABLE
 	set_shader_parameter(UNIFORM_IS_SELECTABLE, value_to_apply)
 	return self


### PR DESCRIPTION
Task: BUG: Reparenting atoms to a parent group does not dim them out