### PR TITLE
Fix an issue when the workspace contains a single atom centered on the origin

### DIFF
--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -257,6 +257,12 @@ func has_atom_selection(include_children: bool = true) -> bool:
 	return false
 
 
+func is_empty() -> bool:
+	if nano_structure is AtomicStructure:
+		return nano_structure.get_valid_atoms_count() == 0
+	return false
+
+
 func is_empty_but_has_subgroups() -> bool:
 	return nano_structure is AtomicStructure and \
 			nano_structure.get_valid_atoms_count() == 0 and \

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -703,11 +703,15 @@ static func _get_visible_objects_aabb(out_workspace_context: WorkspaceContext) -
 	var visible_objects_aabbs: Array[AABB] = []
 	var visible_structure_contexts: Array[StructureContext] = out_workspace_context.get_visible_structure_contexts()
 	for context in visible_structure_contexts:
-		var aabb: AABB = context.nano_structure.get_aabb().abs()
-		if aabb == AABB():
-			# structure is empty
+		if context.is_empty():
 			continue
-		visible_objects_aabbs.push_back(context.nano_structure.get_aabb().abs())
+		var aabb: AABB
+		if context.nano_structure is AtomicStructure:
+			var atomic_structure: AtomicStructure = context.nano_structure
+			aabb = atomic_structure.get_aabb(AtomicStructure.AABB_BoundsType.VisualRadius).abs()
+		else:
+			aabb = context.nano_structure.get_aabb().abs()
+		visible_objects_aabbs.push_back(aabb)
 	assert(visible_objects_aabbs.size() > 0)
 	
 	var aabb: AABB = visible_objects_aabbs.pop_back()


### PR DESCRIPTION
Fixes: CRASH: placing a single atom at the center of the workspace

The old code assumes the default AABB() means the workspace is empty, which is not true if there's a single atom at (0,0,0) 