### PR TITLE
Hide the fixed size dot when too close to the camera

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
@@ -510,6 +510,7 @@ func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array) -> vo
 func set_transparency(in_transparency: float) -> void:
 	_transparency = in_transparency
 	_current_representation.set_transparency(in_transparency)
+	_fixed_size_representation.set_transparency(in_transparency)
 	_outdate_non_active_representations()
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/fixed_size_representation/assets/multimesh_fixed_size.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/fixed_size_representation/assets/multimesh_fixed_size.gdshader
@@ -10,7 +10,7 @@ render_mode unshaded;
 const float COLOR_ADDITIONAL_POWER = 0.05;
 
 uniform float size = 1.0;
-
+uniform float show_distance = 18.0; // Only visible if further than this distance in persective view.
 
 void vertex() {
 	// Fixed Size
@@ -23,12 +23,18 @@ void vertex() {
 		MODELVIEW_MATRIX[0] *= sc;
 		MODELVIEW_MATRIX[1] *= sc;
 		MODELVIEW_MATRIX[2] *= sc;
+		// Hide if the camera size is too small
+		VERTEX *= (h < 1.25) ? 0.0 : 1.0;
 	} else {
 		// Scale by depth.
 		sc = -(MODELVIEW_MATRIX)[3].z * size;
 		MODELVIEW_MATRIX[0] *= sc;
 		MODELVIEW_MATRIX[1] *= sc;
 		MODELVIEW_MATRIX[2] *= sc;
+		// Hide if too close to the camera
+		vec3 center_model_pos = (MODEL_MATRIX * vec4(vec3(0.0), 1.0)).xyz; 
+		float distance_to_camera = length(CAMERA_POSITION_WORLD - center_model_pos);
+		VERTEX *= (distance_to_camera < show_distance) ? 0.0 : 1.0;
 	}
 
 	VERTEX = hide_hydrogen_atoms(VERTEX, COLOR.a);

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/fixed_size_representation/assets/multimesh_fixed_size_material.tres
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/fixed_size_representation/assets/multimesh_fixed_size_material.tres
@@ -16,4 +16,5 @@ shader_parameter/value_correction = 1.0
 shader_parameter/outline_thickness = 0.2
 shader_parameter/is_hovered = 0.0
 shader_parameter/size = 0.014
+shader_parameter/show_distance = 18.0
 script = ExtResource("1_qplja")


### PR DESCRIPTION
Fixes: BUG: FixedSizeRepresentation visible as a dot in transparent molecule previews