### PR TITLE
Hide autopose candidates when another input handlers takes exclusive input

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -35,7 +35,7 @@ func handles_structure_context(in_structure_context: StructureContext) -> bool:
 
 
 func handle_inputs_end() -> void:
-	_show_preview()
+	_hide_preview()
 
 
 func handle_inputs_resume() -> void:


### PR DESCRIPTION
Task: UI Bug - When doing click and drag to connect atoms, suggestions get in the way