### PR TITLE
Fix for not being able to open video tutorials and documentation from the welcome page

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_help/menu_help.gd
+++ b/godot_project/editor/controls/menu_bar/menu_help/menu_help.gd
@@ -23,10 +23,6 @@ func _on_id_pressed(id: int) -> void:
 		POPUP_ID_ABOUT_MSEP_ONE:
 			get_tree().notification(NOTIFICATION_WM_ABOUT)
 		POPUP_ID_DOCUMENTATION:
-			var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-			if workspace_context != null:
-				workspace_context.action_documentation.execute()
+			RingActionOpenDocumentation.open_documentation()
 		POPUP_ID_VIDEO_TUTORIALS:
-			var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-			if workspace_context != null:
-				workspace_context.action_video_tutorials.execute()
+			RingActionVideoTutorials.open_video_tutorials_dialog()

--- a/godot_project/editor/ring_menu_levels/help_menu/ring_action_documentation.gd
+++ b/godot_project/editor/ring_menu_levels/help_menu/ring_action_documentation.gd
@@ -24,6 +24,11 @@ func get_icon() -> RingMenuIcon:
 
 
 func _execute_action() -> void:
+	RingActionOpenDocumentation.open_documentation()
+	_ring_menu.close()
+
+
+static func open_documentation() -> void:
 	if not FileAccess.file_exists(DOCUMENTATION_PATH_SOURCE):
 		printerr("Trying to open documentation, but I cannot find the source file")
 		return
@@ -34,10 +39,9 @@ func _execute_action() -> void:
 		FileUtils.copy_file_from_to(DOCUMENTATION_PATH_SOURCE, destination_documentation_path)
 	
 	OS.shell_open(ProjectSettings.globalize_path(destination_documentation_path))
-	_ring_menu.close()
 
 
-func _need_to_refresh_user_file(in_user_file_path: String) -> bool:
+static func _need_to_refresh_user_file(in_user_file_path: String) -> bool:
 	if not FileAccess.file_exists(in_user_file_path):
 		return true
 	

--- a/godot_project/editor/ring_menu_levels/help_menu/ring_action_video_tutorials.gd
+++ b/godot_project/editor/ring_menu_levels/help_menu/ring_action_video_tutorials.gd
@@ -8,14 +8,11 @@ const VIDEO_TUTORIALS_FOLDER_PATH: String = "res://documentation/video_tutorials
 
 var _workspace_context: WorkspaceContext = null
 var _ring_menu: NanoRingMenu = null
-var _tutorials_dialog: VideoTutorialsDialog = null
 
 
 func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> void:
 	_workspace_context = in_workspace_context
 	_ring_menu = in_menu
-	var molecular_editor: MolecularEditor = Editor_Utils.get_editor()
-	_tutorials_dialog = molecular_editor.video_tutorials_dialog
 	super._init(
 		tr("Video Tutorials"),
 		_execute_action,
@@ -28,5 +25,9 @@ func get_icon() -> RingMenuIcon:
 
 
 func _execute_action() -> void:
+	RingActionVideoTutorials.open_video_tutorials_dialog()
 	_ring_menu.close()
-	_tutorials_dialog.popup_centered_ratio(0.5)
+
+static func open_video_tutorials_dialog() -> void:
+	var molecular_editor: MolecularEditor = Editor_Utils.get_editor()
+	molecular_editor.video_tutorials_dialog.popup_centered_ratio(0.5)


### PR DESCRIPTION
Task: BUG: Menu "Help > Tutorials and Instructions" and "Help > Video Tutorials" doesn't work when in Welcome tab