### PR TITLE
Replace usage of `get_current_workspace()` and `get_current_workspace_context()` wherever possible

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -218,9 +218,9 @@ func save_workspace(in_workspace: Workspace, in_path: String = "") -> void:
 		Editor_Utils.get_editor().prompt_error_msg(tr(&"Failed to save file {0} with error '{1}'").format([path, error_string(err)]))
 		return
 	in_workspace.resource_path = in_path
-	var current_workspace_context: WorkspaceContext = get_current_workspace_context()
-	assert(is_instance_valid(current_workspace_context), "Invalid workspace context")
-	current_workspace_context.mark_saved()
+	var context: WorkspaceContext = get_workspace_context(in_workspace)
+	assert(is_instance_valid(context), "Invalid workspace context")
+	context.mark_saved()
 	workspace_saved.emit(in_workspace)
 	_update_window_title()
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_bonds_panel.gd
@@ -38,8 +38,7 @@ func _update_panel_state() -> void:
 	_no_selection_label.self_modulate.a = 0.0
 	_auto_create_bonds_button.disabled = false
 	var has_selected_atoms: bool = false
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-	for structure: StructureContext in workspace_context.get_visible_structure_contexts():
+	for structure: StructureContext in _workspace_context.get_visible_structure_contexts():
 		if structure.get_selected_atoms().size() > 0:
 			has_selected_atoms = true
 			break

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_atoms_and_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_atoms_and_bonds_panel.gd
@@ -5,11 +5,13 @@ extends DynamicContextControl
 @onready var bond_picker: Container = %BondPicker
 @onready var element_picker: Control = %ElementPicker
 
+var _workspace_context: WorkspaceContext = null
 
 func should_show(in_workspace_context: WorkspaceContext) -> bool:
 	var structure_context: StructureContext = in_workspace_context.get_current_structure_context()
 	if !is_instance_valid(structure_context) || !is_instance_valid(structure_context.nano_structure):
 		return false
+	_workspace_context = in_workspace_context
 	if in_workspace_context.create_object_parameters.get_create_mode_type() \
 			!= CreateObjectParameters.CreateModeType.CREATE_ATOMS_AND_BONDS:
 		return false
@@ -31,19 +33,18 @@ func _ready() -> void:
 
 
 func _on_bond_order_change_requested(in_order: int) -> void:
-	var workspace: Workspace = MolecularEditorContext.get_current_workspace()
-	if workspace == null:
+	if _workspace_context == null or _workspace_context.workspace == null:
 		return
+	var workspace: Workspace = _workspace_context.workspace
 	var context: WorkspaceContext = MolecularEditorContext.get_workspace_context(workspace)
 	context.create_object_parameters.set_new_bond_order(in_order)
 	EditorSfx.mouse_down()
 
 
 func _on_atom_type_change_requested(in_element: int) -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-	if workspace_context == null:
+	if _workspace_context == null:
 		return
