### PR TITLE
Added keyboard shortcuts to snap the camera to cartesian directions

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/camera_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/camera_settings.gd
@@ -19,6 +19,7 @@ func _ready() -> void:
 	invert_camera_orbit_y_check_button.toggled.connect(_on_toggle_invert_orbit_y)
 	perspective_button.toggled.connect(_on_perspective_button_toggled)
 	orthographic_button.toggled.connect(_on_orthographic_button_toggled)
+	MolecularEditorContext.msep_editor_settings.changed.connect(_on_msep_editor_settings_changed)
 
 
 func should_show(_in_workspace_context: WorkspaceContext)-> bool:
@@ -47,3 +48,9 @@ func _on_orthographic_button_toggled(in_enabled: bool) -> void:
 	if not in_enabled:
 		return
 	MolecularEditorContext.msep_editor_settings.editor_camera_orthographic_projection_enabled = true
+
+func _on_msep_editor_settings_changed() -> void:
+	# Camera projection can change with keyboard shortcuts:
+	var is_orthographic: bool = MolecularEditorContext.msep_editor_settings.editor_camera_orthographic_projection_enabled
+	orthographic_button.set_pressed_no_signal(is_orthographic)
+	perspective_button.set_pressed_no_signal(not is_orthographic)

--- a/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
+++ b/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
@@ -40,6 +40,10 @@ func _ready() -> void:
 	GizmoRoot.rotation_ended.connect(_on_transform_rotation_ended)
 
 
+func snap_to_rotation(in_rotation : Vector3) -> void:
+	_orientation_widget.snap_to_rotation(in_rotation)
+
+
 func _set_workspace_context(in_workspace_context: WorkspaceContext) -> void:
 	if workspace_context == in_workspace_context:
 		return

--- a/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/DrawOrientationWidget.gd
+++ b/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/DrawOrientationWidget.gd
@@ -246,7 +246,7 @@ func _calculate_screen_offset(in_orbit_radius: float) -> Vector3:
 	return center_of_viewport3D - center_of_rect3D
 
 
-func _calculate_snap(in_rotation : Vector3) -> void:
+func snap_to_rotation(in_rotation : Vector3) -> void:
 	if !MolecularEditorContext.get_current_workspace_context().has_visible_objects():
 		return
 	
@@ -276,14 +276,14 @@ func _calculate_axis_snap(in_axis_char: String, in_non_inverted_rotation: Vector
 		in_inverted_rotation: Vector3) -> void:
 	if axis_depths[colliding_axis_index][4]:
 		if _determine_axis_overlap(in_axis_char, true, axis_depths[colliding_axis_index][1]):
-			_calculate_snap(in_non_inverted_rotation)
+			snap_to_rotation(in_non_inverted_rotation)
 		else:
-			_calculate_snap(in_inverted_rotation)
+			snap_to_rotation(in_inverted_rotation)
 	else:
 		if _determine_axis_overlap(in_axis_char, false, axis_depths[colliding_axis_index][1]):
-			_calculate_snap(in_inverted_rotation)
+			snap_to_rotation(in_inverted_rotation)
 		else:
-			_calculate_snap(in_non_inverted_rotation)
+			snap_to_rotation(in_non_inverted_rotation)
 
 
 func manage_mouse_click(in_input_event: InputEvent) -> void:

--- a/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/orientation_widget.gd
+++ b/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/orientation_widget.gd
@@ -15,6 +15,10 @@ func _process(_in_delta : float) -> void:
 	_position_orientation_wrapper()
 
 
+func snap_to_rotation(in_rotation : Vector3) -> void:
+	_draw_orientation_widget.snap_to_rotation(in_rotation)
+
+
 func is_snap_active() -> bool:
 	return _draw_orientation_widget.snap_is_active
 

--- a/godot_project/editor/input_handlers/camera_input_handler.gd
+++ b/godot_project/editor/input_handlers/camera_input_handler.gd
@@ -168,6 +168,23 @@ func _finish_orientation_snap(_orientation_widget: Node3D) -> void:
 func forward_input(in_input_event: InputEvent, in_camera: Camera3D, \
 		_in_context: StructureContext) -> bool:
 	
+	if in_input_event is InputEventKey:
+		if in_input_event.is_action_pressed(&"camera_toggle_projection", false, true):
+			MolecularEditorContext.msep_editor_settings.editor_camera_orthographic_projection_enabled = \
+				not MolecularEditorContext.msep_editor_settings.editor_camera_orthographic_projection_enabled
+			return true
+		const KEYBOARD_SHORTCUTS: Dictionary[StringName, Vector3] = {
+			&"camera_snap_front": Vector3(.0, 0, .0),
+			&"camera_snap_back": Vector3(.0, PI, .0),
+			&"camera_snap_right": Vector3(.0, PI * .5, .0),
+			&"camera_snap_left": Vector3(.0, PI * -.5, .0),
+			&"camera_snap_top":  Vector3(PI * -.5, .0, .0),
+			&"camera_snap_bottom": Vector3(PI * .5, .0, .0),
+		}
+		for action: StringName in KEYBOARD_SHORTCUTS.keys():
+			if in_input_event.is_action_pressed(action, false, true):
+				_snap_to_rotation(KEYBOARD_SHORTCUTS[action])
+				return true
 	_detect_which_modifiers_are_being_held_down()
 	
 	_pending_scroll_return = _shift_key_is_held_down
@@ -421,6 +438,11 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, \
 		return true
 	
 	return false
+
+
+func _snap_to_rotation(in_rotation: Vector3) -> void:
+	var vp_container: SubViewportContainer = _workspace_context.get_editor_viewport_container()
+	vp_container.snap_to_rotation(in_rotation)
 
 
 func disable_orbiting_on_up_down_keyboard_only_input() -> void:

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -318,6 +318,41 @@ flush_atom_candidates={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":true,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":61,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+camera_snap_front={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194439,"physical_keycode":0,"key_label":0,"unicode":49,"location":0,"echo":false,"script":null)
+]
+}
+camera_snap_back={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":4194439,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+camera_snap_right={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194441,"physical_keycode":0,"key_label":0,"unicode":51,"location":0,"echo":false,"script":null)
+]
+}
+camera_snap_left={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":4194441,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+camera_snap_top={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194445,"physical_keycode":0,"key_label":0,"unicode":55,"location":0,"echo":false,"script":null)
+]
+}
+camera_snap_bottom={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":4194445,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+camera_toggle_projection={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194443,"physical_keycode":0,"key_label":0,"unicode":53,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 


### PR DESCRIPTION
Task: FEATURE REQUEST: Shortcuts to snap camera rotation to the axes

https://github.com/user-attachments/assets/fff6b981-c608-4ac9-a225-566b2473de65

