### PR TITLE
Fix crash when continuouslt applying and undoing simulation state with Particle Emitters

### DIFF
--- a/godot_project/project_workspace/structs/nano_particle_emitter.gd
+++ b/godot_project/project_workspace/structs/nano_particle_emitter.gd
@@ -355,8 +355,8 @@ func apply_state_snapshot(in_state_snapshot: Dictionary, in_with_instances: bool
 	if _parameters == null:
 		_parameters = NanoParticleEmitterParameters.new()
 	_parameters.apply_state_snapshot(in_state_snapshot["_parameters_snapshot"])
-	_instances_atom_ids = in_state_snapshot["_instances_atom_ids"]
-	_instances_bond_ids = in_state_snapshot["_instances_bond_ids"]
+	_instances_atom_ids = in_state_snapshot["_instances_atom_ids"].duplicate(false)
+	_instances_bond_ids = in_state_snapshot["_instances_bond_ids"].duplicate(false)
 	var instances_group_id: int = in_state_snapshot["_instances_group_id"]
 	if instances_group_id == -1:
 		_instances_group = null


### PR DESCRIPTION
- when creating state snapshot, some arrays of internal state where duplicated
- However when applying the state back, the array was nto duplicated
- This created a scenario where the array stored in the Undo History could be indirectly modified, because was referenced both in snapshot_state and the PArticleEmitter object

Task: CRASH: Applying and undoing simulation state several times with a particle emitter