### PR TITLE
Simplify AtomicStructureRenderer for previews

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
@@ -29,6 +29,7 @@ var _is_label_representation_up_to_date: bool = true
 var _rendering_representation := Rendering.Representation.BALLS_AND_STICKS
 var _nano_structure_id: int = Workspace.INVALID_STRUCTURE_ID
 var _is_built: bool = false
+var _is_preview: bool = false
 var _transparency: float = 0.0
 var _up_to_date_representations: Dictionary = {
 #	Rendering.Representation: true
@@ -44,6 +45,27 @@ func rebuild() -> void:
 	_current_representation.show()
 	_fixed_size_representation.build(structure_context)
 	_fixed_size_representation.refresh_all()
+	_fixed_size_representation.show()
+
+
+func build_for_preview(in_nano_structure: AtomicStructure, in_representation: Rendering.Representation) -> void:
+	# This build method assumes structure will never change, so wont connect to any signal
+	# Preview should never have springs, so we can skil _springs_representation
+	#_springs_representation.build_for_preview(in_nano_structure)
+	_is_preview = true
+	for rep: Rendering.Representation in Rendering.Representation.values():
+		_representation_to_node_map[rep].build_for_preview(in_nano_structure)
+		_up_to_date_representations[rep] = true
+		if rep != in_representation:
+			_representation_to_node_map[rep].hide()
+	_fixed_size_representation.build_for_preview(in_nano_structure)
+	visible = in_nano_structure.get_visible()
+	
+	_is_built = true
+	_labels_representation.build_for_preview(in_nano_structure)
+	_refresh_label_visibility_state()
+	refresh_atom_sizes()
+	_current_representation.show()
 	_fixed_size_representation.show()
 
 
@@ -169,7 +191,6 @@ func desaturate() -> void:
 
 
 func change_representation(new_representation: Rendering.Representation) -> void:
-	var struct_context: StructureContext = _workspace_context.get_structure_context(_nano_structure_id)
 	var old_representation: Representation = _current_representation
 	var old_rendering_representation: Rendering.Representation = _rendering_representation
 	_current_representation.hide()
@@ -177,9 +198,11 @@ func change_representation(new_representation: Rendering.Representation) -> void
 	_current_representation = _representation_to_node_map[new_representation]
 	_current_representation.set_transparency(_transparency)
 	var is_representation_up_to_date: bool = _up_to_date_representations.get(_rendering_representation, false)
-	if not is_representation_up_to_date and is_instance_valid(struct_context):
-		_current_representation.build(struct_context)
-		_up_to_date_representations[_rendering_representation] = true
+	if not is_representation_up_to_date:
+		var struct_context: StructureContext = _workspace_context.get_structure_context(_nano_structure_id)
+		if is_instance_valid(struct_context):
+			_current_representation.build(struct_context)
+			_up_to_date_representations[_rendering_representation] = true
 	
 	_current_representation.refresh_all()
 	_current_representation.show()
@@ -192,6 +215,8 @@ func change_representation(new_representation: Rendering.Representation) -> void
 func _reset_representation_highlight(in_old_representation: Representation,
 			in_old_rendering_representation: Rendering.Representation,
 			in_new_representation: Rendering.Representation) -> void:
+	if _is_preview:
+		return
 	var struct_context: StructureContext = _workspace_context.get_structure_context(_nano_structure_id)
 	var selected_atoms: PackedInt32Array = struct_context.get_selected_atoms()
 	var selected_bonds: PackedInt32Array = struct_context.get_selected_bonds()
@@ -398,6 +423,8 @@ func lowlight_springs(in_springs_to_lowlight: PackedInt32Array) -> void:
 
 
 func _outdate_non_active_representations() -> void:
+	if _is_preview:
+		return
 	for representation: Rendering.Representation in _up_to_date_representations:
 		if _rendering_representation != representation:
 			_up_to_date_representations[representation] = false

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/balls_and_sticks_representation/balls_and_sticks_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/balls_and_sticks_representation/balls_and_sticks_representation.gd
@@ -17,6 +17,13 @@ func build(in_structure_context: StructureContext) -> void:
 	if not _stick_rendering_visible:
 		_stick_representation.hide()
 
+func build_for_preview(in_nano_structure: NanoStructure) -> void:
+	_is_preview = true
+	_preview_instance_id = in_nano_structure.get_instance_id()
+	_sphere_representation.build_for_preview(in_nano_structure)
+	_stick_representation.build_for_preview(in_nano_structure)
+	if not _stick_rendering_visible:
+		_stick_representation.hide()
 
 func highlight_atoms(in_atoms_ids: PackedInt32Array, new_partially_influenced_bonds: PackedInt32Array,
 			in_bonds_released_from_partial_influence: PackedInt32Array) -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/enhanced_sticks_and_balls_representation/enhanced_sticks_and_balls_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/enhanced_sticks_and_balls_representation/enhanced_sticks_and_balls_representation.gd
@@ -17,7 +17,16 @@ func build(in_structure_context: StructureContext) -> void:
 	_stick_representation.build(in_structure_context)
 	if not _bond_rendering_visible:
 		_stick_representation.hide()
-	
+
+
+func build_for_preview(in_nano_structure: NanoStructure) -> void:
+	_is_preview = true
+	_preview_instance_id = in_nano_structure.get_instance_id()
+	_balls_representation.build_for_preview(in_nano_structure)
+	_stick_representation.build_for_preview(in_nano_structure)
+	if not _bond_rendering_visible:
+		_stick_representation.hide()
+
 
 func highlight_atoms(in_atoms_ids: PackedInt32Array, new_partially_influenced_bonds: PackedInt32Array,
 			in_bonds_released_from_partial_influence: PackedInt32Array) -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/labels_representation/labels_representation.gd
@@ -39,7 +39,7 @@ func _notification(in_what: int) -> void:
 
 
 func is_built() -> bool:
-	return _structure_id != Workspace.INVALID_STRUCTURE_ID
+	return _structure_id != Workspace.INVALID_STRUCTURE_ID or _is_preview
 
 
 func build(in_structure_context: StructureContext) -> void:
@@ -85,6 +85,53 @@ func build(in_structure_context: StructureContext) -> void:
 	_segmented_multimesh.bake()
 
 
+func build_for_preview(in_structure: NanoStructure) -> void:
+	assert(is_instance_valid(in_structure))
+	_is_preview = true
+	_preview_instance_id = in_structure.get_instance_id()
+	clear()
+	
+	_segmented_multimesh.set_material_override(_material)
+	
+	refresh_atoms_sizes()
+	
+	var aabb: AABB = AABB()
+	var atoms_ids: PackedInt32Array = in_structure.get_valid_atoms()
+	if atoms_ids.size() < 1:
+		_segmented_multimesh.bake()
+		return
+	
+	aabb.position = in_structure.atom_get_position(atoms_ids[0])
+	var atom_state := Representation.InstanceState.new()
+	for atom_id in atoms_ids:
+		var atom_position: Vector3 = in_structure.atom_get_position(atom_id)
+		var atom_atomic_number: int = in_structure.atom_get_atomic_number(atom_id)
+		var data: ElementData = PeriodicTable.get_by_atomic_number(atom_atomic_number)
+		var additional_color: Color = data.noise_color
+		additional_color.a = data.noise_atlas_id
+		atom_state.is_visible = not in_structure.is_atom_hidden_by_user(atom_id)
+		atom_state.is_locked = in_structure.atom_is_locked(atom_id)
+		if atom_state.is_selected:
+			_highlighted_atoms[atom_id] = true
+		atom_state.is_hydrogen = in_structure.atom_is_hydrogen(atom_id)
+		var atom_transform: Transform3D = Transform3D()
+		atom_transform.origin = atom_position
+		var color: Color = data.color
+		color.g = _atom_number_to_atlas_id_map[data.number]
+		color.b = data.render_radius
+		color.a = atom_state.to_float()
+		
+		_segmented_multimesh.add_particle(atom_id, atom_transform, color, additional_color)
+		aabb = aabb.expand(atom_position)
+	_segmented_multimesh.bake()
+
+
+func _get_related_atomic_structure() -> AtomicStructure:
+	if _is_preview:
+		return instance_from_id(_preview_instance_id)
+	return _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+
+
 func add_atoms(in_atoms_ids: PackedInt32Array) -> void:
 	for atom_id in in_atoms_ids:
 		_add_atom(atom_id)
@@ -121,7 +168,7 @@ func _add_atom(in_atom_id: int) -> void:
 
 
 func refresh_atoms_positions(in_atoms_ids: PackedInt32Array) -> void:
-	var nano_struct: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var nano_struct: NanoStructure = _get_related_atomic_structure()
 	for atom_id in in_atoms_ids:
 		var atom_position: Vector3 = nano_struct.atom_get_position(atom_id)
 		_segmented_multimesh.update_particle_position(atom_id, atom_position)
@@ -144,13 +191,13 @@ func refresh_atoms_atomic_number(in_atoms_and_atomic_numbers: Array[Vector2i]) -
 func refresh_atoms_sizes() -> void:
 	if not is_built():
 		return
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var scale_factor: float = Representation.get_atom_scale_factor(related_nanostructure.get_representation_settings())
 	_apply_scale_factor(scale_factor)
 
 
 func refresh_atoms_visibility(in_atoms_ids: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id: int in in_atoms_ids:
 		var color: Color = _segmented_multimesh.get_particle_color(atom_id)
 		var additional_color: Color = _segmented_multimesh.get_particle_additional_data(atom_id)
@@ -222,7 +269,7 @@ func highlight_atoms(in_atoms_ids: PackedInt32Array, _new_partially_influenced_b
 func lowlight_atoms(in_atoms_ids: PackedInt32Array, 
 			_in_bonds_released_from_partial_influence: PackedInt32Array,
 			_new_partially_influenced_bonds: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id in in_atoms_ids:
 		assert(related_nanostructure.is_atom_valid(atom_id), "atempt to lowlight a non existing atom")
 		if not _highlighted_atoms.get(atom_id, false):
@@ -234,7 +281,7 @@ func lowlight_atoms(in_atoms_ids: PackedInt32Array,
 func _refresh_atom(in_atom_id: int, _in_scale_factor: float = BASE_SCALE) -> void:
 	assert(_segmented_multimesh.is_external_id_known(in_atom_id), "Atempt to refresh non existing atom. Ensure
 		this operation is performed at right time in the context of NanoStructure.[start/end]_edit() call.")
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var atom_position: Vector3 = related_nanostructure.atom_get_position(in_atom_id)
 	var atom_atomic_number: int = related_nanostructure.atom_get_atomic_number(in_atom_id)
 	var data: ElementData = PeriodicTable.get_by_atomic_number(atom_atomic_number)
@@ -283,7 +330,7 @@ func hydrogens_rendering_on() -> void:
 
 
 func refresh_all() -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id: int in related_nanostructure.get_valid_atoms():
 		_refresh_atom(atom_id)
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/representation.gd
@@ -12,8 +12,17 @@ const SETTING_RADIUS_SOURCE_BALLS_AND_STICKS: StringName = &"msep/rendering/ball
 
 const SCALE_FACTOR_STICKS: float = 0.6
 
+@warning_ignore("unused_private_class_variable")
+var _is_preview: bool = false
+@warning_ignore("unused_private_class_variable")
+var _preview_instance_id: int
 
 func build(_in_structure_context: StructureContext) -> void:
+	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
+	return
+
+
+func build_for_preview(_in_nano_structure: NanoStructure) -> void:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
 	return
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/single_atom_representation/single_atom_representation.gd
@@ -62,6 +62,44 @@ func build(in_structure_context: StructureContext) -> void:
 	apply_theme(representation_settings.get_theme())
 
 
+func build_for_preview(in_nano_structure: NanoStructure) -> void:
+	assert(is_instance_valid(in_nano_structure))
+	_is_preview = true
+	_preview_instance_id = in_nano_structure.get_instance_id()
+	clear()
+	var atoms_ids: PackedInt32Array = in_nano_structure.get_valid_atoms()
+	if atoms_ids.size() < 1:
+		_segmented_multimesh.bake()
+		return
+	
+	var atom_state := Representation.InstanceState.new()
+	for atom_id in atoms_ids:
+		var bonds: PackedInt32Array = in_nano_structure.atom_get_bonds(atom_id)
+		if not bonds.is_empty():
+			continue
+		var atom_position: Vector3 = in_nano_structure.atom_get_position(atom_id)
+		atom_state.is_selected = _highlighted_atoms.get(atom_id, false)
+		atom_state.is_visible = not in_nano_structure.is_atom_hidden_by_user(atom_id)
+		atom_state.is_hydrogen = in_nano_structure.atom_is_hydrogen(atom_id)
+		var color: Color = StickRepresentation.get_bond_color(atom_id, in_nano_structure)
+		color.a = atom_state.to_float()
+		var atom_scale: Vector3 = Vector3.ONE * BASE_SCALE
+		var atom_transform: Transform3D = Transform3D()
+		atom_transform = atom_transform.scaled_local(atom_scale)
+		atom_transform.origin = atom_position
+		_segmented_multimesh.add_particle(atom_id, atom_transform, color, color)
+	_segmented_multimesh.bake()
+	
+	var representation_settings: RepresentationSettings = in_nano_structure.get_representation_settings()
+	apply_theme(representation_settings.get_theme())
+
+
+func _get_related_atomic_structure() -> AtomicStructure:
+	if _is_preview:
+		return instance_from_id(_preview_instance_id)
+	return _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+
+
 func _set_hovered_atom_id(in_hovered_atom_id: int) -> void:
 	var prev_hovered_atom_id: int = _hovered_atom_id
 	_hovered_atom_id = in_hovered_atom_id
@@ -73,6 +111,9 @@ func _set_hovered_atom_id(in_hovered_atom_id: int) -> void:
 
 
 func _update_is_selectable_uniform() -> void:
+	if _is_preview:
+		_material.set_selectable(true)
+		return
 	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
 	var is_editable: bool = structure_context.is_editable()
 	_material.set_selectable(is_editable)
@@ -99,7 +140,7 @@ func remove_atoms(in_atoms_ids: PackedInt32Array) -> void:
 func _add_atom(in_atom_id: int) -> void:
 	if _is_bonded_atom(in_atom_id):
 		return
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var atom_position: Vector3 = related_nanostructure.atom_get_position(in_atom_id)
 	var atom_scale: Vector3 = Vector3.ONE * BASE_SCALE
 	var atom_transform: Transform3D = Transform3D()
@@ -110,7 +151,7 @@ func _add_atom(in_atom_id: int) -> void:
 
 
 func refresh_atoms_positions(in_atoms_ids: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id in in_atoms_ids:
 		if _is_bonded_atom(atom_id):
 			continue
@@ -137,7 +178,7 @@ func refresh_atoms_sizes() -> void:
 
 
 func refresh_atoms_color(in_atoms: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id: int in in_atoms:
 		if not _segmented_multimesh.is_external_id_known(atom_id):
 			continue
@@ -155,7 +196,7 @@ func refresh_atoms_color(in_atoms: PackedInt32Array) -> void:
 
 
 func refresh_atoms_visibility(in_atoms_ids: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id: int in in_atoms_ids:
 		if not _segmented_multimesh.is_external_id_known(atom_id):
 			continue
@@ -168,7 +209,7 @@ func refresh_atoms_visibility(in_atoms_ids: PackedInt32Array) -> void:
 
 
 func refresh_all() -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id: int in related_nanostructure.get_valid_atoms():
 		_refresh_atom(atom_id)
 
@@ -188,7 +229,7 @@ func hide() -> void:
 
 
 func add_bonds(_new_bonds: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for bond_id in _new_bonds:
 		var bond: Vector3i = related_nanostructure.get_bond(bond_id)
 		var first_atom_id: int = bond.x
@@ -201,14 +242,14 @@ func add_bonds(_new_bonds: PackedInt32Array) -> void:
 func _hide_atom(in_atom_id: int) -> void:
 	if not _segmented_multimesh.is_external_id_known(in_atom_id):
 		return
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var atom_position: Vector3 = related_nanostructure.atom_get_position(in_atom_id)
 	var atom_transform: Transform3D = Transform3D(Basis().scaled(Vector3.ZERO), atom_position)
 	_segmented_multimesh.update_particle(in_atom_id, atom_transform, Color.BLACK)
 
 
 func remove_bonds(_removed_bonds: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for bond_id in _removed_bonds:
 		var bond: Vector3i = related_nanostructure.get_bond(bond_id)
 		var first_atom_id: int = bond.x
@@ -219,7 +260,7 @@ func remove_bonds(_removed_bonds: PackedInt32Array) -> void:
 
 
 func _ensure_atom_rendered(in_atom_id: int) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	if _segmented_multimesh.is_external_id_known(in_atom_id):
 		_refresh_atom(in_atom_id)
 	elif related_nanostructure.is_atom_valid(in_atom_id):
@@ -254,7 +295,7 @@ func highlight_atoms(in_atoms_ids: PackedInt32Array, _new_partially_influenced_b
 func lowlight_atoms(in_atoms_ids: PackedInt32Array,
 			_in_bonds_released_from_partial_influence: PackedInt32Array,
 			_new_partially_influenced_bonds: PackedInt32Array = PackedInt32Array()) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id in in_atoms_ids:
 		_highlighted_atoms[atom_id] = false
 		if _is_bonded_atom(atom_id):
@@ -267,7 +308,7 @@ func _refresh_atom(in_atom_id: int) -> void:
 	if _is_bonded_atom(in_atom_id):
 		return
 	
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var can_refresh_atom: bool = true
 	if not related_nanostructure.is_atom_valid(in_atom_id):
 		can_refresh_atom = _segmented_multimesh.is_external_id_known(in_atom_id)
@@ -293,7 +334,7 @@ func _refresh_atom(in_atom_id: int) -> void:
 
 
 func _is_bonded_atom(in_atom_id: int) -> bool:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var bonds: PackedInt32Array = related_nanostructure.atom_get_bonds(in_atom_id)
 	return not bonds.is_empty()
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -79,6 +79,57 @@ func build(in_structure_context: StructureContext) -> void:
 	apply_theme(representation_settings.get_theme())
 
 
+func build_for_preview(in_structure: NanoStructure) -> void:
+	_is_preview = true
+	_preview_instance_id = in_structure.get_instance_id()
+	clear()
+	
+	var representation_settings: RepresentationSettings = in_structure.get_representation_settings()
+	var scale_factor: float = Representation.get_atom_scale_factor(representation_settings)
+	_apply_scale_factor(scale_factor)
+
+	var aabb: AABB = AABB()
+	var atoms_ids: PackedInt32Array = in_structure.get_valid_atoms()
+	if atoms_ids.size() < 1:
+		_segmented_multimesh.bake()
+		return
+	
+	var locked_atoms: PackedInt32Array = in_structure.get_locked_atoms()
+	var atom_state := Representation.InstanceState.new()
+	aabb.position = in_structure.atom_get_position(atoms_ids[0])
+	for atom_id in atoms_ids:
+		var atom_position: Vector3 = in_structure.atom_get_position(atom_id)
+		var atom_atomic_number: int = in_structure.atom_get_atomic_number(atom_id)
+		var data: ElementData = PeriodicTable.get_by_atomic_number(atom_atomic_number)
+		var additional_color: Color = data.noise_color
+		additional_color.a = data.noise_atlas_id
+		var atom_radius: float = Representation.get_atom_radius(data, in_structure.get_representation_settings())
+		var atom_scale: Vector3 = Vector3.ONE * atom_radius * BASE_SCALE
+		var atom_transform: Transform3D = Transform3D()
+		var atom_color: Color = data.color
+		if in_structure.has_color_override(atom_id):
+			atom_color = in_structure.get_color_override(atom_id)
+		atom_state.is_visible = not in_structure.is_atom_hidden_by_user(atom_id)
+		atom_state.is_locked = atom_id in locked_atoms
+		atom_state.is_hydrogen = in_structure.atom_is_hydrogen(atom_id)
+		atom_color.a = atom_state.to_float()
+		atom_transform = atom_transform.scaled_local(atom_scale)
+		atom_transform.origin = atom_position
+		_segmented_multimesh.add_particle(atom_id, atom_transform, atom_color, additional_color)
+		aabb = aabb.expand(atom_position)
+	_segmented_multimesh.bake()
+	
+	rendering_ready.emit()
+	
+	apply_theme(representation_settings.get_theme())
+
+
+func _get_related_atomic_structure() -> AtomicStructure:
+	if _is_preview:
+		return instance_from_id(_preview_instance_id)
+	return _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+
+
 func handle_editable_structures_changed(_in_new_editable_structure_contexts: Array[StructureContext]) -> void:
 	if not _workspace_context.has_nano_structure_context_id(_structure_id):
 		assert(ScriptUtils.is_queued_for_deletion_recursive(self), "structure deleted, this rendering instance is about to be deleted")
@@ -116,6 +167,9 @@ func _set_hovered_atom_id(in_hovered_atom_id: int) -> void:
 
 
 func _update_is_selectable_uniform() -> void:
+	if _is_preview:
+		_material.set_selectable(true)
+		return
 	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
 	var is_editable: bool = structure_context.is_editable()
 	_material.set_selectable(is_editable)
@@ -135,7 +189,7 @@ func remove_atoms(in_atoms_ids: PackedInt32Array) -> void:
 
 
 func _add_atom(in_atom_id: int) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var atom_position: Vector3 = related_nanostructure.atom_get_position(in_atom_id)
 	var atom_atomic_number: int = related_nanostructure.atom_get_atomic_number(in_atom_id)
 	var data: ElementData = PeriodicTable.get_by_atomic_number(atom_atomic_number)
@@ -152,7 +206,7 @@ func _add_atom(in_atom_id: int) -> void:
 
 
 func refresh_atoms_positions(in_atoms_ids: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id in in_atoms_ids:
 		var atom_position: Vector3 = related_nanostructure.atom_get_position(atom_id)
 		_segmented_multimesh.update_particle_position(atom_id, atom_position)
@@ -173,7 +227,7 @@ func refresh_atoms_atomic_number(in_atoms_and_atomic_numbers: Array[Vector2i]) -
 func refresh_atoms_sizes(in_update_atoms_radii: bool = false) -> void:
 	if not _segmented_multimesh.is_visible():
 		return
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var scale_factor: float = Representation.get_atom_scale_factor(related_nanostructure.get_representation_settings())
 	_apply_scale_factor(scale_factor)
 	
@@ -189,7 +243,7 @@ func refresh_atoms_sizes(in_update_atoms_radii: bool = false) -> void:
 # This method does not change the hovered / highlight status, use _refresh_atom()
 # to update the complete state.
 func refresh_atoms_color(in_atoms: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id: int in in_atoms:
 		var current_color: Color = _segmented_multimesh.get_particle_color(atom_id)
 		var additional_color: Color = _segmented_multimesh.get_particle_additional_data(atom_id)
@@ -205,7 +259,7 @@ func refresh_atoms_color(in_atoms: PackedInt32Array) -> void:
 
 
 func refresh_atoms_visibility(in_atoms_ids: PackedInt32Array) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id: int in in_atoms_ids:
 		if not _segmented_multimesh.is_external_id_known(atom_id):
 			continue
@@ -222,7 +276,7 @@ func refresh_bonds_visibility(_in_bonds_ids: PackedInt32Array) -> void:
 
 
 func refresh_all() -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id: int in related_nanostructure.get_valid_atoms():
 		_refresh_atom(atom_id)
 
@@ -233,7 +287,7 @@ func clear() -> void:
 
 
 func show() -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	_segmented_multimesh.set_material_override(_material)
 	
 	_segmented_multimesh.show()
@@ -296,7 +350,7 @@ func highlight_atoms(in_atoms_ids: PackedInt32Array,
 func lowlight_atoms(in_atoms_ids: PackedInt32Array, 
 			_in_bonds_released_from_partial_influence: PackedInt32Array = PackedInt32Array(),
 			_new_partially_influenced_bonds: PackedInt32Array = PackedInt32Array()) -> void:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	for atom_id in in_atoms_ids:
 		assert(related_nanostructure.is_atom_valid(atom_id), "atempt to lowlight a non existing atom")
 		if not _highlighted_atoms.get(atom_id, false):
@@ -308,7 +362,7 @@ func lowlight_atoms(in_atoms_ids: PackedInt32Array,
 func _refresh_atom(in_atom_id: int, scale_factor: float = BASE_SCALE) -> void:
 	assert(_segmented_multimesh.is_external_id_known(in_atom_id), "Atempt to refresh non existing atom. Ensure
 		this operation is performed at right time in the context of NanoStructure.[start/end]_edit() call. ")
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id)
+	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var atom_position: Vector3 = related_nanostructure.atom_get_position(in_atom_id)
 	var atom_atomic_number: int = related_nanostructure.atom_get_atomic_number(in_atom_id)
 	var data: ElementData = PeriodicTable.get_by_atomic_number(atom_atomic_number)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
@@ -30,6 +30,11 @@ func build(in_structure_context: StructureContext) -> void:
 	_spring_renderer.initialize(in_structure_context)
 
 
+func build_for_preview(_in_nano_structure: NanoStructure) -> void:
+	# Previews doesn't use springs
+	pass
+
+
 func add_springs(in_springs: PackedInt32Array) -> void:
 	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
 	var nano_struct: NanoStructure = structure_context.nano_structure
@@ -261,6 +266,9 @@ func handle_editable_structures_changed(in_new_editable_structure_contexts: Arra
 
 
 func _update_is_selectable_uniform() -> void:
+	if _is_preview:
+		# No springs in structure previews
+		return
 	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
 	var is_editable: bool = structure_context.is_editable()
 	var global_color: Color = Color(COLOR_EDITABLE, 1.0) if is_editable else Color(COLOR_NON_EDITABLE, 1.0)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -51,23 +51,25 @@ func _init_material_uniforms() -> void:
 
 
 func _update_is_selectable_uniform() -> void:
+	if _is_preview:
+		_capsule_material.set_selectable(true)
+		return
 	var _structure_context: StructureContext = _workspace_context.get_structure_context(_related_structure_id)
 	var is_editable: bool = _structure_context.is_editable()
 	_capsule_material.set_selectable(is_editable)
 
 
-func _calculate_bond_transform(in_bond: Vector3i) -> Transform3D:
-	var related_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+func _calculate_bond_transform(in_nano_structure: AtomicStructure, in_bond: Vector3i) -> Transform3D:
 	var bond_order: int = in_bond.z
 	var first_atom_id: int = in_bond.x
 	var second_atom_id: int = in_bond.y
-	var first_atom_position: Vector3 = related_structure.atom_get_position(first_atom_id)
-	var second_atom_position: Vector3 = related_structure.atom_get_position(second_atom_id)
+	var first_atom_position: Vector3 = in_nano_structure.atom_get_position(first_atom_id)
+	var second_atom_position: Vector3 = in_nano_structure.atom_get_position(second_atom_id)
 	var distance_between_atoms: float = first_atom_position.distance_to(second_atom_position)
 	var dir_from_first_to_second: Vector3 = first_atom_position.direction_to(second_atom_position)
 	var up_vector: Vector3 = StickRepresentation._calc_up_vect_for_single_bond(dir_from_first_to_second) if bond_order == 1 else \
 			StickRepresentation._calc_up_vector_for_higher_bond(first_atom_id, second_atom_id, first_atom_position,
-					second_atom_position, related_structure)
+					second_atom_position, in_nano_structure)
 	var particle_position: Vector3 = (first_atom_position + second_atom_position) / 2.0
 	var new_transform: Transform3D = Transform3D(Basis(), particle_position)
 	new_transform = new_transform.looking_at(first_atom_position, up_vector)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
@@ -30,6 +30,11 @@ func build(in_structure_context: StructureContext) -> void:
 	_ensure_material_configured()
 
 
+func build_for_preview(in_nano_structure: NanoStructure) -> void:
+	super.build_for_preview(in_nano_structure)
+	_ensure_material_configured_for_preview(in_nano_structure)
+
+
 func show() -> void:
 	super.show()
 	_ensure_material_configured()
@@ -75,17 +80,37 @@ func _ensure_material_configured() -> void:
 	_material_bond_3.set_gizmo_rotation(Basis())
 
 
-func _calculate_bond_transform(in_bond: Vector3i) -> Transform3D:
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+func _ensure_material_configured_for_preview(in_nano_structure: AtomicStructure) -> void:
+	_single_stick_multimesh.set_material_override(_material_bond_1)
+	_double_stick_multimesh.set_material_override(_material_bond_2)
+	_tripple_stick_multimesh.set_material_override(_material_bond_3)
+	_single_stick_multimesh.set_material_instance_uniform(INSTANCE_UNIFORM_BASE_SCALE, 1.0)
+	_double_stick_multimesh.set_material_instance_uniform(INSTANCE_UNIFORM_BASE_SCALE, 0.75)
+	_tripple_stick_multimesh.set_material_instance_uniform(INSTANCE_UNIFORM_BASE_SCALE, 0.55)
+	_material_bond_1.set_gizmo_rotation(Basis())
+	_material_bond_2.set_gizmo_rotation(Basis())
+	_material_bond_3.set_gizmo_rotation(Basis())
+	# refresh_atoms_sizes()
+	_shader_scale_factor = Representation.get_atom_scale_factor(in_nano_structure.get_representation_settings())
+	_apply_scale_factor(_shader_scale_factor)
+	_refresh_bond_partial_influence_status(in_nano_structure.get_valid_bonds())
+	#_update_is_selectable_uniform()
+	var is_editable: bool = true # Preview is always tagged "editable"
+	_material_bond_1.set_selectable(is_editable)
+	_material_bond_2.set_selectable(is_editable)
+	_material_bond_3.set_selectable(is_editable)
+
+
+func _calculate_bond_transform(in_nano_structure: AtomicStructure, in_bond: Vector3i) -> Transform3D:
 	var bond_order: int = in_bond.z
 	var first_atom_id: int = in_bond.x
 	var second_atom_id: int = in_bond.y
-	var first_atom_position: Vector3 = related_nanostructure.atom_get_position(first_atom_id)
-	var second_atom_position: Vector3 = related_nanostructure.atom_get_position(second_atom_id)
+	var first_atom_position: Vector3 = in_nano_structure.atom_get_position(first_atom_id)
+	var second_atom_position: Vector3 = in_nano_structure.atom_get_position(second_atom_id)
 	var dir_from_first_to_second: Vector3 = first_atom_position.direction_to(second_atom_position)
 	var up_vector: Vector3 = StickRepresentation._calc_up_vect_for_single_bond(dir_from_first_to_second) if bond_order == 1 else \
 			StickRepresentation._calc_up_vector_for_higher_bond(first_atom_id, second_atom_id, first_atom_position,
-					second_atom_position, related_nanostructure)
+					second_atom_position, in_nano_structure)
 	var _particle_transform: Transform3D = calculate_transform_for_bond(first_atom_position,
 			second_atom_position, up_vector)
 	return _particle_transform

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
@@ -43,7 +43,7 @@ func _initialize() -> void:
 	return
 
 
-func _calculate_bond_transform(_in_bond: Vector3i) -> Transform3D:
+func _calculate_bond_transform(_in_nano_structure: AtomicStructure, _in_bond: Vector3i) -> Transform3D:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
 	return Transform3D()
 
@@ -69,7 +69,7 @@ func build(in_structure_context: StructureContext) -> void:
 			bond_state.is_first_atom_selected = bond_data.x in selected_atoms
 			bond_state.is_second_atom_selected = bond_data.y in selected_atoms
 			bond_state.is_hydrogen = related_nanostructure.atom_is_any_hydrogen([bond_data.x, bond_data.y])
-			_create_bond(bond_id, bond_state)
+			_create_bond(related_nanostructure, bond_id, bond_state)
 	
 	_single_stick_multimesh.bake()
 	_double_stick_multimesh.bake()
@@ -79,9 +79,42 @@ func build(in_structure_context: StructureContext) -> void:
 	apply_theme(representation_settings.get_theme())
 
 
+func build_for_preview(in_nano_structure: NanoStructure) -> void:
+	assert(is_instance_valid(in_nano_structure))
+	_is_preview = true
+	_preview_instance_id = in_nano_structure.get_instance_id()
+	clear()
+	
+	var bonds_ids: PackedInt32Array = in_nano_structure.get_bonds_ids()
+	var bond_state := Representation.InstanceState.new()
+	for bond_id in bonds_ids:
+		if in_nano_structure.is_bond_valid(bond_id):
+			bond_state.is_visible = not in_nano_structure.is_bond_hidden_by_user(bond_id)
+			var bond_data: Vector3i = in_nano_structure.get_bond(bond_id)
+			bond_state.is_hydrogen = in_nano_structure.atom_is_any_hydrogen([bond_data.x, bond_data.y])
+			_create_bond(in_nano_structure, bond_id, bond_state)
+	
+	_single_stick_multimesh.bake()
+	_double_stick_multimesh.bake()
+	_tripple_stick_multimesh.bake()
+	
+	var representation_settings: RepresentationSettings = in_nano_structure.get_representation_settings()
+	apply_theme(representation_settings.get_theme())
+
+
+func _get_related_atomic_structure() -> AtomicStructure:
+	if _is_preview:
+		return instance_from_id(_preview_instance_id)
+	return _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+
+
 func _update_is_selectable_uniform() -> void:
-	var structure_context: StructureContext = _workspace_context.get_structure_context(_related_structure_id)
-	var is_editable: bool = structure_context.is_editable()
+	var is_editable: bool = false
+	if _is_preview:
+		is_editable = true
+	else:
+		var structure_context: StructureContext = _workspace_context.get_structure_context(_related_structure_id)
+		is_editable = structure_context.is_editable()
 	_material_bond_1.set_selectable(is_editable)
 	_material_bond_2.set_selectable(is_editable)
 	_material_bond_3.set_selectable(is_editable)
@@ -93,21 +126,20 @@ func _update_is_hovered_uniform(in_is_hovered: bool) -> void:
 	_material_bond_3.set_hovered(in_is_hovered)
 
 
-func _create_bond(bond_id: int, in_bond_state: Representation.InstanceState) -> ParticleID:
-	var related_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id) as AtomicStructure
-	var bond: Vector3i = related_structure.get_bond(bond_id)
-	var particle_transform: Transform3D = _calculate_bond_transform(bond)
+func _create_bond(in_nano_structure: AtomicStructure, bond_id: int, in_bond_state: Representation.InstanceState) -> ParticleID:
+	var bond: Vector3i = in_nano_structure.get_bond(bond_id)
+	var particle_transform: Transform3D = _calculate_bond_transform(in_nano_structure, bond)
 	var first_atom_id: int = bond.x
 	var second_atom_id: int = bond.y
 	var bond_order: int =  bond.z
-	var first_atom_type: int = related_structure.atom_get_atomic_number(first_atom_id)
-	var second_atom_type: int = related_structure.atom_get_atomic_number(second_atom_id)
+	var first_atom_type: int = in_nano_structure.atom_get_atomic_number(first_atom_id)
+	var second_atom_type: int = in_nano_structure.atom_get_atomic_number(second_atom_id)
 	var first_atom_periodic_table_data: ElementData = PeriodicTable.get_by_atomic_number(first_atom_type)
 	var second_atom_periodic_table_data: ElementData = PeriodicTable.get_by_atomic_number(second_atom_type)
-	var first_color: Color = StickRepresentation.get_bond_color(first_atom_id, related_structure)
-	var second_color: Color = StickRepresentation.get_bond_color(second_atom_id, related_structure)
-	var first_atom_radius: float = get_atom_radius(first_atom_periodic_table_data, related_structure.get_representation_settings())
-	var second_atom_radius: float = get_atom_radius(second_atom_periodic_table_data, related_structure.get_representation_settings())
+	var first_color: Color = StickRepresentation.get_bond_color(first_atom_id, in_nano_structure)
+	var second_color: Color = StickRepresentation.get_bond_color(second_atom_id, in_nano_structure)
+	var first_atom_radius: float = get_atom_radius(first_atom_periodic_table_data, in_nano_structure.get_representation_settings())
+	var second_atom_radius: float = get_atom_radius(second_atom_periodic_table_data, in_nano_structure.get_representation_settings())
 	var smaller_atom_radius: float = min(first_atom_radius, second_atom_radius)
 	first_color.a = in_bond_state.to_float()
 	second_color.a = smaller_atom_radius
@@ -169,6 +201,8 @@ func highlight_atoms(in_atoms_ids: PackedInt32Array, \
 
 
 func _refresh_bond_partial_influence_status(new_partially_influenced_bonds: PackedInt32Array) -> void:
+	if _is_preview:
+		return
 	var structure_context: StructureContext = _workspace_context.get_structure_context(_related_structure_id)
 	var related_structure: AtomicStructure = structure_context.nano_structure as AtomicStructure
 	for bond_id: int in new_partially_influenced_bonds:
@@ -316,7 +350,7 @@ func remove_atoms(_in_atoms_ids: PackedInt32Array) -> void:
 
 
 func refresh_atoms_positions(in_atoms_ids: PackedInt32Array) -> void:
-	var related_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+	var related_structure: AtomicStructure = _get_related_atomic_structure()
 	var already_served_bonds: Dictionary = {}
 	for atom_id in in_atoms_ids:
 		var atom_bonds: PackedInt32Array = related_structure.atom_get_bonds(atom_id)
@@ -328,7 +362,7 @@ func refresh_atoms_positions(in_atoms_ids: PackedInt32Array) -> void:
 			var particle_id: ParticleID = _bond_id_to_particle_id[bond_id]
 			var related_multimesh: SegmentedMultimesh = _bond_order_to_segmented_multimesh[particle_id.bond_order]
 			var bond: Vector3i = related_structure.get_bond(bond_id)
-			var bond_transform: Transform3D = _calculate_bond_transform(bond)
+			var bond_transform: Transform3D = _calculate_bond_transform(related_structure, bond)
 			related_multimesh.update_particle_transform(particle_id.bond_id, bond_transform)
 			assert(bond.z == particle_id.bond_order, "Desynchronization between NanoStructure and Representation")
 	
@@ -345,7 +379,7 @@ func refresh_atoms_locking(_in_atoms_ids: PackedInt32Array) -> void:
 
 
 func refresh_atoms_atomic_number(in_atoms_and_atomic_numbers: Array[Vector2i]) -> void:
-	var related_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+	var related_structure: AtomicStructure = _get_related_atomic_structure()
 	var bonds_to_update: Dictionary = {
 		# bond_id<int> = true
 	}
@@ -360,14 +394,14 @@ func refresh_atoms_atomic_number(in_atoms_and_atomic_numbers: Array[Vector2i]) -
 
 
 func refresh_atoms_sizes() -> void:
-	var related_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+	var related_structure: AtomicStructure = _get_related_atomic_structure()
 	_shader_scale_factor = Representation.get_atom_scale_factor(related_structure.get_representation_settings())
 	_apply_scale_factor(_shader_scale_factor)
 	refresh_all()
 
 
 func refresh_atoms_color(in_atoms: PackedInt32Array) -> void:
-	var related_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+	var related_structure: AtomicStructure = _get_related_atomic_structure()
 	var bonds_to_update: Dictionary = {
 		# bond_id<int> = true
 	}
@@ -396,7 +430,7 @@ func refresh_atoms_visibility(_in_atoms_ids: PackedInt32Array) -> void:
 
 
 func refresh_bonds_visibility(in_bonds_ids: PackedInt32Array) -> void:
-	var related_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+	var related_structure: AtomicStructure = _get_related_atomic_structure()
 	for bond_id: int in in_bonds_ids:
 		if not bond_id in _bond_id_to_particle_id:
 			continue
@@ -412,7 +446,7 @@ func refresh_bonds_visibility(in_bonds_ids: PackedInt32Array) -> void:
 
 
 func refresh_all() -> void:
-	var related_structure: AtomicStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+	var related_structure: AtomicStructure = _get_related_atomic_structure()
 	_refresh_bond_partial_influence_status(related_structure.get_valid_bonds())
 
 
@@ -457,7 +491,7 @@ func add_bonds(new_bonds: PackedInt32Array) -> void:
 		bond_state.is_first_atom_selected = bond_data.x in selected_atoms
 		bond_state.is_second_atom_selected = bond_data.y in selected_atoms
 		bond_state.is_hydrogen = atomic_structure.atom_is_any_hydrogen([bond_data.x, bond_data.y])
-		_create_bond(bond_id, bond_state)
+		_create_bond(atomic_structure, bond_id, bond_state)
 	_single_stick_multimesh.rebuild_if_needed()
 	_double_stick_multimesh.rebuild_if_needed()
 	_tripple_stick_multimesh.rebuild_if_needed()
@@ -504,7 +538,7 @@ func bonds_changed(changed_bonds: PackedInt32Array) -> void:
 			bond_state.is_hydrogen = atomic_structure.atom_is_any_hydrogen([bond.x, bond.y])
 			
 			#
-			_create_bond(bond_id, bond_state)
+			_create_bond(atomic_structure, bond_id, bond_state)
 			
 			#
 			var new_multimesh: SegmentedMultimesh = _bond_order_to_segmented_multimesh[new_bond_order]
@@ -557,7 +591,7 @@ func refresh_atomic_numbers_of_bond_atoms(changed_bonds: PackedInt32Array) -> vo
 		bond_state.is_hydrogen = related_structure.atom_is_any_hydrogen([bond.x, bond.y])
 		first_color.a = bond_state.to_float()
 		second_color.a = smaller_atom_radius
-		var particle_transform: Transform3D = _calculate_bond_transform(bond)
+		var particle_transform: Transform3D = _calculate_bond_transform(related_structure, bond)
 		segmented_multimesh.update_particle_transform_and_color(bond_id, particle_transform, first_color, second_color)
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sticks_single_atom_representation/sticks_and_single_atom_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sticks_single_atom_representation/sticks_and_single_atom_representation.gd
@@ -14,7 +14,17 @@ func _notification(in_what: int) -> void:
 func build(in_structure_context: StructureContext) -> void:
 	_single_atom_representation.build(in_structure_context)
 	_stick_representation.build(in_structure_context)
-	
+
+
+func build_for_preview(in_nano_structure: NanoStructure) -> void:
+	_is_preview = true
+	_preview_instance_id = in_nano_structure.get_instance_id()
+	_single_atom_representation.build_for_preview(in_nano_structure)
+	_stick_representation.build_for_preview(in_nano_structure)
+
+
+
+
 
 func highlight_atoms(in_atoms_ids: PackedInt32Array, new_partially_influenced_bonds: PackedInt32Array,
 			in_bonds_released_from_partial_influence: PackedInt32Array) -> void:

--- a/godot_project/editor/rendering/structure_preview/structure_preview.gd
+++ b/godot_project/editor/rendering/structure_preview/structure_preview.gd
@@ -18,9 +18,7 @@ var _transparency: float = DEFAULT_PREVIEW_TRANSPARENCY
 ## by calling [code]set_structure[/code].
 var _auto_update_preview: bool = true 
 
-var _preview_workspace_context: WorkspaceContext
-var _preview_workspace: Workspace
-var _preview_structure_context: StructureContext
+var _structure: AtomicStructure
 var _enabled_on_preview_viewport: bool = false
 
 
@@ -36,6 +34,8 @@ func _ready_deferred() -> void:
 	workspace_context.aborted_creating_object.connect(_on_workspace_context_aborted_creating_object)
 	var representation_settings: RepresentationSettings = workspace_context.workspace.representation_settings
 	representation_settings.changed.connect(_on_representation_settings_changed.bind(representation_settings))
+	representation_settings.atom_labels_visibility_changed.connect(_on_representation_settings_atom_labels_visibility_changed)
+	representation_settings.bond_visibility_changed.connect(_on_representation_settings_bond_visibility_changed)
 
 
 func enable_on_preview_viewport() -> void:
@@ -56,31 +56,18 @@ func set_structure(in_structure: NanoStructure) -> void:
 	_atomic_structure_renderer = AtomicStructureRendererScn.instantiate() as AtomicStructureRenderer
 	add_child(_atomic_structure_renderer)
 	
-	if is_instance_valid(_preview_workspace_context):
-		_preview_workspace_context.queue_free()
-	if is_instance_valid(_preview_structure_context):
-		_preview_structure_context.queue_free()
-	
-	var structure_copy: NanoStructure = NanoMolecularStructure.new()
-	structure_copy.apply_state_snapshot(in_structure.create_state_snapshot())
-	structure_copy.set_representation_settings(in_structure.get_representation_settings())
-	_preview_workspace_context = load(WorkspaceContextScn).instantiate()
-	_preview_workspace = Workspace.new()
-	_preview_workspace.representation_settings = in_structure.get_representation_settings()
-	_preview_workspace.add_structure(structure_copy)
-	add_child(_preview_workspace_context)
-	_preview_workspace_context.initialize(_preview_workspace)
-	_preview_structure_context = _preview_workspace_context.get_nano_structure_context(structure_copy)
+	_structure = NanoMolecularStructure.new()
+	_structure.apply_state_snapshot(in_structure.create_state_snapshot())
+	_structure.set_representation_settings(in_structure.get_representation_settings())
 	
 	var representation_settings: RepresentationSettings = in_structure.get_representation_settings()
-	_atomic_structure_renderer.build(_preview_structure_context, representation_settings.get_rendering_representation())
+	_atomic_structure_renderer.build_for_preview(_structure, representation_settings.get_rendering_representation())
 	_atomic_structure_renderer.set_transparency(_transparency)
 	
 	var display_labels: bool = representation_settings.get_display_atom_labels()
-	if display_labels:
-		_atomic_structure_renderer.ensure_label_rendering_on()
-	else:
-		_atomic_structure_renderer.ensure_label_rendering_off()
+	var display_bonds: bool = representation_settings.get_display_bonds()
+	_on_representation_settings_atom_labels_visibility_changed(display_labels)
+	_on_representation_settings_bond_visibility_changed(display_bonds)
 	
 	_atomic_structure_renderer.apply_theme(representation_settings.get_theme())
 
@@ -103,6 +90,24 @@ func set_auto_update(enabled: bool) -> void:
 func _on_representation_settings_changed(in_representation_settings: RepresentationSettings) -> void:
 	if is_instance_valid(_atomic_structure_renderer):
 		_atomic_structure_renderer.change_representation(in_representation_settings.get_rendering_representation())
+
+
+func _on_representation_settings_atom_labels_visibility_changed(in_display_labels: bool) -> void:
+	if not is_instance_valid(_atomic_structure_renderer):
+		return
+	if in_display_labels:
+		_atomic_structure_renderer.ensure_label_rendering_on()
+	else:
+		_atomic_structure_renderer.ensure_label_rendering_off()
+
+
+func _on_representation_settings_bond_visibility_changed(in_display_bonds: bool) -> void:
+	if not is_instance_valid(_atomic_structure_renderer):
+		return
+	if in_display_bonds:
+		_atomic_structure_renderer.ensure_bond_rendering_on()
+	else:
+		_atomic_structure_renderer.ensure_bond_rendering_off()
 
 
 func _on_workspace_context_started_creating_object(workspace_context: WorkspaceContext) -> void:


### PR DESCRIPTION
- Removed the dependency of a dummy Workspace, WorkspaceContext, and StructureContext.
- This will no longer create orphan nodes and an unused WorkspaceMainView that was leanking every time a new structure was loaded.

Tasks:
- BUG: **StructurePreview** is creating a bunch of orphan nodes that are never freed
- BUG: Preview of small molecules and particle emitters looks dimmed out (Regression from task)