### PR TITLE
Disable options from View menu while no worksapce is active

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_view/menu_camera/menu_camera.gd
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_camera/menu_camera.gd
@@ -27,6 +27,8 @@ func _update_menu() -> void:
 func _update_for_context(in_context: WorkspaceContext) -> void:
 	var has_context: bool = is_instance_valid(in_context)
 	set_item_disabled(get_item_index(ID_CAPTURE_CAMERA_IMAGE), !has_context)
+	set_item_disabled(get_item_index(ID_CAMERA_PROJECTION), !has_context)
+	set_item_disabled(get_item_index(ID_EDIT_CAMERA), !has_context)
 	if has_context:
 		var has_visible_objects: bool = in_context.get_visible_structure_contexts().size() > 0
 		set_item_disabled(get_item_index(ID_CAPTURE_CAMERA_IMAGE), !has_visible_objects)

--- a/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
@@ -59,7 +59,6 @@ func _update_for_context(in_context: WorkspaceContext) -> void:
 		set_item_disabled(get_item_index(ID_SHOW_HIDDEN_OBJECTS), !has_hidden_objects)
 		set_item_disabled(get_item_index(ID_OVERRIDE_DEFAULT_COLORS), !in_context.is_any_atom_selected())
 		
-		
 		var current_representation: int = in_context.workspace.representation_settings.get_rendering_representation()
 		set_item_disabled(get_item_index(ID_REPRESENTATION_VAN_DER_WAALS), \
 			Rendering.Representation.VAN_DER_WAALS_SPHERES == current_representation)
@@ -71,12 +70,21 @@ func _update_for_context(in_context: WorkspaceContext) -> void:
 			Rendering.Representation.ENHANCED_STICKS == current_representation)
 		set_item_disabled(get_item_index(ID_REPRESENTATION_BALLS_AND_STICKS), \
 			Rendering.Representation.BALLS_AND_STICKS == current_representation)
+	else:
+		for i: int in item_count:
+			if is_item_separator(i) or get_item_submenu_node(i) != null:
+				continue
+			if get_item_id(i) in [ID_TOGGLE_FEATURE_FLAGS_MANAGER, ID_SHOW_ALGORITHM_TWEAKS]:
+				continue
+			set_item_disabled(i, true)
 	set_item_checked(get_item_index(ID_TOGGLE_OBJECT_TREE_VIEW), visible_object_tree)
 
 
 func _on_id_pressed(in_id: int) -> void:
 	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-	var representation_settings: RepresentationSettings = workspace_context.workspace.representation_settings
+	var representation_settings: RepresentationSettings = null
+	if workspace_context != null:
+		representation_settings = workspace_context.workspace.representation_settings
 	match in_id:
 		ID_FOCUS_ON_VISIBLE_OBJECTS:
 			assert(workspace_context)

--- a/godot_project/editor/controls/menu_bar/menu_view/menu_view.tscn
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_view.tscn
@@ -138,4 +138,3 @@ shortcut_hide_selected_objects = SubResource("Shortcut_suqnu")
 shortcut_show_hidden_objects = SubResource("Shortcut_hp7en")
 
 [node name="Camera" parent="." instance=ExtResource("21_qnyh1")]
-unfocusable = true

--- a/godot_project/editor/controls/menu_bar/msep_popup_menu.gd
+++ b/godot_project/editor/controls/menu_bar/msep_popup_menu.gd
@@ -3,6 +3,7 @@ class_name NanoPopupMenu extends PopupMenu
 
 func _init() -> void:
 	hide()
+	MolecularEditorContext.homepage_activated.connect(_on_workspace_activated.bind(null))
 	MolecularEditorContext.workspace_activated.connect(_on_workspace_activated)
 	about_to_popup.connect(_on_about_to_popup)
 	popup_hide.connect(_on_popup_hide)


### PR DESCRIPTION
Tasks:
- CRASH: Menu "View > Feature Flags" crashes if clicked from the Welcome tab
- BUG: Several items available in "View" menu from the Welcome tab
