### PR TITLE
Dont offer option to correct overlapping atoms when there's no atoms in the workspace

### DIFF
--- a/godot_project/editor/ring_menu_levels/atoms/ring_action_correct_overlapping_atoms.gd
+++ b/godot_project/editor/ring_menu_levels/atoms/ring_action_correct_overlapping_atoms.gd
@@ -18,11 +18,16 @@ func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> voi
 			_execute_action,
 			tr("Move overlapping atoms away from each other.")
 	)
+	with_validation(_can_correct_atoms)
 
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		_model_validator.queue_free()
+
+
+func _can_correct_atoms() -> bool:
+	return _workspace_context.has_valid_atoms()
 
 
 func get_icon() -> RingMenuIcon:


### PR DESCRIPTION
Task: MINIMAL: "Correct overlapping atoms" in the ring menu is available when there's no atoms in the project