### PR TITLE
Make the template preview of Particle Emitters match the orientation in which will be created

### DIFF
--- a/godot_project/editor/rendering/particle_emitter_renderer/particle_emitter_renderer.gd
+++ b/godot_project/editor/rendering/particle_emitter_renderer/particle_emitter_renderer.gd
@@ -121,7 +121,7 @@ func transform_by_external_transform(in_selection_initial_pos: Vector3, in_initi
 	var emitter: NanoParticleEmitter = _workspace_context.workspace.get_structure_by_int_guid(_emitter_id)
 	for i: int in _structure_previews.size():
 		var preview: StructurePreview = _structure_previews[i]
-		preview.global_position = global_transform.origin + emitter.calculate_instance_offset(i)
+		preview.set_preview_transform(global_transform.translated(emitter.calculate_instance_offset(i)))
 
 
 func _set_structure_preview_count(in_count: int) -> void:
@@ -140,7 +140,7 @@ func _set_structure_preview_count(in_count: int) -> void:
 			add_child(instance)
 			instance.set_structure(template)
 			instance.set_auto_update(false)
-			instance.global_position = global_position + emitter.calculate_instance_offset(index)
+			instance.set_preview_transform(global_transform.translated(emitter.calculate_instance_offset(index)))
 			instance.visible = self.visible
 			_structure_previews.push_back(instance)
 
@@ -150,7 +150,7 @@ func _on_emitter_transform_changed(in_transform: Transform3D) -> void:
 	var emitter: NanoParticleEmitter = _workspace_context.workspace.get_structure_by_int_guid(_emitter_id)
 	for i: int in _structure_previews.size():
 		var preview: StructurePreview = _structure_previews[i]
-		preview.global_position = in_transform.origin + emitter.calculate_instance_offset(i)
+		preview.set_preview_transform(in_transform.translated(emitter.calculate_instance_offset(i)))
 
 
 func update(delta: float) -> void:

--- a/godot_project/editor/rendering/structure_preview/structure_preview.gd
+++ b/godot_project/editor/rendering/structure_preview/structure_preview.gd
@@ -19,6 +19,8 @@ var _transparency: float = DEFAULT_PREVIEW_TRANSPARENCY
 var _auto_update_preview: bool = true 
 
 var _structure: AtomicStructure
+var _original_atoms_positions: Dictionary [int, Vector3]
+var _current_basis: Basis = NanoParticleEmitter.DEFAULT_TRANSFORM.basis
 var _enabled_on_preview_viewport: bool = false
 
 
@@ -64,6 +66,9 @@ func set_structure(in_structure: NanoStructure) -> void:
 	_structure = NanoMolecularStructure.new()
 	_structure.apply_state_snapshot(in_structure.create_state_snapshot())
 	_structure.set_representation_settings(in_structure.get_representation_settings())
+	_original_atoms_positions = {}
+	for atom_id: int in _structure.get_valid_atoms():
+		_original_atoms_positions[atom_id] = _structure.atom_get_position(atom_id)
 	
 	var representation_settings: RepresentationSettings = in_structure.get_representation_settings()
 	_atomic_structure_renderer.build_for_preview(_structure, representation_settings.get_rendering_representation())
@@ -75,6 +80,23 @@ func set_structure(in_structure: NanoStructure) -> void:
 	_on_representation_settings_bond_visibility_changed(display_bonds)
 	
 	_atomic_structure_renderer.apply_theme(representation_settings.get_theme())
+
+
+func set_preview_transform(in_transform: Transform3D) -> void:
+	# Renderer does not support applying a rotation to the entire Node
+	# Instead the rotation needs to be applied to each individual atom
+	global_position = in_transform.origin
+	if _current_basis != in_transform.basis:
+		_structure.start_edit()
+		var basis_to_apply: Basis = in_transform.basis * NanoParticleEmitter.DEFAULT_TRANSFORM.basis.inverse()
+		for atom_id: int in _original_atoms_positions.keys():
+			var atom_pos: Vector3 = _original_atoms_positions[atom_id]
+			atom_pos = basis_to_apply * atom_pos
+			_structure.atom_set_position(atom_id, atom_pos)
+		_structure.end_edit()
+		_current_basis = in_transform.basis
+		var representation_settings: RepresentationSettings = _structure.get_representation_settings()
+		_atomic_structure_renderer.build_for_preview(_structure, representation_settings.get_rendering_representation())
 
 
 func update(in_delta: float) -> void:


### PR DESCRIPTION
Task: BUG: Molecule Preview of particle emitter does not properly show initial orientation of the molecule