### PR TITLE
Show creation panel for emitters and anchors

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/creation_distance_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/creation_distance_panel.gd
@@ -32,6 +32,8 @@ func should_show(in_workspace_context: WorkspaceContext) -> bool:
 		CreateObjectParameters.CreateModeType.CREATE_SHAPES,
 		CreateObjectParameters.CreateModeType.CREATE_FRAGMENT,
 		CreateObjectParameters.CreateModeType.CREATE_VIRTUAL_MOTORS,
+		CreateObjectParameters.CreateModeType.CREATE_ANCHORS_AND_SPRINGS,
+		CreateObjectParameters.CreateModeType.CREATE_PARTICLE_EMITTERS,
 	]:
 		return false
 	if !in_workspace_context.create_object_parameters.creation_distance_from_camera_factor_changed.is_connected(_on_creation_distance_from_camera_factor_changed):


### PR DESCRIPTION
Fixes: BUG: When creating `Anchors` and `Particle Emitters` the **Creation Distance** panel is not displayed