### PR TITLE
Remove old rules for hovering groups

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -98,14 +98,6 @@ func handle_hover_structure_changed(in_toplevel_hovered_structure_context: Struc
 	var is_hovered: bool = AtomicStructureRenderer.is_atomic_structure_hovered(
 		workspace, in_toplevel_hovered_structure_context, structure_context
 	)
-	var are_structures_valid := is_instance_valid(in_hovered_structure_context) and \
-			is_instance_valid(structure_context) and is_instance_valid(structure_context.nano_structure) \
-			and is_instance_valid(in_hovered_structure_context.nano_structure)
-	if not is_hovered and are_structures_valid:
-		is_hovered = workspace.is_a_ancestor_of_b(in_hovered_structure_context.nano_structure, \
-				structure_context.nano_structure)
-	if is_hovered and in_hovered_structure_context.nano_structure.int_guid == workspace.active_structure_int_guid:
-		is_hovered = false
 	var hovered_atom_id: int = -1 if in_hovered_structure_context != structure_context else in_atom_id
 	if hovered_atom_id != _hovered_atom_id:
 		_set_hovered_atom_id(hovered_atom_id)


### PR DESCRIPTION
- They are now covered in AtomicStructureRenderer.is_atomic_structure_hovered

Task: BUG: Hover group missmatch