### PR TITLE
Disable 'Create>SmallMolecules' menu when no workspace active

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_create/menu_create.gd
+++ b/godot_project/editor/controls/menu_bar/menu_create/menu_create.gd
@@ -16,10 +16,19 @@ func _ready() -> void:
 	add_submenu_item(tr("Shapes"), shapes.name)
 	add_submenu_item("Virtual Objects", virtual_objects.name)
 
+
 func _update_menu() -> void:
 	atoms._update_menu()
 	shapes._update_menu()
 	virtual_objects._update_menu()
+	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
+	_update_for_context(workspace_context)
+
+
+func _update_for_context(in_context: WorkspaceContext) -> void:
+	var has_context: bool = is_instance_valid(in_context)
+	set_item_disabled(get_item_index(ID_CREATE_SMALL_MOLECULES), !has_context)
+
 
 func _on_id_pressed(in_id: int) -> void:
 	if in_id == ID_CREATE_SMALL_MOLECULES:


### PR DESCRIPTION
Depends on #412 (Can be merged individually, but needs [this change](https://github.com/MSEP-one/msep.one/blob/3a2dfff7911a1d0e1916a25f6b8e513f88ecfd7e/godot_project/editor/controls/menu_bar/msep_popup_menu.gd#L6) to work properly on Welcome tab

Task: BUG: Menu "Create > Small Molecules" available in Welcome tab