### PR TITLE
Mouse selection now allows to select/unselect/multiselect entire molecules with double click

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -4,6 +4,7 @@ extends SelectionInputHandlerBase
 const MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED = 20 * 20
 
 
+var _select_connected_queued_at: int = 0
 var _press_down_position: Vector2 = Vector2(-100, -100)
 
 
@@ -41,6 +42,9 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 		if _activate_selection_logic(in_camera, in_input_event.position, editable_structures):
 			_workspace_context.snapshot_moment("Change Selection")
 			return true
+		# Selection logic needs to happen on mouse release
+		# because of that we give a window of 200 msec for releasing the mouse after double click
+		_select_connected_queued_at = Time.get_ticks_msec()
 	
 	if is_left_mouse_button_event:
 		if in_input_event.is_pressed():
@@ -62,13 +66,17 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 	var editable_structures: Array[StructureContext] = workspace_context.get_editable_structure_contexts()
 	if in_input_event.is_action_pressed(&"unselect", false, true) or \
 		_user_is_unselecting_on_mac_pressed(in_input_event, false, true):
-		var input_consumed: bool = _screen_deselection_logic(in_camera, in_input_event.position, editable_structures)
+		var input_consumed: bool = _select_connected_selection_logic(in_camera, in_input_event.position, editable_structures, false, true)
+		if input_consumed == false:
+			input_consumed = _screen_deselection_logic(in_camera, in_input_event.position, editable_structures)
 		if input_consumed and !get_workspace_context().has_selection():
 			# Selection was cleared, DynamicContextDocker is no longer relevant
 			MolecularEditorContext.request_workspace_docker_focus(CreateDocker.UNIQUE_DOCKER_NAME)
 		return input_consumed
 	elif in_input_event.is_action_pressed(&"multiselect", false, true) or _user_is_selecting_on_mac_pressed(in_input_event, false, true):
-		var input_consumed: bool = _screen_selection_logic(in_camera, in_input_event.position, editable_structures, true)
+		var input_consumed: bool = _select_connected_selection_logic(in_camera, in_input_event.position, editable_structures, true)
+		if input_consumed == false:
+			input_consumed = _screen_selection_logic(in_camera, in_input_event.position, editable_structures, true)
 		if input_consumed:
 			if !get_workspace_context().has_selection():
 				# Selection was cleared, DynamicContextDocker is no longer relevant
@@ -103,7 +111,9 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 		if rendering.is_virtual_anchor_preview_visible():
 			# Virtual Anchor and/or Spring is being created, avoid changing selection
 			return false
-		var input_consumed: bool = _screen_selection_logic(in_camera, in_input_event.position, editable_structures, false)
+		var input_consumed: bool = _select_connected_selection_logic(in_camera, in_input_event.position, editable_structures, false)
+		if input_consumed == false:
+			input_consumed = _screen_selection_logic(in_camera, in_input_event.position, editable_structures, false)
 		if input_consumed:
 			if !get_workspace_context().has_selection():
 				if MolecularEditorContext.is_workspace_docker_active(DynamicContextDocker.UNIQUE_DOCKER_NAME):
