### PR TITLE
Allow to copy MSEP version to clipboard from InitialInfo and About screens

### DIFF
--- a/godot_project/autoloads/about_msep_one/about_msep_one.gd
+++ b/godot_project/autoloads/about_msep_one/about_msep_one.gd
@@ -13,7 +13,7 @@ signal confirmed()
 var was_closed: bool = false
 
 var _blur_background: ColorRect
-var _label_date_of_build: Label
+var _label_date_of_build: RichTextLabel
 var _button_close: Button
 var _blur_tween: Tween = null
 
@@ -38,16 +38,25 @@ func _notification(in_what: int) -> void:
 			_EXPORT_DATE_SETTING_NAME,
 			_EXPORT_DATE_SETTING_DEFAULT
 		)
-		_label_date_of_build.text = tr(&"Build date: ") + build_date
 		var commit_hash: String = ProjectSettings.get_setting(
 			_EXPORT_COMMIT_SETTING_NAME,
 			_EXPORT_COMMIT_SETTING_DEFAULT
 		)
 		if !commit_hash.is_empty():
 			var short_hash: String = commit_hash.substr(0, 10)
-			_label_date_of_build.text += "." + short_hash
+			build_date += "." + short_hash
+		_label_date_of_build.clear()
+		_label_date_of_build.push_meta(build_date,RichTextLabel.META_UNDERLINE_ALWAYS, tr(&"Copy version to clipboard"))
+		_label_date_of_build.add_text(tr(&"Build date: ") + build_date)
+		_label_date_of_build.pop()
+		_label_date_of_build.meta_clicked.connect(_on_label_date_of_build_meta_clicked)
 		
 		_button_close.pressed.connect(_on_button_close_pressed)
+
+
+func _on_label_date_of_build_meta_clicked(in_meta: Variant) -> void:
+	var build_date: String = in_meta as String
+	DisplayServer.clipboard_set("MSEP.one " + build_date)
 
 
 func _on_button_close_pressed() -> void:

--- a/godot_project/autoloads/about_msep_one/about_msep_one.tscn
+++ b/godot_project/autoloads/about_msep_one/about_msep_one.tscn
@@ -108,10 +108,12 @@ Ongoing contributions provided by MSEP Foundation, and Prehensile Tales BV
 
 "
 
-[node name="LabelDateOfBuild" type="Label" parent="VBoxContainer/TabContainer/About Us/HBoxContainer/VBoxContainer"]
+[node name="LabelDateOfBuild" type="RichTextLabel" parent="VBoxContainer/TabContainer/About Us/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Build date: yyyy-mm-dd.git_commit_hash"
+fit_content = true
+scroll_active = false
 
 [node name="Label2" type="Label" parent="VBoxContainer/TabContainer/About Us/HBoxContainer/VBoxContainer"]
 layout_mode = 2

--- a/godot_project/autoloads/initial_info_screen/initial_info_screen.gd
+++ b/godot_project/autoloads/initial_info_screen/initial_info_screen.gd
@@ -13,7 +13,7 @@ signal confirmed()
 var was_closed: bool = false
 
 var _blur_background: ColorRect
-var _label_date_of_build: Label
+var _label_date_of_build: RichTextLabel
 var _button_close: Button
 var _blur_tween: Tween = null
 
@@ -34,18 +34,27 @@ func _notification(in_what: int) -> void:
 			_EXPORT_DATE_SETTING_NAME,
 			_EXPORT_DATE_SETTING_DEFAULT
 		)
-		_label_date_of_build.text = tr(&"Build date: ") + build_date
 		var commit_hash: String = ProjectSettings.get_setting(
 			_EXPORT_COMMIT_SETTING_NAME,
 			_EXPORT_COMMIT_SETTING_DEFAULT
 		)
 		if !commit_hash.is_empty():
 			var short_hash: String = commit_hash.substr(0, 10)
-			_label_date_of_build.text += "." + short_hash
+			build_date += "." + short_hash
+		_label_date_of_build.clear()
+		_label_date_of_build.push_meta(build_date,RichTextLabel.META_UNDERLINE_ALWAYS, tr(&"Copy version to clipboard"))
+		_label_date_of_build.add_text(tr(&"Build date: ") + build_date)
+		_label_date_of_build.pop()
+		_label_date_of_build.meta_clicked.connect(_on_label_date_of_build_meta_clicked)
 		
 		_button_close.pressed.connect(_on_button_close_pressed)
 	elif in_what == NOTIFICATION_READY:
 		appear()
+
+
+func _on_label_date_of_build_meta_clicked(in_meta: Variant) -> void:
+	var build_date: String = in_meta as String
+	DisplayServer.clipboard_set("MSEP.one " + build_date)
 
 
 func _on_button_close_pressed() -> void:

--- a/godot_project/autoloads/initial_info_screen/initial_info_screen.tscn
+++ b/godot_project/autoloads/initial_info_screen/initial_info_screen.tscn
@@ -100,10 +100,12 @@ Tutorials can be found by navigating to the 'Help' menu and selecting 'Tutorials
 horizontal_alignment = 1
 autowrap_mode = 3
 
-[node name="LabelDateOfBuild" type="Label" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
+[node name="LabelDateOfBuild" type="RichTextLabel" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Build date: yyyy-mm-dd.git_commit_hash"
+fit_content = true
+scroll_active = false
 horizontal_alignment = 1
 
 [node name="ButtonClose" type="Button" parent="VBoxContainer"]


### PR DESCRIPTION
Task: UX: Make the "Build Date" a clickable label that copies the version of the application to the system clipboard

Note: loading initial_info_screen.tscn file in Godot editor crashes it. I followed steps discovered from Gilles in #201 to be able to edit it

<img width="828" height="500" alt="version-initial-screen" src="https://github.com/user-attachments/assets/9e18644d-6123-4610-88c3-10c244489f93" />

<img width="1048" height="536" alt="version-about-screen" src="https://github.com/user-attachments/assets/c625876c-e985-421b-9360-149f205beecb" />

**Clipboard from initial screen:**
MSEP.one 2025-07-30.9f356069d5
**Clipboard from about screen:**
MSEP.one 2025-07-30.9f356069d5