### PR TITLE
Disable 'Create>Atoms>Correct Overlapping Atoms' when cannot be used

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_create/menu_atoms/menu_atoms.gd
+++ b/godot_project/editor/controls/menu_bar/menu_create/menu_atoms/menu_atoms.gd
@@ -60,6 +60,7 @@ func _update_for_context(in_context: WorkspaceContext) -> void:
 			set_item_disabled(get_item_index(ID_AUTO_BONDER), true)
 		set_item_disabled(get_item_index(ID_ADD_HYDROGENS), true)
 		set_item_disabled(get_item_index(ID_LOCK_UNLOCK_SELECTED_ATOMS), true)
+		set_item_disabled(get_item_index(ID_CORRECT_OVERLAPPING_ATOMS), true)
 		return
 	
 	# Validate Auto Bonder
@@ -83,6 +84,10 @@ func _update_for_context(in_context: WorkspaceContext) -> void:
 	# Validate Lock/Unlock atoms
 	var has_selection: bool = in_context.is_any_atom_selected()
 	set_item_disabled(get_item_index(ID_LOCK_UNLOCK_SELECTED_ATOMS), not has_selection)
+	
+	# Validate Correct Overlapping Atoms
+	var has_valid_atoms: bool = in_context.has_valid_atoms()
+	set_item_disabled(get_item_index(ID_CORRECT_OVERLAPPING_ATOMS), not has_valid_atoms)
 
 
 func _on_id_pressed(in_id: int) -> void:


### PR DESCRIPTION
Depends on #412 (Can be merged individually, but needs [this change](https://github.com/MSEP-one/msep.one/blob/3a2dfff7911a1d0e1916a25f6b8e513f88ecfd7e/godot_project/editor/controls/menu_bar/msep_popup_menu.gd#L6) to work properly on Welcome tab

Task: BUG: Menu "Create > Atoms > Correct Overlapping Atoms" available in Welcome tab