### PR TITLE
Remove 'Small Molecules' option from file menu

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_file/menu_file.gd
+++ b/godot_project/editor/controls/menu_bar/menu_file/menu_file.gd
@@ -9,8 +9,7 @@ enum {
 	POPUP_ID_SAVE_WORKSPACE_AS = 3,
 	POPUP_ID_IMPORT_PDB = 4,
 	POPUP_ID_IMPORT_FROM_LIBRARY = 5,
-	POPUP_ID_LOAD_FRAGMENT = 6,
-	POPUP_ID_CLOSE_WORKSPACE = 7,
+	POPUP_ID_CLOSE_WORKSPACE = 6,
 	POPUP_ID_EXPORT_FILE = 9,
 }
 
@@ -65,7 +64,6 @@ func _ready() -> void:
 func _update_menu() -> void:
 	var has_workspace: bool = MolecularEditorContext.get_current_workspace_context() != null
 	set_item_disabled(get_item_index(POPUP_ID_IMPORT_FROM_LIBRARY), !has_workspace)
-	set_item_disabled(get_item_index(POPUP_ID_LOAD_FRAGMENT), !has_workspace)
 	var can_save: bool = MolecularEditorContext.get_current_workspace() != null
 	set_item_disabled(get_item_index(POPUP_ID_SAVE_WORKSPACE), !can_save)
 	set_item_disabled(get_item_index(POPUP_ID_SAVE_WORKSPACE_AS), !can_save)
@@ -110,7 +108,3 @@ func _on_id_pressed(id: int) -> void:
 			if workspace == null:
 				return
 			MolecularEditorContext.request_close_workspace(workspace)
-		POPUP_ID_LOAD_FRAGMENT:
-			var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
-			if workspace_context != null:
-				workspace_context.action_load_fragment.execute()

--- a/godot_project/editor/controls/menu_bar/menu_file/menu_file.tscn
+++ b/godot_project/editor/controls/menu_bar/menu_file/menu_file.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=3 uid="uid://c3s1rv4dhbs3w"]
+[gd_scene load_steps=22 format=3 uid="uid://c3s1rv4dhbs3w"]
 
 [ext_resource type="Texture2D" uid="uid://b0u2u4oqkalh6" path="res://editor/controls/menu_bar/menu_file/icons/icon_new_workspace_16px.svg" id="1_8iynl"]
 [ext_resource type="Texture2D" uid="uid://c1gkfabphk2cm" path="res://editor/icons/import_x28.svg" id="1_1325o"]
@@ -9,7 +9,6 @@
 [ext_resource type="Texture2D" uid="uid://rjttvpirxl7" path="res://editor/controls/menu_bar/menu_file/icons/import_library_16px.svg" id="6_kulc7"]
 [ext_resource type="Texture2D" uid="uid://belaqyj0of62f" path="res://editor/icons/export_x28.svg" id="6_tuv0m"]
 [ext_resource type="Texture2D" uid="uid://jam6o276yr51" path="res://editor/controls/menu_bar/menu_file/icons/icon_close_workspace_16px.svg" id="7_in2el"]
-[ext_resource type="Texture2D" uid="uid://78ihcr4jpk3u" path="res://editor/controls/menu_bar/menu_file/icons/load_fragment_16px.svg" id="7_ntm2u"]
 
 [sub_resource type="InputEventKey" id="InputEventKey_cisi5"]
 device = -1
@@ -63,7 +62,8 @@ events = [SubResource("InputEventKey_rse6r")]
 [node name="MenuFile" type="PopupMenu"]
 size = Vector2i(1190, 888)
 visible = true
-item_count = 9
+unfocusable = true
+item_count = 8
 item_0/text = "New Workspace"
 item_0/icon = ExtResource("1_8iynl")
 item_0/id = 0
@@ -85,12 +85,9 @@ item_5/id = 9
 item_6/text = "Import from Library"
 item_6/icon = ExtResource("6_kulc7")
 item_6/id = 5
-item_7/text = "Small Molecules"
-item_7/icon = ExtResource("7_ntm2u")
+item_7/text = "Close Current Workspace"
+item_7/icon = ExtResource("7_in2el")
 item_7/id = 6
-item_8/text = "Close Current Workspace"
-item_8/icon = ExtResource("7_in2el")
-item_8/id = 7
 script = ExtResource("2_8babr")
 shortcut_new = SubResource("Shortcut_lncuv")
 shortcut_open = SubResource("Shortcut_osav5")


### PR DESCRIPTION
- This option was repeated in the Create menu, so it was redundant

Task: BUG: "Small Molecules" repeated on both "File Menu" and "Create Menu"