### PR TITLE
Dont create 2 undo states when reseting background color

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/color/confirmation_color_popup.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/color/confirmation_color_popup.gd
@@ -34,7 +34,6 @@ func _on_apply_button_pressed() -> void:
 func _on_default_button_pressed() -> void:
 	_color_picker.color = DEFAULT_COLOR
 	_selected_color = _color_picker.color
-	color_selected.emit(_selected_color)
 	
 	default_pressed.emit()
 	hide()


### PR DESCRIPTION
The system was creating 1 stapshot for reseting custom color to black, and another one in the same frame for reseting color to the default color. This now happens all in a single undo snapshot

Task: BUG - Error doing Undo after resetting overridden background color