### PR TITLE
Disable menu 'Create>VirtualObjects' when no workspace is active

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_virtual_objects/menu_virtual_objects.gd
+++ b/godot_project/editor/controls/menu_bar/menu_virtual_objects/menu_virtual_objects.gd
@@ -35,6 +35,9 @@ func _update_menu() -> void:
 				add_icon_item(data[&"icon"], data[&"text"], id)
 			else:
 				remove_item(get_item_index(id))
+	var has_context: bool = MolecularEditorContext.get_current_workspace() != null
+	for i in item_count:
+		set_item_disabled(i, not has_context)
 
 
 func _on_id_pressed(in_id: int) -> void:


### PR DESCRIPTION
Depends on #412 (Can be merged individually, but needs [this change](https://github.com/MSEP-one/msep.one/blob/3a2dfff7911a1d0e1916a25f6b8e513f88ecfd7e/godot_project/editor/controls/menu_bar/msep_popup_menu.gd#L6) to work properly on Welcome tab

Task: BUG: All virtual Objects in "Create > Virtual Objects" submenu are available from Welcome tab