### PR TITLE
Fixes to #416

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.tscn
@@ -32,8 +32,10 @@ text = "Maximum Undo Steps"
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 1
+mouse_filter = 1
 max_value = 512.0
 value = 128.0
+allow_greater = true
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
 layout_mode = 2
@@ -50,5 +52,7 @@ text = "Maximum Atom Candidates"
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 1
+mouse_filter = 1
 max_value = 512.0
 value = 50.0
+allow_greater = true


### PR DESCRIPTION
Fix the tooltip not appearing when hovering the spinbox, and allows setting a higher value than the spinbox max value.