### PR TITLE
Update selectable material uniform when theme changes

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/fixed_size_representation/fixed_size_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/fixed_size_representation/fixed_size_representation.gd
@@ -15,4 +15,6 @@ func apply_theme(_in_theme: Theme3D) -> void:
 	# Far away atoms will look the same regardless of the theme (but will still
 	# respect the atoms colors). The parent function will override the fixed
 	# size material, so it's not called.
-	pass
+	var is_built: bool = _workspace_context != null
+	if is_built:
+		_update_is_selectable_uniform()

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
@@ -377,6 +377,9 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_segmented_multimesh.set_mesh_override(new_mesh)
 	_segmented_multimesh.set_material_override(_material)
 	_material.copy_state_from(old_material)
+	var is_built: bool = _workspace_context != null
+	if is_built:
+		_update_is_selectable_uniform()
 
 
 func saturate() -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -387,6 +387,9 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_segmented_multimesh.set_material_override(_material)
 	_material.set_scale_factor(_shader_scale)
 	_material.copy_state_from(old_material)
+	var is_built: bool = _workspace_context != null
+	if is_built:
+		_update_is_selectable_uniform()
 
 
 func create_state_snapshot() -> Dictionary:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
@@ -260,6 +260,13 @@ func handle_editable_structures_changed(in_new_editable_structure_contexts: Arra
 	_spring_renderer.set_global_color(global_color)
 
 
+func _update_is_selectable_uniform() -> void:
+	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
+	var is_editable: bool = structure_context.is_editable()
+	var global_color: Color = Color(COLOR_EDITABLE, 1.0) if is_editable else Color(COLOR_NON_EDITABLE, 1.0)
+	_spring_renderer.set_global_color(global_color)
+
+
 func handle_hover_structure_changed(_in_toplevel_hovered_structure_context: StructureContext,
 			in_hovered_structure_context: StructureContext, _in_atom_id: int, _in_bond_id: int,
 			in_spring_id: int) -> void:
@@ -291,6 +298,9 @@ func refresh_atoms_locking(_in_atoms_ids: PackedInt32Array) -> void:
 
 func apply_theme(in_theme: Theme3D) -> void:
 	_spring_renderer.change_look(in_theme.create_spring_mesh(), in_theme.create_spring_material())
+	var is_built: bool = _workspace_context != null
+	if is_built:
+		_update_is_selectable_uniform()
 
 
 func saturate() -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -152,6 +152,10 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_material_bond_1.copy_state_from(old_order_1_material)
 	_material_bond_2.copy_state_from(old_order_2_material)
 	_material_bond_3.copy_state_from(old_order_3_material)
+	
+	var is_built: bool = _workspace_context != null
+	if is_built:
+		_update_is_selectable_uniform()
 
 
 func saturate() -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/enhanced_capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/enhanced_capsule_stick_representation.gd
@@ -38,3 +38,7 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_material_bond_1.copy_state_from(old_order_1_material)
 	_material_bond_2.copy_state_from(old_order_2_material)
 	_material_bond_3.copy_state_from(old_order_3_material)
+	
+	var is_built: bool = _workspace_context != null
+	if is_built:
+		_update_is_selectable_uniform()

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
@@ -170,3 +170,7 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_material_bond_1.copy_state_from(old_order_1_material)
 	_material_bond_2.copy_state_from(old_order_2_material)
 	_material_bond_3.copy_state_from(old_order_3_material)
+	
+	var is_built: bool = _workspace_context != null
+	if is_built:
+		_update_is_selectable_uniform()

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -901,6 +901,7 @@ func _refresh_outline_color() -> void:
 		outline_color = representation_settings.get_custom_selection_outline_color()
 	else:
 		outline_color = representation_settings.get_theme().get_highlight_color()
+	
 	RenderingServer.global_shader_parameter_set(&"selected_atom_outline_color", outline_color)
 	RenderingServer.global_shader_parameter_set(&"reference_shape_selected_wireframe_color", outline_color)
 


### PR DESCRIPTION
Task: BUG: When switching between academic and modern view or colors schemas, the dimming of disabled groups stops working until you change the active group

The bug when switching color schema was already alegedly fixed by https://github.com/MSEP-one/msep.one/pull/325