### PR TITLE
Expose the maximum atom candidates in the workspace settings

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.gd
@@ -1,18 +1,26 @@
 extends DynamicContextControl
 
 
-@onready var max_undo_count_spinbox: SpinBox = %MaxUndoCountSpinbox
+@onready var max_undo_count_spinbox: SpinBoxSlider = %MaxUndoCountSpinbox
+@onready var max_atom_candidates_spinbox: SpinBoxSlider = %MaxAtomCandidatesSpinbox
 
 
 func _ready() -> void:
-	max_undo_count_spinbox.value_changed.connect(_on_max_undo_count_spinbox_value_changed)
+	max_undo_count_spinbox.value_confirmed.connect(_on_max_undo_count_spinbox_value_confirmed)
+	max_atom_candidates_spinbox.value_confirmed.connect(_on_max_atom_candidates_spinbox_value_confirmed)
 
 
 func should_show(_in_workspace_context: WorkspaceContext)-> bool:
 	var max_undo_count: int = MolecularEditorContext.msep_editor_settings.editor_max_undo_count
 	max_undo_count_spinbox.set_value_no_signal(max_undo_count)
+	var max_candidates_count: int = MolecularEditorContext.msep_editor_settings.editor_max_atom_candidates
+	max_atom_candidates_spinbox.set_value_no_signal(max_candidates_count)
 	return true
 
 
-func _on_max_undo_count_spinbox_value_changed(in_value: float) -> void:
+func _on_max_undo_count_spinbox_value_confirmed(in_value: float) -> void:
 	MolecularEditorContext.msep_editor_settings.editor_max_undo_count = int(in_value)
+
+
+func _on_max_atom_candidates_spinbox_value_confirmed(in_value: float) -> void:
+	MolecularEditorContext.msep_editor_settings.editor_max_atom_candidates = int(in_value)

--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://cjvjuaxjbr4vn"]
+[gd_scene load_steps=3 format=3 uid="uid://cjvjuaxjbr4vn"]
 
 [ext_resource type="Script" uid="uid://wf4j5hsnus1g" path="res://editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.gd" id="1_ljkt2"]
+[ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="2_c3eig"]
 
 [node name="PerformanceSettings" type="VBoxContainer"]
 offset_right = 484.0
@@ -16,17 +17,38 @@ text = "Performance"
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/HBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Maximum Undo Steps"
 
-[node name="MaxUndoCountSpinbox" type="SpinBox" parent="PanelContainer/HBoxContainer"]
+[node name="MaxUndoCountSpinbox" parent="PanelContainer/VBoxContainer/HBoxContainer" instance=ExtResource("2_c3eig")]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 1
 max_value = 512.0
 value = 128.0
-allow_greater = true
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+layout_mode = 2
+tooltip_text = "The maximum amount of selected atoms before the suggestions are turned off.
+
+Atom candidates appear when atoms are selected and Create Mode is active (press Alt to force show the suggestions)."
+
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Maximum Atom Candidates"
+
+[node name="MaxAtomCandidatesSpinbox" parent="PanelContainer/VBoxContainer/HBoxContainer2" instance=ExtResource("2_c3eig")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 1
+max_value = 512.0
+value = 50.0

--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -2,7 +2,6 @@ extends InputHandlerCreateObjectBase
 
 
 const MAX_MERGE_DISTANCE: float = 0.069
-const MAX_ATOMS_FOR_AUTO_POSING: int = 50
 # H-H bond is 0.075 nm, that is the closest 2 atoms should be
 const MIN_DISTANCE_TO_ATOMS: float = 0.069
 const AtomCandidate = AtomAutoposePreview.AtomCandidate
@@ -69,6 +68,7 @@ func _init(in_context: WorkspaceContext) -> void:
 	_workspace_context.simulation_finished.connect(_on_workspace_context_simulation_started_or_finished)
 	var representation_settings: RepresentationSettings = _workspace_context.workspace.representation_settings
 	representation_settings.changed.connect(_on_representation_settings_changed)
+	MolecularEditorContext.msep_editor_settings.changed.connect(_on_editor_settings_changed)
 
 
 func _on_current_structure_context_changed(in_context: StructureContext) -> void:
@@ -267,10 +267,11 @@ func _update_candidates() -> void:
 	
 	var context: StructureContext = _workspace_context.get_current_structure_context()
 	var total_atoms_selected: int = context.get_selected_atoms().size()
-	if total_atoms_selected > MAX_ATOMS_FOR_AUTO_POSING:
+	var max_candidates: int = MolecularEditorContext.msep_editor_settings.editor_max_atom_candidates
+	if total_atoms_selected > max_candidates:
 		_get_rendering().atom_autopose_preview_set_candidates(_candidates)
 		_workspace_context.get_editor_viewport_container().show_warning_in_message_bar(\
-			"Selecting over 50 atoms hides Potential Atom Position. Select fewer to enable this feature.")
+			"Selecting over %d atoms hides Potential Atom Position. Select fewer atoms or increase the limit in the Workspace Settings to enable this feature." % max_candidates)
 		return
 	
 	var candidate_data: ElementData = PeriodicTable.get_by_atomic_number(_element_selected)
@@ -616,6 +617,10 @@ func _on_workspace_context_atom_relaxation_started() -> void:
 func _on_workspace_context_atoms_relaxation_finished(_error: String) -> void:
 	if _should_show():
 		_show_preview()
+
+
+func _on_editor_settings_changed() -> void:
+	_candidates_dirty = true
 
 
 func _check_input_event_can_bind(in_event: InputEventWithModifiers, in_only_join_candidates: bool) -> bool:

--- a/godot_project/editor/settings/msep_settings.gd
+++ b/godot_project/editor/settings/msep_settings.gd
@@ -28,6 +28,8 @@ var _ui_sfx_bus_index: int =  AudioServer.get_bus_index(&"Ui Sfx")
 	set = set_editor_camera_orthographic_projection_enabled
 @export var editor_max_undo_count: int = 128:
 	set = set_editor_max_undo_count
+@export var editor_max_atom_candidates: int = 50:
+	set = set_editor_max_atom_candidates
 @export var custom_background_color: Color:
 	set = set_custom_background_color
 @export var custom_background_color_enabled: bool = false:
@@ -72,6 +74,11 @@ func set_editor_sfx_volume_db(in_value_db: float) -> void:
 
 func set_editor_max_undo_count(in_value: int) -> void:
 	editor_max_undo_count = in_value
+	changed.emit()
+
+
+func set_editor_max_atom_candidates(in_value: int) -> void:
+	editor_max_atom_candidates = in_value
 	changed.emit()
 
 


### PR DESCRIPTION
Fixes: "UX: Support to change or disable the maximum amount of selected atoms to provide autopose candidate"