### PR TITLE
Update topbar submenues when root menues updates

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_create/menu_atoms/menu_atoms.gd
+++ b/godot_project/editor/controls/menu_bar/menu_create/menu_atoms/menu_atoms.gd
@@ -75,11 +75,10 @@ func _update_for_context(in_context: WorkspaceContext) -> void:
 		set_item_disabled(get_item_index(ID_AUTO_BONDER), true)
 
 	# Validate Add Hydrogens
+	set_item_disabled(get_item_index(ID_ADD_HYDROGENS), true)
 	for context in in_context.get_visible_structure_contexts():
 		if context.nano_structure is AtomicStructure and context.nano_structure.get_valid_atoms_count() > 0:
 			set_item_disabled(get_item_index(ID_ADD_HYDROGENS), false)
-			return
-	set_item_disabled(get_item_index(ID_ADD_HYDROGENS), true)
 	
 	# Validate Lock/Unlock atoms
 	var has_selection: bool = in_context.is_any_atom_selected()

--- a/godot_project/editor/controls/menu_bar/menu_create/menu_create.gd
+++ b/godot_project/editor/controls/menu_bar/menu_create/menu_create.gd
@@ -2,9 +2,9 @@ extends NanoPopupMenu
 
 signal request_hide
 
-@onready var atoms: PopupMenu = $Atoms
-@onready var shapes: PopupMenu = $Shapes
-@onready var virtual_objects: PopupMenu = $VirtualObjects
+@onready var atoms: NanoPopupMenu = $Atoms
+@onready var shapes: NanoPopupMenu = $Shapes
+@onready var virtual_objects: NanoPopupMenu = $VirtualObjects
 
 const ID_CREATE_SMALL_MOLECULES = 1
 
@@ -17,7 +17,9 @@ func _ready() -> void:
 	add_submenu_item("Virtual Objects", virtual_objects.name)
 
 func _update_menu() -> void:
-	pass
+	atoms._update_menu()
+	shapes._update_menu()
+	virtual_objects._update_menu()
 
 func _on_id_pressed(in_id: int) -> void:
 	if in_id == ID_CREATE_SMALL_MOLECULES:

--- a/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
@@ -8,6 +8,7 @@ signal request_hide
 @export var shortcut_hide_selected_objects: Shortcut
 @export var shortcut_show_hidden_objects: Shortcut
 
+@onready var camera_submenu: NanoPopupMenu = $Camera
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -35,6 +36,7 @@ func _ready() -> void:
 func _update_menu() -> void:
 	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
 	_update_for_context(workspace_context)
+	camera_submenu._update_menu()
 
 
 func _update_for_context(in_context: WorkspaceContext) -> void:


### PR DESCRIPTION
- This oversight caused several options to be available when they shouldn't. In example:
	- Lock Atoms available when not atoms selected
	- Correct Hydrogens available when hydrogens hidden
	- Change camera, select atom elements, select shape type, etc; when no workspace was active

Task: BUG -- CMD+L causes strange graphics flash