### PR TITLE
When performing grow/shrink selection from ring menu, dont close the ring menu

### DIFF
--- a/godot_project/editor/ring_menu_levels/select_menu/ring_action_grow_selection.gd
+++ b/godot_project/editor/ring_menu_levels/select_menu/ring_action_grow_selection.gd
@@ -28,6 +28,5 @@ func can_grow_selection() -> bool:
 
 
 func _execute_action() -> void:
-	_ring_menu.close()
 	if can_grow_selection():
 		_workspace_context.grow_selection()

--- a/godot_project/editor/ring_menu_levels/select_menu/ring_action_shrink_selection.gd
+++ b/godot_project/editor/ring_menu_levels/select_menu/ring_action_shrink_selection.gd
@@ -28,6 +28,5 @@ func can_shrink() -> bool:
 
 
 func _execute_action() -> void:
-	_ring_menu.close()
 	if can_shrink():
 		_workspace_context.shrink_selection()


### PR DESCRIPTION
Task: UX: Make Ring Menu not close when clicking "Grow/Shrink Selection"