### PR TITLE
Fix atom candidates wording in the performance settings panel

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.gd
@@ -8,6 +8,7 @@ extends DynamicContextControl
 func _ready() -> void:
 	max_undo_count_spinbox.value_confirmed.connect(_on_max_undo_count_spinbox_value_confirmed)
 	max_atom_candidates_spinbox.value_confirmed.connect(_on_max_atom_candidates_spinbox_value_confirmed)
+	_configure_tooltips()
 
 
 func should_show(_in_workspace_context: WorkspaceContext)-> bool:
@@ -24,3 +25,12 @@ func _on_max_undo_count_spinbox_value_confirmed(in_value: float) -> void:
 
 func _on_max_atom_candidates_spinbox_value_confirmed(in_value: float) -> void:
 	MolecularEditorContext.msep_editor_settings.editor_max_atom_candidates = int(in_value)
+
+
+func _configure_tooltips() -> void:
+	var container: Control = max_atom_candidates_spinbox.get_parent()
+	var shortcut: String = "Option ⌥" if Editor_Utils.is_mac() else "Alt"
+	container.tooltip_text = "The maximum amount of selected atoms before the suggestions are turned off.
+		Atom candidates appear when atoms are selected and Create Mode is active.
+		
+		(Press %s to enter 'Create mode' and show the suggestions)." % shortcut

--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/performance_settings.tscn
@@ -4,8 +4,8 @@
 [ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="2_c3eig"]
 
 [node name="PerformanceSettings" type="VBoxContainer"]
-offset_right = 484.0
-offset_bottom = 213.0
+offset_right = 494.0
+offset_bottom = 114.0
 script = ExtResource("1_ljkt2")
 
 [node name="Label" type="Label" parent="."]
@@ -39,19 +39,18 @@ allow_greater = true
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
 layout_mode = 2
-tooltip_text = "The maximum amount of selected atoms before the suggestions are turned off.
-
-Atom candidates appear when atoms are selected and Create Mode is active (press Alt to force show the suggestions)."
 
 [node name="Label" type="Label" parent="PanelContainer/VBoxContainer/HBoxContainer2"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "Maximum Atom Candidates"
+text = "Selection Limit for Potential Atom Suggestions"
+autowrap_mode = 2
 
 [node name="MaxAtomCandidatesSpinbox" parent="PanelContainer/VBoxContainer/HBoxContainer2" instance=ExtResource("2_c3eig")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 1
+size_flags_vertical = 4
 mouse_filter = 1
 max_value = 512.0
 value = 50.0

--- a/godot_project/utils/Editor_Utils.gd
+++ b/godot_project/utils/Editor_Utils.gd
@@ -41,6 +41,10 @@ static func get_msep_version(in_include_features: bool = true) -> String:
 	return msep_version
 
 
+static func is_mac() -> bool:
+	return OS.get_name().to_lower() in ["macos", "ios"]
+
+
 static func _collect_godot_features() -> String:
 	var godot_features: PackedStringArray = []
 	var all_features: Array[String] = [


### PR DESCRIPTION
Follow up to "UX: Support to change or disable the maximum amount of selected atoms to provide autopose candidate"