### PR TITLE
Don't create an undo step when grow / shrink selection can't change the selection

### DIFF
--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
@@ -189,11 +189,12 @@ func select_by_type(types_to_select: PackedInt32Array) -> void:
 	_process_atom_selection_result(result)
 
 
-func select_connected(in_show_hidden_objects: bool) -> void:
+func select_connected(in_show_hidden_objects: bool) -> AtomSelection.AtomSelectionResult:
 	var nano_structure: NanoStructure = _structure_context.nano_structure
 	assert(!nano_structure.is_being_edited(), "Setting the selection while structure is changing is insecure and should be avoided")
 	var result: AtomSelection.AtomSelectionResult = _atom_selection.select_connected(in_show_hidden_objects)
 	_process_atom_selection_result(result)
+	return result
 
 
 func can_grow_selection() -> bool:

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -327,7 +327,7 @@ func select_by_type(types_to_select: PackedInt32Array) -> void:
 	return _selection_db.select_by_type(types_to_select)
 
 
-func select_connected(in_show_hidden_objects: bool = false) -> void: 
+func select_connected(in_show_hidden_objects: bool = false) -> AtomSelection.AtomSelectionResult: 
 	return _selection_db.select_connected(in_show_hidden_objects)
 
 

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -507,23 +507,34 @@ static func _select_by_type(out_workspace_context: WorkspaceContext, types: Pack
 
 static func _select_connected(out_workspace_context: WorkspaceContext, in_show_hidden_objects: bool) -> void:
 	var all_structures: Array[StructureContext] = out_workspace_context.get_structure_contexts_with_selection()
+	var selection_changed: bool = false
 	for struct_context in all_structures:
-		struct_context.select_connected(in_show_hidden_objects)
-	out_workspace_context.snapshot_moment("Select Connected Atoms")
+		var result: AtomSelection.AtomSelectionResult = struct_context.select_connected(in_show_hidden_objects)
+		selection_changed = selection_changed or result.selection_changed
+	if selection_changed:
+		out_workspace_context.snapshot_moment("Select Connected Atoms")
 
 
 static func _grow_selection(out_workspace_context: WorkspaceContext) -> void:
 	var all_structures: Array[StructureContext] = out_workspace_context.get_structure_contexts_with_selection()
+	var selection_changed: bool = false
 	for struct_context in all_structures:
-		struct_context.grow_selection()
-	out_workspace_context.snapshot_moment("Grow Selection")
+		if struct_context.can_grow_selection():
+			struct_context.grow_selection()
+			selection_changed = true
+	if selection_changed:
+		out_workspace_context.snapshot_moment("Grow Selection")
 
 
 static func _shrink_selection(out_workspace_context: WorkspaceContext) -> void:
 	var all_structures: Array[StructureContext] = out_workspace_context.get_structure_contexts_with_selection()
+	var selection_changed: bool = false
 	for struct_context in all_structures:
-		struct_context.shrink_selection()
-	out_workspace_context.snapshot_moment("Shrink Selection")
+		if struct_context.has_cached_selection_set():
+			struct_context.shrink_selection()
+			selection_changed = true
+	if selection_changed:
+		out_workspace_context.snapshot_moment("Shrink Selection")
 
 
 static func _move_selection_to_new_structure(out_workspace_context: WorkspaceContext, in_parent_structure_id: int, in_new_group_name: String) -> void:


### PR DESCRIPTION
Fix: BUG: "Grow Selection" and "Select Connected" adds an undo step even when nothing new was selected, also is available from visual/topbar menu but not from Ring Menu