### PR TITLE
Gracefully handle aborting simulations when closing a workspace

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -71,6 +71,7 @@ func _ensure_workspace_initialized(out_workspace_context: WorkspaceContext) -> v
 		_workspace_context = out_workspace_context
 		out_workspace_context.about_to_apply_simulation.connect(_on_workspace_context_about_to_apply_simulation)
 		out_workspace_context.alerts_panel_visibility_changed.connect(_on_workspace_context_alerts_panel_visibility_changed)
+		out_workspace_context.tree_exiting.connect(_on_workspace_closed)
 		_open_mm_failure_tracker.set_workspace_context(out_workspace_context)
 		# Initialize UI
 		var params: SimulationParameters = out_workspace_context.workspace.simulation_parameters
@@ -149,6 +150,11 @@ func _on_workspace_context_about_to_apply_simulation() -> void:
 
 func _on_workspace_context_alerts_panel_visibility_changed(in_is_visible: bool) -> void:
 	_button_view_alerts.visible = (not in_is_visible) and _workspace_context.has_alerts()
+
+
+func _on_workspace_closed() -> void:
+	# Dont process any ongoing simulation anymore
+	set_physics_process(false)
 
 
 func _set_status(in_status: Status) -> void:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -143,7 +143,9 @@ func _notification(what: int) -> void:
 	
 	if what == NOTIFICATION_PREDELETE:
 		create_object_parameters = null
-	
+		if is_simulating():
+			# Let OpenMM know it doesn't need to process this simulation anymore
+			OpenMM.request_abort_simulation(_simulation)
 		if is_instance_valid(workspace_main_view):
 			if not workspace_main_view.is_inside_tree():
 				workspace_main_view.free()


### PR DESCRIPTION
Task: CRASH: Closing a workspace during simulation