### PR TITLE
Ensure workspace always fit inside the simulation boundaries

### DIFF
--- a/godot_project/autoloads/openmm/openmm_payload.gd
+++ b/godot_project/autoloads/openmm/openmm_payload.gd
@@ -91,6 +91,7 @@ func add_structure(structure: AtomicStructure, atom_ids: PackedInt32Array,
 	for atom_id in atom_ids:
 		var is_atom_locked: bool = lock_atoms and structure.atom_is_locked(atom_id)
 		_store_atom_in_byte_array(structure, atom_id, is_atom_locked, original_to_request_atom_id_map)
+	_expand_aabb_to_aabb(structure.get_aabb(AtomicStructure.AABB_BoundsType.ContactRadius))
 
 	for bond_id in bond_ids:
 		_store_bond_in_byte_array(structure, bond_id, original_to_request_atom_id_map)
@@ -194,7 +195,6 @@ func _store_atom_in_byte_array(structure: AtomicStructure, in_atom_id: int,
 	# chunk[8-15]:  position Y
 	# chunk[16-23]: position Z
 	var atom_pos: Vector3 = structure.atom_get_position(in_atom_id)
-	_expand_aabb_to(atom_pos)
 	raw_initial_positions.push_back(atom_pos)
 	if nudge_atoms_fix_enabled and not in_atom_locked:
 		atom_pos += _create_random_nudge()
@@ -242,8 +242,7 @@ func add_shape(in_shape: NanoShape) -> void:
 	shape_dict[&"transform"] = transform
 	other_objects_data[in_shape.int_guid] = JSON.stringify(shape_dict, "\t")
 	var shape_aabb: AABB = in_shape.get_aabb()
-	_expand_aabb_to(shape_aabb.position)
-	_expand_aabb_to(shape_aabb.end)
+	_expand_aabb_to_aabb(shape_aabb)
 
 
 func add_motor(in_motor: NanoVirtualMotor) -> void:
@@ -265,7 +264,7 @@ func add_motor(in_motor: NanoVirtualMotor) -> void:
 		var value: Variant = in_motor.get_parameters().get(prop_info.name)
 		motor_dict.parameters[prop_info.name] = value
 	other_objects_data[in_motor.int_guid] = JSON.stringify(motor_dict, "\t")
-	_expand_aabb_to(position)
+	_expand_aabb_to_aabb(in_motor.get_aabb())
 
 
 func add_emitter(in_emitter: NanoParticleEmitter) -> void:
@@ -314,7 +313,7 @@ func add_emitter(in_emitter: NanoParticleEmitter) -> void:
 	# Calculate resting position for disabled instances
 	# First lets find the size of each individual molecule
 	const SAFE_MARGIN = 1.0
-	var molecule_size: Vector3 = in_emitter.get_parameters().get_molecule_template().get_aabb().grow(SAFE_MARGIN).size
+	var molecule_size: Vector3 = in_emitter.get_parameters().get_molecule_template().get_aabb(AtomicStructure.AABB_BoundsType.ContactRadius).grow(SAFE_MARGIN).size
 	var curr_pos := Vector3.ZERO
 	for space: AABB in _extra_ocupied_space:
 		curr_pos.y -= space.size.y
@@ -339,7 +338,7 @@ func add_emitter(in_emitter: NanoParticleEmitter) -> void:
 	emitter_dict[&"atoms_list"] = payload_atom_ids
 	emitter_dict[&"atom_rest_position_buffer"] = atom_rest_position_buffer
 	other_objects_data[in_emitter.int_guid] = JSON.stringify(emitter_dict, "\t")
-	_expand_aabb_to(position)
+	_expand_aabb_to_aabb(in_emitter.get_aabb(AtomicStructure.AABB_BoundsType.ContactRadius))
 
 
 func _advance_pos(in_curr_pos: Vector3, in_molecule_size: Vector3) -> Vector3:
@@ -402,10 +401,20 @@ func _add_anchor(in_anchor: NanoVirtualAnchor) -> void:
 	anchor_dict[&"anchor_id"] = in_anchor.int_guid
 	anchor_dict[&"position"] = [position.x, position.y, position.z]
 	other_objects_data[in_anchor.int_guid] = JSON.stringify(anchor_dict, "\t")
-	_expand_aabb_to(position)
+	_expand_aabb_to_aabb(in_anchor.get_aabb())
 
 
-func _expand_aabb_to(in_to_point: Vector3) -> void:
+
+func _expand_aabb_to_aabb(in_aabb: AABB) -> void:
+	if calculated_aabb == AABB():
+		calculated_aabb = in_aabb
+	else:
+		in_aabb = in_aabb.abs()
+		_expand_aabb_to_pos(in_aabb.position)
+		_expand_aabb_to_pos(in_aabb.end)
+
+
+func _expand_aabb_to_pos(in_to_point: Vector3) -> void:
 	if calculated_aabb == AABB():
 		calculated_aabb.position = in_to_point
 	else:

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_settings_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_settings_panel.gd
@@ -1,6 +1,11 @@
 extends DynamicContextControl
 
 const _MENU_ITEM_SHOW_USER_FILES: int = 0
+const _MIN_SIZE_LABEL_MODULATE: Dictionary = {
+	true : Color.WHITE,
+	false : Color8(223, 223, 223),
+	&"simulating" : Color8(145, 136, 164),
+}
 
 var _force_field_option_button: OptionButton
 var _advanced_menu_button: MenuButton
@@ -17,6 +22,8 @@ var _integrator_option_button: OptionButton
 var _simulation_box_unconstrained_button: CheckBox
 var _simulation_box_constrained_button: CheckBox
 var _simulation_box_size_slider: SpinBoxSlider
+var _simulation_box_min_size_label: Label
+var _simulation_box_min_size_slider: SpinBoxSlider
 
 
 var _workspace_context: WorkspaceContext
@@ -48,10 +55,13 @@ func _notification(what: int) -> void:
 		_simulation_box_unconstrained_button = %SimulationBoxUnconstrainedButton as CheckBox
 		_simulation_box_constrained_button = %SimulationBoxConstrainedButton as CheckBox
 		_simulation_box_size_slider = %SimulationBoxSizeSlider as SpinBoxSlider
+		_simulation_box_min_size_label = %SimulationBoxMinSizeLabel as Label
+		_simulation_box_min_size_slider = %SimulationBoxMinSizeSlider as SpinBoxSlider
 		_advanced_options_checkbox.toggled.connect(_on_advanced_menu_button_toggled)
 		_integrator_option_button.item_selected.connect(_on_integrator_option_button_item_selected)
 		_simulation_box_unconstrained_button.toggled.connect(_on_simulation_box_unconstrained_button_toggled)
 		_simulation_box_size_slider.value_confirmed.connect(_on_simulation_box_size_slider_value_confirmed)
+		_simulation_box_min_size_slider.value_confirmed.connect(_on_simulation_box_min_size_slider_value_confirmed)
 
 
 func _ensure_initialized(in_workspace_context: WorkspaceContext) -> void:
@@ -83,6 +93,10 @@ func _ensure_initialized(in_workspace_context: WorkspaceContext) -> void:
 		var box_size_percentage: float = _workspace_context.workspace.simulation_settings_advanced_constrained_simulation_box_size_percentage
 		_simulation_box_size_slider.set_value_no_signal(box_size_percentage)
 		_simulation_box_size_slider.editable = use_constrained_simulation_box
+		var box_min_size: float = _workspace_context.workspace.simulation_settings_advanced_constrained_simulation_minimum_size
+		_simulation_box_min_size_slider.set_value_no_signal(box_min_size)
+		_simulation_box_min_size_slider.editable = use_constrained_simulation_box
+		_simulation_box_min_size_label.self_modulate = _MIN_SIZE_LABEL_MODULATE[use_constrained_simulation_box]
 		_update_advanced_settings_ui()
 
 
@@ -165,12 +179,20 @@ func _on_simulation_box_unconstrained_button_toggled(_in_pressed: bool) -> void:
 	var use_constrained_simulation_box: bool = _simulation_box_constrained_button.button_pressed
 	_workspace_context.workspace.simulation_settings_advanced_use_constrained_simulation_box = use_constrained_simulation_box
 	_simulation_box_size_slider.editable = use_constrained_simulation_box
+	_simulation_box_min_size_slider.editable = use_constrained_simulation_box
+	_simulation_box_min_size_label.self_modulate = _MIN_SIZE_LABEL_MODULATE[use_constrained_simulation_box]
 
 
 func _on_simulation_box_size_slider_value_confirmed(in_value: float) -> void:
 	if _workspace_context == null or _workspace_context.workspace == null:
 		return
 	_workspace_context.workspace.simulation_settings_advanced_constrained_simulation_box_size_percentage = in_value
+
+
+func _on_simulation_box_min_size_slider_value_confirmed(in_value: float) -> void:
+	if _workspace_context == null or _workspace_context.workspace == null:
+		return
+	_workspace_context.workspace.simulation_settings_advanced_constrained_simulation_minimum_size = in_value
 
 
 func _on_workspace_context_simulation_started() -> void:
@@ -186,6 +208,8 @@ func _on_workspace_context_simulation_started() -> void:
 	_simulation_box_unconstrained_button.disabled = true
 	_simulation_box_constrained_button.disabled = true
 	_simulation_box_size_slider.editable = false
+	_simulation_box_min_size_slider.editable = false
+	_simulation_box_min_size_label.self_modulate = _MIN_SIZE_LABEL_MODULATE[&"simulating"]
 
 
 func _on_workspace_context_simulation_finished() -> void:
@@ -201,6 +225,8 @@ func _on_workspace_context_simulation_finished() -> void:
 	_simulation_box_unconstrained_button.disabled = false
 	_simulation_box_constrained_button.disabled = false
 	_simulation_box_size_slider.editable = _simulation_box_constrained_button.button_pressed
+	_simulation_box_min_size_slider.editable = _simulation_box_constrained_button.button_pressed
+	_simulation_box_min_size_label.self_modulate = _MIN_SIZE_LABEL_MODULATE[_simulation_box_constrained_button.button_pressed]
 
 
 func _update_forcefields_list() -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_settings_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_settings_panel.tscn
@@ -164,8 +164,9 @@ text = "Simulation Volume Optimization"
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer"]
+[node name="VBoxContainer" type="GridContainer" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer"]
 layout_mode = 2
+columns = 2
 
 [node name="SimulationBoxUnconstrainedButton" type="CheckBox" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
@@ -174,16 +175,16 @@ button_pressed = true
 button_group = SubResource("ButtonGroup_sjw3i")
 text = "Disabled"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer"]
+[node name="Empty" type="Control" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="SimulationBoxConstrainedButton" type="CheckBox" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+[node name="SimulationBoxConstrainedButton" type="CheckBox" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 button_group = SubResource("ButtonGroup_sjw3i")
 text = "Current simulation volume *"
 
-[node name="SimulationBoxSizeSlider" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer" instance=ExtResource("4_y5kv6")]
+[node name="SimulationBoxSizeSlider" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer" instance=ExtResource("4_y5kv6")]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
@@ -194,6 +195,25 @@ value = 125.0
 allow_greater = true
 editable = false
 suffix = "%"
+metadata/_custom_type_script = "uid://ci2a678xscx2c"
+
+[node name="SimulationBoxMinSizeLabel" type="Label" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Minimum volume size    "
+horizontal_alignment = 2
+
+[node name="SimulationBoxMinSizeSlider" parent="AdvancedOptionsPanel/VBoxContainer/PanelContainer/VBoxContainer" instance=ExtResource("4_y5kv6")]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+size_flags_horizontal = 1
+max_value = 4.0
+step = 0.1
+value = 1.0
+allow_greater = true
+editable = false
+suffix = "nm"
 metadata/_custom_type_script = "uid://ci2a678xscx2c"
 
 [node name="AdvancedSettingsInfoLabel" parent="AdvancedOptionsPanel/VBoxContainer" instance=ExtResource("2_i1oqk")]

--- a/godot_project/project_workspace/structs/nano_particle_emitter.gd
+++ b/godot_project/project_workspace/structs/nano_particle_emitter.gd
@@ -306,10 +306,16 @@ func get_icon() -> Texture2D:
 	return preload("res://editor/icons/MolecularStructure_x28.svg")
 
 
-func get_aabb() -> AABB:
-	var aabb := AABB(_transform.origin, Vector3())
-	aabb = aabb.grow(0.5)
-	return aabb.abs()
+func get_aabb(in_bounds_type := AtomicStructure.AABB_BoundsType.AtomsPositions) -> AABB:
+	if _parameters == null or _parameters.get_molecule_template() == null:
+		var aabb := AABB(_transform.origin, Vector3())
+		aabb = aabb.grow(0.5)
+		return aabb.abs()
+	else:
+		var aabb: AABB = _parameters.get_molecule_template().get_aabb(in_bounds_type)
+		# Move the box relative to particle emitter position
+		aabb.position = _transform.origin - aabb.size / 2.0
+		return aabb
 
 
 func is_particle_emitter_within_screen_rect(in_camera: Camera3D, screen_rect: Rect2i) -> bool:

--- a/godot_project/project_workspace/workspace.gd
+++ b/godot_project/project_workspace/workspace.gd
@@ -115,6 +115,8 @@ static var instance_counter: int = 0
 ## to calculate periodic box by growing the existing AABB by this percentage
 @export_range(100.0, 200.0, 1.0, "or_greater") var simulation_settings_advanced_constrained_simulation_box_size_percentage: float = 125.0
 
+@export_range(0.0, 4.0, 0.1, "or_greater") var simulation_settings_advanced_constrained_simulation_minimum_size: float = 1.0
+
 @export_group("", "") # end of "Advanced Simulation Settings" group
 
 ## RandomNumberGenerator is used to create unique IDs, state and seed are stored

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -515,14 +515,19 @@ func start_simulating(in_simulation_data: SimulationData) -> void:
 
 func get_simulation_boundaries() -> AABB:
 	assert(is_simulating(), "There's not an active simulation")
-	var aabb: AABB = _simulation.original_payload.calculated_aabb
+	var aabb: AABB = _simulation.original_payload.calculated_aabb.abs()
 	if workspace != null:
 		var grow_factor: float = \
 			workspace.simulation_settings_advanced_constrained_simulation_box_size_percentage / 100.0
 		var grown_aabb := AABB()
 		grown_aabb.size = aabb.size * grow_factor
 		grown_aabb.position = aabb.get_center() - (grown_aabb.size * 0.5)
-		aabb = grown_aabb
+		aabb = grown_aabb.abs()
+		var minimum_boundary_size: float = workspace.simulation_settings_advanced_constrained_simulation_minimum_size
+		if aabb.get_shortest_axis_size() < minimum_boundary_size:
+			var center: Vector3 = aabb.get_center()
+			var size: Vector3 = aabb.size.max(Vector3.ONE * minimum_boundary_size)
+			aabb = AABB(center - size / 2.0, size)
 	return aabb
 
 


### PR DESCRIPTION
- Adjusted how the boundaries AABB is calculated
- Included van del waals size of the particles in the molecule size
- Added a 'Minimum Size'  setting along with percentage of workspace. Defaulted to 1 nanometer

Tasks:
- SUGGESTION: Add a minimum size to "Simulation Volume Optimization"
- **Part 1 of** CRASH running simulation with only emitter in it