@@ -281,6 +291,70 @@ func _activate_selection_logic(
 				return false
 			get_workspace_context().change_current_structure_context(affected_context)
 			return true
+	return false
+
+
+func _select_connected_selection_logic(
+			in_camera: Camera3D,
+			in_screen_position: Vector2,
+			out_editable_structures: Array[StructureContext],
+			in_is_multiselect: bool,
+			in_is_deselect: bool = false) -> bool:
+	if Time.get_ticks_msec() - _select_connected_queued_at > 200 or out_editable_structures.is_empty():
+		return false
+	
+	var multi_structure_hit_result := MultiStructureHitResult.new(in_camera, in_screen_position, out_editable_structures)
+	if multi_structure_hit_result.did_hit():
+		# perform selection
+		var hit_context: StructureContext = multi_structure_hit_result.closest_hit_structure_context
+		if hit_context != get_workspace_context().get_current_structure_context():
+			return false
+		if multi_structure_hit_result.hit_type != MultiStructureHitResult.HitType.HIT_ATOM:
+			# Bonds doesn't count
+			return false
+		var hit_atom: int = multi_structure_hit_result.closest_hit_atom_id
+		var result: Dictionary[StringName, PackedInt32Array] = \
+				hit_context.find_atoms_and_bonds_connected_to(hit_atom)
+		var atoms: PackedInt32Array = result.atoms
+		var bonds: PackedInt32Array = result.bonds
+		var selected_atoms: PackedInt32Array = hit_context.get_selected_atoms()
+		var selected_bonds: PackedInt32Array = hit_context.get_selected_bonds()
+		var int_in_array: Callable = func (id: int, array: PackedInt32Array) -> bool:
+			return id in array
+		# Case 1: deselect connected
+		if in_is_deselect:
+			var any_selected: int = (
+				Array(atoms).any(int_in_array.bind(selected_atoms))
+				and
+				Array(bonds).any(int_in_array.bind(selected_bonds))
+			)
+			if any_selected:
+				hit_context.deselect_atoms(atoms)
+				hit_context.deselect_bonds(bonds)
+				return true
+			return false
+		# When double clicking an atom and holding shift, the first click will deselect the atom
+		# This is why this condition excludes it
+		var atoms_without_clicked := Array(atoms.duplicate())
+		atoms_without_clicked.erase(hit_atom)
+		var all_except_clicked_selected: int = (
+			atoms_without_clicked.all(int_in_array.bind(selected_atoms))
+			and
+			Array(bonds).all(int_in_array.bind(selected_bonds))
+		)
+		# Case 2: if all is selected, deselect it, no matter keyboard shortcuts
+		if all_except_clicked_selected:
+			hit_context.deselect_atoms(atoms)
+			hit_context.deselect_bonds(bonds)
+			return true
+		# Case 3: if not multiselection, deselect all before selecting atoms and bonds
+		if not in_is_multiselect:
+			hit_context.deselect_atoms(selected_atoms)
+			hit_context.deselect_bonds(selected_bonds)
+		# Case 4 (and second part of 3): select connected atoms and bonds
+		hit_context.select_atoms(atoms)
+		hit_context.select_bonds(bonds)
+		return true
 	return false
 
 

--- a/godot_project/project_workspace/structs/atomic_structure.gd
+++ b/godot_project/project_workspace/structs/atomic_structure.gd
@@ -655,6 +655,33 @@ func atom_has_motor_link(_in_atom_id: int) -> bool:
 	return false
 
 
+## Returns a Dictionary with all atoms and bonds linked by bonds to in_atom_id.
+## You can access to each list with the members &"atoms" and &"bonds"
+func find_atoms_and_bonds_connected_to(in_atom_id: int) -> Dictionary[StringName, PackedInt32Array]:
+	var visited_atoms: Dictionary[int, bool] = {}
+	var visited_bonds: Dictionary[int, bool] = {}
+	# new_findings is a dctionary to automatically remove duplicates if 2 atoms
+	# have bonds to the same atom in the same look
+	var new_findings: Dictionary[int, bool] = { in_atom_id : true }
+	while not new_findings.is_empty():
+		var atoms_to_watch := PackedInt32Array(new_findings.keys())
+		new_findings = {}
+		for atom_id: int in atoms_to_watch:
+			visited_atoms[atom_id] = true
+			var atom_bonds: PackedInt32Array = atom_get_bonds(atom_id)
+			for bond_id: int in atom_bonds:
+				visited_bonds[bond_id] = true
+				var other_atom_id: int = atom_get_bond_target(atom_id, bond_id)
+				if visited_atoms.get(other_atom_id, false) == true:
+					continue
+				new_findings[other_atom_id] = true
+	var result: Dictionary[StringName, PackedInt32Array] = {
+		&"atoms": PackedInt32Array(visited_atoms.keys()),
+		&"bonds": PackedInt32Array(visited_bonds.keys()),
+	}
+	return result
+
+
 ## Returns the int_guid of the NanoVirtualMotor connected to [code]in_atom_id[/code] or 0 if not linked
 func motor_link_get_motor_id(_in_atom_id: int) -> int:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -331,6 +331,12 @@ func select_connected(in_show_hidden_objects: bool = false) -> void:
 	return _selection_db.select_connected(in_show_hidden_objects)
 
 
+func find_atoms_and_bonds_connected_to(in_atom_id: int) -> Dictionary[StringName, PackedInt32Array]:
+	if not nano_structure is AtomicStructure:
+		return {}
+	return nano_structure.find_atoms_and_bonds_connected_to(in_atom_id)
+
+
 func can_grow_selection() -> bool:
 	if _selection_db.has_cached_selection_set():
 		return true


### PR DESCRIPTION
- If holding Ctrl|Cmd, all connected atoms and bonds will be removed from the selection
- If holding shift, the molecule will be added to the selection
- If holding shift, but the molecule was already selected, it will be removed from selection
- If no button is held, seleciton will be replaced with molecule
- If a subgroup is double clicked, then the active group changes, just like before
- This gives a more refined and intuitive way of selecting than the L shortcut

Task: UX SUGGESTION: Double clicking an atom that is part of the active group, selects all linked atoms