### PR TITLE
Make atom outlines more obvious on van der waals and mechanical representation

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/representation.gd
@@ -10,6 +10,10 @@ const SETTING_RADIUS_SOURCE_VAN_DER_WAALS: StringName = &"msep/rendering/van_der
 const SETTING_RADIUS_SOURCE_MECHANICAL_SIMULATION: StringName = &"msep/rendering/mechanical_simulation/radius_source"
 const SETTING_RADIUS_SOURCE_BALLS_AND_STICKS: StringName = &"msep/rendering/balls_and_sticks/radius_source"
 
+const SETTING_OUTLINE_THICKNESS_VAN_DER_WAALS: StringName = &"msep/rendering/van_der_waals/outline_thickness"
+const SETTING_OUTLINE_THICKNESS_MECHANICAL_SIMULATION: StringName = &"msep/rendering/mechanical_simulation/outline_thickness"
+const SETTING_OUTLINE_THICKNESS_BALLS_AND_STICKS: StringName = &"msep/rendering/balls_and_sticks/outline_thickness"
+
 const SCALE_FACTOR_STICKS: float = 0.6
 
 @warning_ignore("unused_private_class_variable")
@@ -223,6 +227,19 @@ static func get_atom_scale_factor(in_representation_settings: RepresentationSett
 			if in_representation_settings != null:
 				return in_representation_settings.get_balls_and_sticks_size_factor()
 			return ProjectSettings.get_setting(SETTING_SCALE_FACTOR_BALLS_AND_STICKS, 0.3)
+
+
+static func get_outline_thickness(in_representation_settings: RepresentationSettings) -> float:
+	var representation := Rendering.Representation.BALLS_AND_STICKS
+	if in_representation_settings != null:
+		representation = in_representation_settings.get_rendering_representation()
+	match representation:
+		Rendering.Representation.VAN_DER_WAALS_SPHERES:
+			return ProjectSettings.get_setting(SETTING_OUTLINE_THICKNESS_VAN_DER_WAALS, 0.8)
+		Rendering.Representation.MECHANICAL_SIMULATION:
+			return ProjectSettings.get_setting(SETTING_OUTLINE_THICKNESS_MECHANICAL_SIMULATION, 0.8)
+		Rendering.Representation.BALLS_AND_STICKS, _:
+			return ProjectSettings.get_setting(SETTING_OUTLINE_THICKNESS_BALLS_AND_STICKS, 0.3)
 
 
 static func get_atom_radius(in_data: ElementData, in_representation_settings: RepresentationSettings) -> float:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/sphere_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/sphere_material.gd
@@ -42,6 +42,11 @@ func set_scale_factor(new_scale_factor: float) -> SphereMaterial:
 	return self
 
 
+func set_outline_thickness(new_thickness: float) -> SphereMaterial:
+	set_shader_parameter(UNIFORM_OUTLINE_THICKNESS, new_thickness)
+	return self
+
+
 func update_gizmo(in_gizmo_origin: Vector3, in_gizmo_rotation: Basis) -> void:
 	set_shader_parameter(UNIFORM_GIZMO_ORIGIN, in_gizmo_origin)
 	set_shader_parameter(UNIFORM_GIZMO_ROTATION, in_gizmo_rotation)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/sphere_representation.gd
@@ -39,6 +39,8 @@ func build(in_structure_context: StructureContext) -> void:
 	var representation_settings: RepresentationSettings = related_nanostructure.get_representation_settings()
 	var scale_factor: float = Representation.get_atom_scale_factor(representation_settings)
 	_apply_scale_factor(scale_factor)
+	var outline_thickness: float = Representation.get_outline_thickness(representation_settings)
+	_material.set_outline_thickness(outline_thickness)
 
 	var aabb: AABB = AABB()
 	var atoms_ids: PackedInt32Array = related_nanostructure.get_valid_atoms()
@@ -230,6 +232,8 @@ func refresh_atoms_sizes(in_update_atoms_radii: bool = false) -> void:
 	var related_nanostructure: NanoStructure = _get_related_atomic_structure()
 	var scale_factor: float = Representation.get_atom_scale_factor(related_nanostructure.get_representation_settings())
 	_apply_scale_factor(scale_factor)
+	var outline_thickness: float = Representation.get_outline_thickness(related_nanostructure.get_representation_settings())
+	_material.set_outline_thickness(outline_thickness)
 	
 	if in_update_atoms_radii:
 		# The actual atom radius is stored in each particle transform, we need to modify all of them
@@ -293,6 +297,8 @@ func show() -> void:
 	_segmented_multimesh.show()
 	var scale_factor: float = Representation.get_atom_scale_factor(related_nanostructure.get_representation_settings())
 	_apply_scale_factor(scale_factor)
+	var outline_thickness: float = Representation.get_outline_thickness(related_nanostructure.get_representation_settings())
+	_material.set_outline_thickness(outline_thickness)
 	_update_is_selectable_uniform()
 
 

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -345,6 +345,9 @@ simulation/relaxation_animation_time=0.5
 clipboard/paste_offset_direction/x=0.0
 clipboard/paste_offset_direction/y=0.0
 clipboard/paste_offset_direction/z=0.0
+rendering/van_der_waals/outline_thickness=0.8
+rendering/mechanical_simulation/outline_thickness=0.8
+rendering/balls_and_sticks/outline_thickness=0.3
 
 [network]
 


### PR DESCRIPTION
Tasks:
- BUG - Selection Highlights No Longer Work for Van Der Waals, or Molecular Engineering views.
- BUG - Certain aspects of rendering aren't being resent when going back to msep from academic view

Before
<img width="672" height="560" alt="image" src="https://github.com/user-attachments/assets/7734fa7e-aa71-4dc1-b4c7-83b89ea86920" />

After
<img width="823" height="567" alt="image" src="https://github.com/user-attachments/assets/bbb7e41d-4ed6-4ecf-a461-fec18b666c17" />
