### PR TITLE
Move 'Reference shapes' to the 'Virtual objects' ring menu

### DIFF
--- a/godot_project/editor/ring_menu_levels/ring_level_main_menu.gd
+++ b/godot_project/editor/ring_menu_levels/ring_level_main_menu.gd
@@ -8,7 +8,6 @@ func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> voi
 	
 	add_action(RingActionFileMenu.new(_workspace_context, in_menu))
 	add_action(RingActionAtomsMenu.new(_workspace_context, in_menu))
-	add_action(RingActionAddShapes.new(_workspace_context, in_menu))
 	add_action(RingActionVirtualObjectsMenu.new(_workspace_context, in_menu))
 	add_action(RingActionEditMenu.new(_workspace_context, in_menu))
 	add_action(RingActionViewMenu.new(_workspace_context, in_menu))

--- a/godot_project/editor/ring_menu_levels/virtual_objects/ring_level_virtual_objects.gd
+++ b/godot_project/editor/ring_menu_levels/virtual_objects/ring_level_virtual_objects.gd
@@ -22,3 +22,4 @@ func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> voi
 		add_action(RingActionCreateAnchorsAndSprings.new(in_workspace_context, in_menu))
 	if FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAG_PARTICLE_EMITTERS):
 		add_action(RingActionCreateParticleEmitters.new(in_workspace_context, in_menu))
+	add_action(RingActionAddShapes.new(_workspace_context, in_menu))


### PR DESCRIPTION
Fixes: UX: Reference Shapes ring menu should be moved inside Virtual Objects Ring Menu