### PR TITLE
Fix remaining valence calculation for elements close to helium

### DIFF
--- a/godot_project/autoloads/openmm/openmm_payload.gd
+++ b/godot_project/autoloads/openmm/openmm_payload.gd
@@ -544,6 +544,8 @@ func _calculate_remaining_valence(in_structure: AtomicStructure, in_atom_id: int
 	var valence_left: int = data.valence
 	if data.number > 5:
 		valence_left = 8 - valence_left
+	else:
+		valence_left = 2 - valence_left
 	valence_left -= used_valence
 	return valence_left
 


### PR DESCRIPTION
Task: BUG: Relax with "Treat incomplete valences as if they have been filled with hydrogens" tries to passivate Helium atoms