### PR TITLE
Prevent zero-length bonds

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -65,15 +65,12 @@ func _calculate_bond_transform(in_nano_structure: AtomicStructure, in_bond: Vect
 	var second_atom_id: int = in_bond.y
 	var first_atom_position: Vector3 = in_nano_structure.atom_get_position(first_atom_id)
 	var second_atom_position: Vector3 = in_nano_structure.atom_get_position(second_atom_id)
-	var distance_between_atoms: float = first_atom_position.distance_to(second_atom_position)
 	var dir_from_first_to_second: Vector3 = first_atom_position.direction_to(second_atom_position)
 	var up_vector: Vector3 = StickRepresentation._calc_up_vect_for_single_bond(dir_from_first_to_second) if bond_order == 1 else \
 			StickRepresentation._calc_up_vector_for_higher_bond(first_atom_id, second_atom_id, first_atom_position,
 					second_atom_position, in_nano_structure, get_viewport().get_camera_3d())
-	var particle_position: Vector3 = (first_atom_position + second_atom_position) / 2.0
-	var new_transform: Transform3D = Transform3D(Basis(), particle_position)
-	new_transform = new_transform.looking_at(first_atom_position, up_vector)
-	new_transform = new_transform.scaled_local(Vector3(1, 1, distance_between_atoms))
+	var new_transform: Transform3D = calculate_transform_for_bond(first_atom_position,
+			second_atom_position, up_vector)
 	return new_transform
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
@@ -714,7 +714,9 @@ func _calculate_partial_selection_translation(in_bond: Vector3i, in_delta_transl
 static func calculate_transform_for_bond(in_first_pos: Vector3, in_sec_pos: Vector3,
 			in_up_vector: Vector3) -> Transform3D:
 	var particle_position: Vector3 = (in_first_pos + in_sec_pos) / 2.0
-	var length: float = in_first_pos.distance_to(in_sec_pos)
+	# Zero length bonds cause rendering issues. A length 0.025 makes the
+	# capsule stick looks like a sphere when two atoms are at the same place.
+	var length: float = max(0.025, in_first_pos.distance_to(in_sec_pos))
 	var particle_transform: Transform3D = Transform3D(Basis(), particle_position)
 	if particle_transform.origin.distance_squared_to(in_first_pos) > 0.0001:
 		particle_transform = particle_transform.looking_at(in_first_pos, in_up_vector)


### PR DESCRIPTION
Fixes: BUG: two bonded atoms at the same position become invisible in stick view

Maybe fixes: BUG - Weird untouchable objects appear after running "auto-bond"