-	workspace_context.create_object_parameters.set_new_atom_element(in_element)
+	_workspace_context.create_object_parameters.set_new_atom_element(in_element)
 	EditorSfx.mouse_down()
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_docker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_docker.gd
@@ -175,7 +175,6 @@ func _on_current_structure_context_changed(in_structure_context: StructureContex
 
 
 func _on_structure_context_selection_changed() -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_workspace_context(MolecularEditorContext.get_current_workspace())
-	if is_instance_valid(workspace_context):
-		_update_visibility(should_show(workspace_context))
+	if is_instance_valid(_workspace_context):
+		_update_visibility(should_show(_workspace_context))
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_fragment_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_fragment_panel.gd
@@ -15,8 +15,10 @@ var _fragment_map: Dictionary = {
 @onready var _no_search_result_found: Label = %NoSearchResultFound
 @onready var _group_check_box: CheckBox = %GroupCheckBox
 
+var _workspace_context: WorkspaceContext = null
 
 func should_show(in_workspace_context: WorkspaceContext) -> bool:
+	_workspace_context = in_workspace_context
 	var structure_context: StructureContext = in_workspace_context.get_current_structure_context()
 	if !is_instance_valid(structure_context) || !is_instance_valid(structure_context.nano_structure):
 		return false
@@ -83,11 +85,10 @@ func _init_fragments_ui() -> void:
 func _on_fragment_selected(fragment_path: String) -> void:
 	var unpacked_mol_path: String = WorkspaceUtils.unpack_mol_file_and_get_path(fragment_path)
 	var absolute_path: String = ProjectSettings.globalize_path(unpacked_mol_path)
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-	assert(is_instance_valid(workspace_context))
-	var structure: NanoStructure = await WorkspaceUtils.get_nano_structure_from_file(workspace_context, absolute_path, false, false, false)
+	assert(is_instance_valid(_workspace_context))
+	var structure: NanoStructure = await WorkspaceUtils.get_nano_structure_from_file(_workspace_context, absolute_path, false, false, false)
 	structure.set_structure_name(fragment_path.get_file().get_basename())
-	workspace_context.create_object_parameters.set_new_structure(structure)
+	_workspace_context.create_object_parameters.set_new_structure(structure)
 	# HACK: for responsivemes, we will "fake" a mouse movement to ensure preview of the molecule will
 	# reappear in the desired position only if the mouse is hovering the viewport
 	if BusyIndicator.visible:

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
@@ -96,8 +96,7 @@ func _update_ui() -> void:
 func _on_create_from_selection_button_pressed() -> void:
 	assert(WorkspaceUtils.can_create_particle_emitter_from_selection(_workspace_context))
 	# 1. Create emitter parameters from settings
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-	var selected_contexts: Array[StructureContext] = workspace_context.get_atomic_structure_contexts_with_selection()
+	var selected_contexts: Array[StructureContext] = _workspace_context.get_atomic_structure_contexts_with_selection()
 	# 2. Validate topology of selection
 	_workspace_context.start_async_work(tr(&"Validating topology"))
 	const SELECTION_ONLY = true
@@ -140,7 +139,7 @@ func _on_create_from_selection_button_pressed() -> void:
 	_center_template_on_origin(template)
 	template.end_edit()
 	template.set_structure_name("Template")
-	template.set_representation_settings(workspace_context.workspace.representation_settings)
+	template.set_representation_settings(_workspace_context.workspace.representation_settings)
 	_create_particle_emitter_from_template(template, center_of_selection)
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/creation_distance_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/creation_distance_panel.gd
@@ -73,9 +73,10 @@ func _on_snap_to_shape_surface_toggled(enabled: bool) -> void:
 
 
 func _on_creation_distance_value_changed(in_new_distance: float) -> void:
-	var workspace: Workspace = MolecularEditorContext.get_current_workspace()
-	if workspace == null:
+	var workspace_context: WorkspaceContext = _weak_workspace_context.get_ref() as WorkspaceContext
+	if workspace_context == null or workspace_context.workspace == null:
 		return
+	var workspace: Workspace = workspace_context.workspace
 	var delta: float = creation_distance.max_value - creation_distance.min_value
 	var factor: float = (in_new_distance - creation_distance.min_value) / delta
 	var context: WorkspaceContext = MolecularEditorContext.get_workspace_context(workspace)
@@ -89,8 +90,8 @@ func _on_create_distance_method_changed(in_new_method: CreateObjectParameters.Cr
 
 
 func _on_creation_distance_from_camera_factor_changed(_in_factor: float) -> void:
-	var context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-	if creation_distance.value == context.create_object_parameters.drop_distance:
+	var context: WorkspaceContext = _weak_workspace_context.get_ref() as WorkspaceContext
+	if context == null or creation_distance.value == context.create_object_parameters.drop_distance:
 		return
 	creation_distance.value = context.create_object_parameters.drop_distance
 

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_docker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_docker.gd
@@ -163,9 +163,8 @@ func _update_internal(in_workspace_context: WorkspaceContext) -> void:
 
 
 func _update_docker_visibility() -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_workspace_context(MolecularEditorContext.get_current_workspace())
-	if is_instance_valid(workspace_context):
-		_update_visibility(should_show(workspace_context))
+	if is_instance_valid(_workspace_context):
+		_update_visibility(should_show(_workspace_context))
 
 
 func get_unique_docker_name() -> StringName:

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker.gd
@@ -121,6 +121,6 @@ func _on_current_structure_context_changed(in_structure_context: StructureContex
 
 
 func _on_structure_context_selection_changed() -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
+	var workspace_context := _weak_workspace_context.get_ref() as WorkspaceContext
 	if is_instance_valid(workspace_context):
 		_update_visibility(should_show(workspace_context))

--- a/godot_project/editor/controls/workspace_view/controls/mode_selector/mode_selector.gd
+++ b/godot_project/editor/controls/workspace_view/controls/mode_selector/mode_selector.gd
@@ -5,6 +5,7 @@ extends Control
 @onready var _create_mode_button: Button = %CreateModeButton
 @onready var _select_mode_button: Button = %SelectModeButton
 
+var _workspace_context: WorkspaceContext = null
 
 func _ready() -> void:
 	_create_mode_button.toggled.connect(_on_create_mode_button_toggled)
@@ -14,6 +15,7 @@ func _ready() -> void:
 func initialize(in_workspace_context: WorkspaceContext) -> void:
 	if in_workspace_context == null:
 		return
+	_workspace_context = in_workspace_context
 	var create_object_parameters: CreateObjectParameters = in_workspace_context.create_object_parameters as CreateObjectParameters
 	assert(create_object_parameters != null, "Workspace Context should always have CreateObjectParameters component")
 	_set_create_mode_enabled(create_object_parameters.get_create_mode_enabled())
@@ -29,10 +31,8 @@ func _set_create_mode_enabled(in_enabled: bool) -> void:
 
 
 func _on_create_mode_button_toggled(enabled: bool) -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-	workspace_context.create_object_parameters.set_create_mode_enabled(enabled)
+	_workspace_context.create_object_parameters.set_create_mode_enabled(enabled)
 
 
 func _on_select_mode_button_toggled(enabled: bool) -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-	workspace_context.create_object_parameters.set_create_mode_enabled(not enabled)
+	_workspace_context.create_object_parameters.set_create_mode_enabled(not enabled)

--- a/godot_project/editor/rendering/atom_autopose_preview/atom_autopose_preview.gd
+++ b/godot_project/editor/rendering/atom_autopose_preview/atom_autopose_preview.gd
@@ -72,7 +72,8 @@ func _process(_delta: float) -> void:
 	if MolecularEditorContext.is_homepage_active():
 		return
 	# Redraw if the selection is being moved
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context() as WorkspaceContext
+	var editor_viewport: WorkspaceEditorViewport = get_viewport()
+	var workspace_context: WorkspaceContext = editor_viewport.get_workspace_context()
 	var rendering: Rendering = workspace_context.get_rendering()
 	var context: StructureContext = workspace_context.get_current_structure_context()
 	var structure: NanoStructure = context.nano_structure

--- a/godot_project/editor/rendering/atom_preview/atom_preview.gd
+++ b/godot_project/editor/rendering/atom_preview/atom_preview.gd
@@ -18,7 +18,12 @@ func _ready() -> void:
 
 
 func _ready_deferred() -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
+	var editor_viewport: WorkspaceEditorViewport = get_viewport() as WorkspaceEditorViewport
+	if editor_viewport == null:
+		# This viewport is for preview in WorkspaceDockers
+		# no need for preview
+		return
+	var workspace_context: WorkspaceContext = editor_viewport.get_workspace_context()
 	assert(workspace_context)
 	_representation_settings = workspace_context.workspace.representation_settings
 	_representation_settings.changed.connect(_on_representation_settings_changed)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -69,7 +69,7 @@ func _calculate_bond_transform(in_nano_structure: AtomicStructure, in_bond: Vect
 	var dir_from_first_to_second: Vector3 = first_atom_position.direction_to(second_atom_position)
 	var up_vector: Vector3 = StickRepresentation._calc_up_vect_for_single_bond(dir_from_first_to_second) if bond_order == 1 else \
 			StickRepresentation._calc_up_vector_for_higher_bond(first_atom_id, second_atom_id, first_atom_position,
-					second_atom_position, in_nano_structure)
+					second_atom_position, in_nano_structure, get_viewport().get_camera_3d())
 	var particle_position: Vector3 = (first_atom_position + second_atom_position) / 2.0
 	var new_transform: Transform3D = Transform3D(Basis(), particle_position)
 	new_transform = new_transform.looking_at(first_atom_position, up_vector)

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
@@ -110,7 +110,7 @@ func _calculate_bond_transform(in_nano_structure: AtomicStructure, in_bond: Vect
 	var dir_from_first_to_second: Vector3 = first_atom_position.direction_to(second_atom_position)
 	var up_vector: Vector3 = StickRepresentation._calc_up_vect_for_single_bond(dir_from_first_to_second) if bond_order == 1 else \
 			StickRepresentation._calc_up_vector_for_higher_bond(first_atom_id, second_atom_id, first_atom_position,
-					second_atom_position, in_nano_structure)
+					second_atom_position, in_nano_structure, get_viewport().get_camera_3d())
 	var _particle_transform: Transform3D = calculate_transform_for_bond(first_atom_position,
 			second_atom_position, up_vector)
 	return _particle_transform

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
@@ -609,7 +609,7 @@ static func _calc_up_vect_for_single_bond(in_dir_between_atoms: Vector3) -> Vect
 
 
 static func _calc_up_vector_for_higher_bond(in_first_atom_id: int, in_second_atom_id: int, first_atom_position: Vector3,
-			second_atom_position: Vector3, in_nanostructure: NanoStructure) -> Vector3:
+			second_atom_position: Vector3, in_nanostructure: NanoStructure, in_camera: Camera3D) -> Vector3:
 
 	var third_atom_id: int = _find_atom_connected_to_first_but_not_second(in_first_atom_id, in_second_atom_id,
 			in_nanostructure)
@@ -621,9 +621,8 @@ static func _calc_up_vector_for_higher_bond(in_first_atom_id: int, in_second_ato
 	if third_atom_id == -1:
 		# there is no way to determine proper up vector, we need at least three points for that, let's do our best
 		# while working around it
-		var camera: Camera3D = MolecularEditorContext.get_current_workspace_context().get_editor_viewport().get_camera_3d()
-		if camera != null:
-			return -camera.global_transform.basis.z
+		if in_camera != null:
+			return -in_camera.global_transform.basis.z
 		else:
 			var direction_between_atoms: Vector3 = first_atom_position.direction_to(second_atom_position)
 			var up_vect: Vector3 = direction_between_atoms.cross(Vector3(0, 0, 1))
@@ -675,7 +674,7 @@ func _calculate_partial_selection_transform(in_bond: Vector3i, in_rotation_point
 	var dir_from_first_to_second: Vector3 = first_atom_new_pos.direction_to(second_atom_new_pos)
 	var up_vector: Vector3 = StickRepresentation._calc_up_vect_for_single_bond(dir_from_first_to_second) if bond_order == 1 else \
 			StickRepresentation._calc_up_vector_for_higher_bond(first_atom_id, second_atom_id, first_atom_new_pos,
-					second_atom_new_pos, related_structure)
+					second_atom_new_pos, related_structure, get_viewport().get_camera_3d())
 	var _particle_transform: Transform3D = calculate_transform_for_bond(first_atom_new_pos,
 			second_atom_new_pos, up_vector)
 	return _particle_transform
@@ -706,7 +705,7 @@ func _calculate_partial_selection_translation(in_bond: Vector3i, in_delta_transl
 	var dir_from_first_to_second: Vector3 = first_atom_new_pos.direction_to(second_atom_new_pos)
 	var up_vector: Vector3 = StickRepresentation._calc_up_vect_for_single_bond(dir_from_first_to_second) if bond_order == 1 else \
 			StickRepresentation._calc_up_vector_for_higher_bond(first_atom_id, second_atom_id, first_atom_new_pos,
-					second_atom_new_pos, related_structure)
+					second_atom_new_pos, related_structure, get_viewport().get_camera_3d())
 	var _particle_transform: Transform3D = calculate_transform_for_bond(first_atom_new_pos,
 			second_atom_new_pos, up_vector)
 	return _particle_transform

--- a/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
+++ b/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
@@ -26,7 +26,12 @@ func _ready() -> void:
 
 
 func _ready_deferred() -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
+	var editor_viewport: WorkspaceEditorViewport = get_viewport() as WorkspaceEditorViewport
+	if editor_viewport == null:
+		# This viewport is for preview in WorkspaceDockers
+		# no need for preview
+		return
+	var workspace_context: WorkspaceContext = editor_viewport.get_workspace_context()
 	assert(workspace_context)
 	_representation_settings = workspace_context.workspace.representation_settings
 	_representation_settings.changed.connect(_on_representation_settings_changed)

--- a/godot_project/editor/rendering/particle_emitter_renderer/particle_emitter_renderer.gd
+++ b/godot_project/editor/rendering/particle_emitter_renderer/particle_emitter_renderer.gd
@@ -74,6 +74,9 @@ func build(in_workspace_context: WorkspaceContext, in_emitter: NanoParticleEmitt
 
 func _ensure_emitter_signal_connections(in_emitter_or_null: NanoParticleEmitter = null) -> void:
 	if in_emitter_or_null == null:
+		# This assumes workspace is active.
+		# Should only be happening because of undo/redo from apply_state_snapshot()
+		# If asserts ever happens check if this callback is comming from a different source
 		var workspace: Workspace = MolecularEditorContext.get_current_workspace()
 		assert(workspace.has_structure_with_int_guid(_emitter_id), "Particle emitter not present in active workspace")
 		in_emitter_or_null = workspace.get_structure_by_int_guid(_emitter_id) as NanoParticleEmitter

--- a/godot_project/editor/rendering/structure_preview/structure_preview.gd
+++ b/godot_project/editor/rendering/structure_preview/structure_preview.gd
@@ -28,7 +28,12 @@ func _ready() -> void:
 
 
 func _ready_deferred() -> void:
-	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context() as WorkspaceContext
+	var editor_viewport: WorkspaceEditorViewport = get_viewport() as WorkspaceEditorViewport
+	if editor_viewport == null:
+		# This viewport is for preview in WorkspaceDockers
+		# no need for preview
+		return
+	var workspace_context: WorkspaceContext = editor_viewport.get_workspace_context()
 	assert(workspace_context)
 	workspace_context.started_creating_object.connect(_on_workspace_context_started_creating_object.bind(workspace_context))
 	workspace_context.aborted_creating_object.connect(_on_workspace_context_aborted_creating_object)

--- a/godot_project/project_workspace/structs/nano_molecular_structure.gd
+++ b/godot_project/project_workspace/structs/nano_molecular_structure.gd
@@ -452,7 +452,8 @@ func spring_create(in_anchor_id: int, in_atom_id: int, in_spring_constant_force:
 	_springs[_highest_spring_id] = NanoSpring.create(in_anchor_id, in_atom_id, in_spring_constant_force,
 			is_equilibrium_length_automatic, in_equilibrium_manual_length)
 	_signal_queue_springs_added.append(_highest_spring_id)
-	var anchor: NanoVirtualAnchor = MolecularEditorContext.get_current_workspace().get_structure_by_int_guid(in_anchor_id)
+	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
+	var anchor: NanoVirtualAnchor = workspace.get_structure_by_int_guid(in_anchor_id)
 	_springs[_highest_spring_id].anchor_is_visible = anchor.get_visible()
 	anchor.handle_spring_added(self, _highest_spring_id)
 	if not anchor.position_changed.is_connected(_on_anchor_position_change):
@@ -507,7 +508,8 @@ func spring_invalidate(in_spring_id: int) -> void:
 	_invalid_springs[in_spring_id] = _springs[in_spring_id]
 	_springs.erase(in_spring_id)
 	_signal_queue_springs_moved.erase(in_spring_id)
-	var anchor: NanoVirtualAnchor = MolecularEditorContext.get_current_workspace().get_structure_by_int_guid(anchor_id)
+	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
+	var anchor: NanoVirtualAnchor = workspace.get_structure_by_int_guid(anchor_id)
 	anchor.handle_spring_removed(self, in_spring_id)
 	
 	var is_still_linked_to_anchor: bool = anchor.is_structure_related(int_guid)
@@ -527,7 +529,8 @@ func spring_revalidate(in_spring_id: int) -> void:
 	
 	var revalidated_spring: NanoSpring = _springs[in_spring_id]
 	var related_anchor_id: int = revalidated_spring.target_anchor
-	var anchor: NanoVirtualAnchor = MolecularEditorContext.get_current_workspace().get_structure_by_int_guid(related_anchor_id)
+	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
+	var anchor: NanoVirtualAnchor = workspace.get_structure_by_int_guid(related_anchor_id)
 	anchor.handle_spring_added(self, in_spring_id)
 	if not anchor.position_changed.is_connected(_on_anchor_position_change):
 		anchor.position_changed.connect(_on_anchor_position_change.bind(anchor))

--- a/godot_project/project_workspace/structs/nano_particle_emitter.gd
+++ b/godot_project/project_workspace/structs/nano_particle_emitter.gd
@@ -39,9 +39,9 @@ func _init() -> void:
 
 func get_total_molecule_instance_count() -> int:
 	# Limit is time, be it the entire simulation or some value configured
-	var workspace: Workspace = MolecularEditorContext.get_current_workspace()
-	assert(workspace.has_structure(self), "get_total_molecule_instance_count() can only " +
-		"be called while workspace is being edited!")
+	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
+	assert(workspace != null, "get_total_molecule_instance_count() can only " +
+		"be called when present in a workspace")
 	return calculate_total_molecule_instance_count(_parameters, workspace)
 
 
@@ -101,7 +101,7 @@ func create_instances(out_group: AtomicStructure) -> void:
 	var params: NanoMolecularStructure.AddAtomParameters = null
 	var molecules_per_instance: int = _parameters.get_molecules_per_instance()
 	var total_count: int = get_total_molecule_instance_count()
-	var workspace: Workspace = MolecularEditorContext.get_current_workspace()
+	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
 	var step_size_femtoseconds: float = workspace.simulation_parameters.step_size_in_femtoseconds
 	var step_size_nanoseconds: float = TimeSpanPicker.femtoseconds_to_unit(
 		step_size_femtoseconds, TimeSpanPicker.Unit.NANOSECOND)
@@ -348,7 +348,8 @@ func create_state_snapshot(in_with_instances: bool = false) -> Dictionary:
 		else:
 			state_snapshot["_instances_group"] = _instances_group.int_guid
 			state_snapshot["_instances_group_state"] = _instances_group.create_state_snapshot()
-			var workspace_cotext: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
+			var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
+			var workspace_cotext: WorkspaceContext = MolecularEditorContext.get_workspace_context(workspace)
 			var rendering: Rendering = workspace_cotext.get_rendering()
 			var renderer := rendering._get_renderer_for_atomic_structure(_instances_group)
 			state_snapshot["_instances_group_renderer_state"] = renderer.create_state_snapshot()
@@ -364,24 +365,22 @@ func apply_state_snapshot(in_state_snapshot: Dictionary, in_with_instances: bool
 	_instances_atom_ids = in_state_snapshot["_instances_atom_ids"].duplicate(false)
 	_instances_bond_ids = in_state_snapshot["_instances_bond_ids"].duplicate(false)
 	var instances_group_id: int = in_state_snapshot["_instances_group_id"]
+	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
 	if instances_group_id == -1:
 		_instances_group = null
 	else:
-		# Assume undo/redo operation can only happen in active workspace
-		var workspace: Workspace = MolecularEditorContext.get_current_workspace()
-		assert(workspace.has_structure(self), "Not my workspace!")
+		assert(workspace != null, "Workspace not found!")
 		_instances_group = workspace.get_structure_by_int_guid(instances_group_id)
 	if in_with_instances:
 		var group_id: int = in_state_snapshot["_instances_group"]
 		if group_id == Workspace.INVALID_STRUCTURE_ID:
 			return
+		var workspace_context: WorkspaceContext = MolecularEditorContext.get_workspace_context(workspace)
 		var group_structure_context: StructureContext = \
-			MolecularEditorContext.get_current_workspace_context().\
-			get_nano_structure_context_from_id(group_id)
+			workspace_context.get_nano_structure_context_from_id(group_id)
 		_instances_group = group_structure_context.nano_structure as AtomicStructure
 		_instances_group.apply_state_snapshot(in_state_snapshot["_instances_group_state"])
 		group_structure_context.get_collision_engine().rebuild(group_structure_context)
-		var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
 		var rendering: Rendering = workspace_context.get_rendering()
 		var renderer := rendering._get_renderer_for_atomic_structure(_instances_group)
 		renderer.apply_state_snapshot(in_state_snapshot["_instances_group_renderer_state"])

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/atom_selection/atom_selection.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/atom_selection/atom_selection.gd
@@ -208,7 +208,8 @@ func select_connected(in_show_hidden_objects: bool = false) -> AtomSelectionResu
 		return AtomSelectionResult.new(false, PackedInt32Array(), PackedInt32Array(), PackedInt32Array())
 	
 	if should_show_hydrogens or not hidden_atoms_to_show.is_empty():
-		var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
+		var editor_viewport: WorkspaceEditorViewport = get_viewport()
+		var workspace_context: WorkspaceContext = editor_viewport.get_workspace_context()
 		if should_show_hydrogens:
 			related_structure.enable_hydrogens_visibility()
 		if not hidden_atoms_to_show.is_empty():


### PR DESCRIPTION
Task: TECH DEBT: review usage of get_current_workspace() and get_current_workspace_context()