### PR TITLE
Create interface for hiding virtual objects during simulations

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
@@ -5,6 +5,10 @@ var _bonds_toggle: CheckButton
 var _labels_toggle: CheckButton
 var _hydrogens_toggle: CheckButton
 var _simulation_boundaries_toggle: CheckButton
+var _hide_reference_shapes_toggle: CheckButton
+var _hide_virtual_motors_toggle: CheckButton
+var _hide_particle_emitters_toggle: CheckButton
+var _hide_anchors_and_springs_toggle: CheckButton
 
 var _workspace_context: WorkspaceContext = null
 
@@ -14,7 +18,12 @@ func _notification(what: int) -> void:
 		_bonds_toggle = $Settings/PanelContainer/VBoxContainer/ShowBondsToggle
 		_labels_toggle = $Settings/PanelContainer/VBoxContainer/ShowLabelsToggle
 		_hydrogens_toggle = $Settings/PanelContainer/VBoxContainer/ShowHydrogensToggle
-		_simulation_boundaries_toggle = $Settings/PanelContainer/VBoxContainer/ShowSimulationBoundariesToggle
+		_simulation_boundaries_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideSimulationBoundariesToggle
+		_hide_reference_shapes_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideReferenceShapesToggle
+		_hide_virtual_motors_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideVirtualMotorsToggle
+		_hide_particle_emitters_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideParticleEmittersToggle
+		_hide_anchors_and_springs_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideAnchorsAndSpringsToggle
+
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	_workspace_context = in_workspace_context
@@ -32,8 +41,11 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	_bonds_toggle.set_pressed_no_signal(_workspace_context.are_bonds_visualised())
 	_labels_toggle.set_pressed_no_signal(_workspace_context.are_atom_labels_visualised())
 	_hydrogens_toggle.set_pressed_no_signal(_workspace_context.are_hydrogens_visualized())
-	_simulation_boundaries_toggle.set_pressed_no_signal(settings.get_display_simulation_boundaries())
-	
+	_simulation_boundaries_toggle.set_pressed_no_signal(not settings.get_display_simulation_boundaries())
+	_hide_reference_shapes_toggle.set_pressed_no_signal(settings.get_should_hide_virtual_object_during_simulation(NanoShape))
+	_hide_virtual_motors_toggle.set_pressed_no_signal(settings.get_should_hide_virtual_object_during_simulation(NanoVirtualMotor))
+	_hide_particle_emitters_toggle.set_pressed_no_signal(settings.get_should_hide_virtual_object_during_simulation(NanoParticleEmitter))
+	_hide_anchors_and_springs_toggle.set_pressed_no_signal(settings.get_should_hide_virtual_object_during_simulation(NanoVirtualAnchor))
 	return true
 
 
@@ -91,5 +103,8 @@ func _on_show_potential_atoms_toggle_toggled(button_pressed: bool) -> void:
 	_workspace_context.workspace.representation_settings.set_display_auto_posing(button_pressed)
 
 
-func _on_show_simulation_boundaries_toggle_toggled(button_pressed: bool) -> void:
-	_workspace_context.workspace.representation_settings.set_display_simulation_boundaries(button_pressed)
+func _on_hide_simulation_boundaries_toggle_toggled(button_pressed: bool) -> void:
+	_workspace_context.workspace.representation_settings.set_display_simulation_boundaries(not button_pressed)
+
+func _on_hide_virtual_objects_toggle(button_pressed: bool, in_type: StringName) -> void:
+	_workspace_context.workspace.representation_settings.set_should_hide_virtual_object_during_simulation(in_type, button_pressed)

--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
@@ -46,13 +46,55 @@ layout_mode = 2
 button_pressed = true
 text = "Show Potential Atom Positions"
 
-[node name="ShowSimulationBoundariesToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer"]
+[node name="Title" type="Label" parent="Settings/PanelContainer/VBoxContainer"]
+layout_mode = 2
+theme_type_variation = &"HeaderSmall"
+text = "Hide during Simulations"
+
+[node name="PanelContainer" type="PanelContainer" parent="Settings/PanelContainer/VBoxContainer"]
+layout_mode = 2
+theme_type_variation = &"SubcategoryPanel"
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Settings/PanelContainer/VBoxContainer/PanelContainer"]
+layout_mode = 2
+
+[node name="HideSimulationBoundariesToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 button_pressed = true
-text = "Show Simulation Boundaries"
+text = "Simulation Boundaries"
+
+[node name="HideReferenceShapesToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+visible = false
+layout_mode = 2
+button_pressed = true
+text = "Reference Shapes"
+
+[node name="HideVirtualMotorsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+visible = false
+layout_mode = 2
+button_pressed = true
+text = "Virtual Motors"
+
+[node name="HideParticleEmittersToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+visible = false
+layout_mode = 2
+button_pressed = true
+text = "Particle Emitters
+"
+
+[node name="HideAnchorsAndSpringsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+visible = false
+layout_mode = 2
+button_pressed = true
+text = "Anchors and Springs
+"
 
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowBondsToggle" to="." method="_on_show_bonds_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowLabelsToggle" to="." method="_on_show_labels_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowHydrogensToggle" to="." method="_on_show_hydrogens_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowPotentialAtomsToggle" to="." method="_on_show_potential_atoms_toggle_toggled"]
-[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowSimulationBoundariesToggle" to="." method="_on_show_simulation_boundaries_toggle_toggled"]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideSimulationBoundariesToggle" to="." method="_on_hide_simulation_boundaries_toggle_toggled"]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideReferenceShapesToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"reference_shapes"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideVirtualMotorsToggle" to="." method="_on_show_hydrogens_toggle_toggled" binds= [&"_on_show_hydrogens_toggle_toggled"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideParticleEmittersToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"particle_emitters"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideAnchorsAndSpringsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"anchors_and_springs"]]

--- a/godot_project/editor/controls/workspace_view/box_selection/box_selection.gd
+++ b/godot_project/editor/controls/workspace_view/box_selection/box_selection.gd
@@ -152,6 +152,10 @@ func apply_deselection() -> void:
 
 func _is_virtual_object_within_screen_rect(in_context: StructureContext, in_camera: Camera3D) -> bool:
 	assert(in_context.nano_structure.is_virtual_object())
+	var is_simulating: bool = in_context.workspace_context.is_simulating()
+	if is_simulating and in_context.workspace_context.workspace.representation_settings \
+			.get_should_hide_virtual_object_during_simulation(in_context.nano_structure.get_script()):
+			return false
 	if in_context.nano_structure is NanoShape:
 		return in_context.nano_structure.is_shape_within_screen_rect(in_camera, _rect)
 	if in_context.nano_structure is NanoVirtualMotor:

--- a/godot_project/project_workspace/structs/representation_settings.gd
+++ b/godot_project/project_workspace/structs/representation_settings.gd
@@ -4,6 +4,7 @@ class_name RepresentationSettings extends Resource
 signal representation_changed(new_representation: Rendering.Representation)
 signal balls_and_sticks_size_factor_changed(new_factor: float)
 signal balls_and_sticks_size_source_changed(new_source: RepresentationSettings.UserAtomSizeSource)
+signal should_hide_virtual_object_during_simulation_changed(object_type: StringName, should_hide: bool)
 signal bond_visibility_changed(are_visible: bool)
 signal hydrogen_visibility_changed(are_visible: bool)
 signal atom_labels_visibility_changed(are_visible: bool)
@@ -59,6 +60,14 @@ enum UserAtomSizeSource {
 
 
 @export var _color_schema: PeriodicTable.ColorSchema = PeriodicTable.ColorSchema.MSEP
+
+
+@export var _hide_during_simulation: Dictionary[StringName, bool] = {
+	reference_shapes = false,
+	virtual_motor = false,
+	particle_emitters = false,
+	anchors_and_springs = false,
+}
 
 
 func set_balls_and_sticks_size_source(in_size_souce: UserAtomSizeSource) -> void:
@@ -216,6 +225,37 @@ func get_color_schema() -> PeriodicTable.ColorSchema:
 	return _color_schema
 
 
+func set_should_hide_virtual_object_during_simulation(in_type: StringName, in_should_hide: bool) -> void:
+	var key: StringName = _variant_to_virtual_object_key(in_type)
+	if _hide_during_simulation[key] == in_should_hide:
+		return
+	_hide_during_simulation[key] = in_should_hide
+	should_hide_virtual_object_during_simulation_changed.emit(key, in_should_hide)
+
+
+func get_should_hide_virtual_object_during_simulation(in_type: Variant) -> bool:
+	var key: StringName = _variant_to_virtual_object_key(in_type)
+	return _hide_during_simulation[key]
+
+
+func _variant_to_virtual_object_key(in_type: Variant) -> StringName:
+	var SCRIPT_TO_KEY_MAP: Dictionary[Script, StringName] = {
+		NanoShape: &"reference_shapes",
+		NanoVirtualMotor: &"virtual_motor",
+		NanoParticleEmitter: &"particle_emitters",
+		NanoVirtualAnchor: &"anchors_and_springs",
+	}
+	var key := StringName()
+	if typeof(in_type) == TYPE_STRING_NAME:
+		key = in_type
+	elif in_type is Script:
+		key = SCRIPT_TO_KEY_MAP[in_type]
+	else:
+		assert(false, "Unexpected argument in_type with type '" + type_string(typeof(in_type)) + "' and value '" + str(in_type) + "'")
+		pass
+	return key
+
+
 func deep_copy() -> RepresentationSettings:
 	var copy := RepresentationSettings.new()
 	copy._rendering_representation = _rendering_representation
@@ -231,7 +271,7 @@ func deep_copy() -> RepresentationSettings:
 	copy._theme = _theme.duplicate(true)
 	copy._color_schema = _color_schema
 	return copy
-	
+
 
 func create_state_snapshot() -> Dictionary:
 	var snapshot: Dictionary = {

--- a/godot_project/project_workspace/workspace_context/multi_structure_hit_result.gd
+++ b/godot_project/project_workspace/workspace_context/multi_structure_hit_result.gd
@@ -17,8 +17,13 @@ var closest_hit_bond_id: int
 var closest_hit_spring_id: int
 var hit_type: HitType
 
+var _representation_settings: RepresentationSettings
+var _is_simulating: bool
 
 func _init(in_camera: Camera3D, in_screen_position: Vector2, in_query_structures: Array[StructureContext]) -> void:
+	if in_query_structures.size():
+		_representation_settings = in_query_structures[0].workspace_context.workspace.representation_settings
+		_is_simulating = in_query_structures[0].workspace_context.is_simulating()
 	closest_hit_structure_context = null
 	closest_hit_atom_id = AtomicStructure.INVALID_ATOM_ID
 	closest_hit_bond_id = AtomicStructure.INVALID_BOND_ID
@@ -136,6 +141,8 @@ func _calculate_spring_sqr_distance_to_camera(in_struct_context: StructureContex
 			in_camera_pos: Vector3) -> float:
 	if in_spring_id == AtomicStructure.INVALID_SPRING_ID:
 		return INF
+	if _is_simulating and _representation_settings.get_should_hide_virtual_object_during_simulation(NanoVirtualAnchor):
+		return INF
 	var nano_structure: NanoStructure = in_struct_context.nano_structure
 	var atom_pos: Vector3 = nano_structure.spring_get_atom_position(in_spring_id)
 	var anchor_pos: Vector3 = nano_structure.spring_get_anchor_position(in_spring_id, in_struct_context)
@@ -145,6 +152,8 @@ func _calculate_spring_sqr_distance_to_camera(in_struct_context: StructureContex
 
 func _calculate_shape_sqr_distance_to_camera(in_camera: Camera3D, in_screen_pos: Vector2,
 			in_context: StructureContext) -> float:
+	if _is_simulating and _representation_settings.get_should_hide_virtual_object_during_simulation(NanoShape):
+		return INF
 	var shape_intersections: PackedVector3Array = _get_ray_hits_shape(in_camera, in_screen_pos, in_context)
 	var is_shape_collision_detected: bool = not shape_intersections.is_empty()
 	if not is_shape_collision_detected:

--- a/godot_project/project_workspace/workspace_context/structure_context/collision_engine/collision_engine.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/collision_engine/collision_engine.gd
@@ -35,9 +35,11 @@ var _motor_shape_rid: RID # = PhysicsServer3D.sphere_shape_create()
 var _particle_emitter_shape_rid: RID # = PhysicsServer3D.cylinder_shape_create()
 var _anchor_shape_rid: RID # = PhysicsServer3D.sphere_shape_create()
 var _spring_shape_rid: RID # = PhysicsServer3D.box_shape_create()
+var _virtual_object_type := StringName()
+var _hiding_virtual_object_during_simulation: bool = false
+var _is_simulating: bool = false
 var _hydrogens_enabled: bool = true
 var _is_initialized: bool = false
-
 
 func _notification(in_what: int) -> void:
 	if in_what == NOTIFICATION_SCENE_INSTANTIATED:
@@ -61,6 +63,7 @@ func initialize(in_structure_context: StructureContext) -> void:
 	_structure_context = in_structure_context
 	var nano_structure: NanoStructure = in_structure_context.nano_structure
 	var representation_settings: RepresentationSettings = nano_structure.get_representation_settings()
+	
 	_hydrogens_enabled = representation_settings.get_hydrogens_visible()
 	_refresh_atom_radiuses()
 	_refresh_bond_radiuses()
@@ -122,18 +125,37 @@ func initialize(in_structure_context: StructureContext) -> void:
 	
 	if nano_structure is NanoVirtualMotor:
 		_add_motor(nano_structure as NanoVirtualMotor)
+		_virtual_object_type = &"virtual_motor"
 	
 	if nano_structure is NanoParticleEmitter:
 		_add_particle_emitter(nano_structure)
+		_virtual_object_type = &"particle_emitters"
 	
 	if nano_structure is NanoVirtualAnchor:
 		_add_anchor(nano_structure as NanoVirtualAnchor)
+		_virtual_object_type = &"anchors_and_springs"
+	
+	if not _virtual_object_type.is_empty() and not representation_settings \
+			.should_hide_virtual_object_during_simulation_changed \
+			.is_connected(_on_should_hide_virtual_object_during_simulation_changed):
+		representation_settings.should_hide_virtual_object_during_simulation_changed.connect(_on_should_hide_virtual_object_during_simulation_changed)
+		_hiding_virtual_object_during_simulation = \
+			representation_settings.get_should_hide_virtual_object_during_simulation(_virtual_object_type)
+		in_structure_context.workspace_context.simulation_started.connect(set.bind(&"_is_simulating", true))
+		in_structure_context.workspace_context.simulation_finished.connect(set.bind(&"_is_simulating", false))
+		_is_simulating = in_structure_context.workspace_context.is_simulating()
 	
 	_is_initialized = true
 
 
 func is_initialized() -> bool:
 	return _is_initialized
+
+
+func _on_should_hide_virtual_object_during_simulation_changed(in_type: StringName, in_should_hide: bool) -> void:
+	if in_type == _virtual_object_type:
+		_hiding_virtual_object_during_simulation = in_should_hide
+
 
 
 func _refresh_atom_radiuses() -> void:
@@ -583,6 +605,8 @@ func ray_bond(in_screen_position: Vector2, in_camera: Camera3D) -> int:
 
 
 func ray_virtual_object(in_screen_position: Vector2, in_camera: Camera3D) -> bool:
+	if _is_simulating and _hiding_virtual_object_during_simulation:
+		return false
 	var ray_normal: Vector3 = in_camera.project_ray_normal(in_screen_position)
 	var ray_origin: Vector3 = in_camera.project_ray_origin(in_screen_position) * PHYSIC_SPACE_SIZE_FACTOR
 	var collided_virtual_object_id: int = _atom_collision_space.raycast(ray_origin, ray_normal, CollisionLayer.VIRTUAL_OBJECT)


### PR DESCRIPTION
### TODO:
- Implement hiding on each renderer and enable the UI that allow to toggle each case

### Known Issues:
- Changing the toggle of an object will prevent the objects from being selected, but will not unselect the object. This needs discussion, because changing selection would need to create Undo History Snapshots, which is not nice ideal during simulations

Task: Part 1 of New Feature - Add "Hide Virtual Objects During Simulation" toggle