### PR TITLE
When focusing on selection, ensure the object being created still fits the viewport

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
@@ -83,6 +83,17 @@ func _on_id_pressed(in_id: int) -> void:
 		ID_FOCUS_ON_SELECTED_OBJECTS:
 			assert(workspace_context)
 			var focus_aabb: AABB = WorkspaceUtils.get_selected_objects_aabb(workspace_context)
+			var create_params: CreateObjectParameters = workspace_context.create_object_parameters
+			var create_distance_is_fixed: bool = \
+				create_params.get_create_distance_method() == \
+				CreateObjectParameters.CreateDistanceMethod.FIXED_DISTANCE_TO_CAMERA
+			if create_params.get_create_mode_enabled() and not create_distance_is_fixed:
+				var created_object_aabb: AABB = WorkspaceUtils.get_created_object_aabb(workspace_context)
+				if created_object_aabb != AABB():
+					# center the template AABB in the center of selection
+					created_object_aabb.position = focus_aabb.get_center() - created_object_aabb.size / 2
+					focus_aabb = focus_aabb.expand(created_object_aabb.position)
+					focus_aabb = focus_aabb.expand(created_object_aabb.end)
 			WorkspaceUtils.focus_camera_on_aabb(workspace_context, focus_aabb)
 		ID_HIDE_SELECTED_OBJECTS:
 			assert(workspace_context)

--- a/godot_project/editor/ring_menu_levels/view_menu/ring_action_focus_on_selection.gd
+++ b/godot_project/editor/ring_menu_levels/view_menu/ring_action_focus_on_selection.gd
@@ -29,5 +29,16 @@ func _can_focus() -> bool:
 func _execute_action() -> void:
 	assert(_workspace_context)
 	var focus_aabb: AABB = WorkspaceUtils.get_selected_objects_aabb(_workspace_context)
+	var create_params: CreateObjectParameters = _workspace_context.create_object_parameters
+	var create_distance_is_fixed: bool = \
+		create_params.get_create_distance_method() == \
+		CreateObjectParameters.CreateDistanceMethod.FIXED_DISTANCE_TO_CAMERA
+	if create_params.get_create_mode_enabled() and not create_distance_is_fixed:
+		var created_object_aabb: AABB = WorkspaceUtils.get_created_object_aabb(_workspace_context)
+		if created_object_aabb != AABB():
+			# center the template AABB in the center of selection
+			created_object_aabb.position = focus_aabb.get_center() - created_object_aabb.size / 2
+			focus_aabb = focus_aabb.expand(created_object_aabb.position)
+			focus_aabb = focus_aabb.expand(created_object_aabb.end)
 	WorkspaceUtils.focus_camera_on_aabb(_workspace_context, focus_aabb)
 	_ring_menu.close()

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -51,6 +51,11 @@ static func get_selected_objects_aabb(out_workspace_context: WorkspaceContext) -
 	return _get_selected_objects_aabb(out_workspace_context)
 
 
+## Returns an AABB containing the object, and centered in world origin
+static func get_created_object_aabb(workspace_context: WorkspaceContext) -> AABB:
+	return _get_created_object_aabb(workspace_context)
+
+
 static func focus_camera_on_aabb(out_workspace_context: WorkspaceContext, in_focus_aabb: AABB) -> void:
 	_focus_camera_on_aabb(out_workspace_context, in_focus_aabb)
 
@@ -700,6 +705,24 @@ static func _get_selected_objects_aabb(out_workspace_context: WorkspaceContext) 
 		aabb = aabb.merge(selected_objects_aabbs.pop_back())
 	return aabb
 
+
+static func _get_created_object_aabb(workspace_context: WorkspaceContext) -> AABB:
+	var create_parameters: CreateObjectParameters = workspace_context.create_object_parameters
+	var size := Vector3()
+	match workspace_context.create_object_parameters.get_create_mode_type():
+		CreateObjectParameters.CreateModeType.CREATE_SHAPES:
+			size = create_parameters.get_selected_shape_for_new_objects().get_aabb().abs().size
+		CreateObjectParameters.CreateModeType.CREATE_FRAGMENT:
+			var new_structure: AtomicStructure = create_parameters.get_new_structure() as AtomicStructure
+			if new_structure != null:
+				size = new_structure.get_aabb(AtomicStructure.AABB_BoundsType.ContactRadius).size
+		CreateObjectParameters.CreateModeType.CREATE_VIRTUAL_MOTORS:
+			size = Vector3.ONE
+		CreateObjectParameters.CreateModeType.CREATE_ANCHORS_AND_SPRINGS:
+			size = Vector3.ONE
+		_:
+			pass
+	return AABB(-size/2.0, size)
 
 static func _move_camera_outside_of_aabb(out_workspace_context: WorkspaceContext, aabb: AABB) -> void:
 	var camera: Camera3D = out_workspace_context.get_camera()


### PR DESCRIPTION
Task: BUG: Focusing on selection can make ghost reference shape not fit in the screen