### PR TITLE
Change input event for unselecting in MacOS

### DIFF
--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -258,7 +258,7 @@ cancel={
 }
 unselect_mac={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"button_mask":2,"position":Vector2(498, 35),"global_position":Vector2(1186, 494),"factor":1.0,"button_index":2,"canceled":false,"pressed":true,"double_click":false,"script":null)
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"button_mask":2,"position":Vector2(498, 35),"global_position":Vector2(1186, 494),"factor":1.0,"button_index":2,"canceled":false,"pressed":true,"double_click":false,"script":null)
 ]
 }
 select_mac={


### PR DESCRIPTION
DISCLAIMER: this is untested

Task: UX SUGGESTION: Double clicking an atom that is part of the active group, selects all linked atoms