### PR TITLE
Fix highlighting of 'Find Visible Atoms by Type' from TopBar/VisualMenu

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -296,8 +296,9 @@ func request_workspace_docker_focus(in_docker_unique_name: StringName, in_catego
 		return
 	# Wait one frame to allow controls update their visibility
 	await get_tree().process_frame
-	if docker.has_category(in_category_name):
-		docker.highlight_category(in_category_name)
+	assert(docker.has_category(in_category_name), "Missing category '%s' in docker with unique name '%s'" %
+		[in_category_name, in_docker_unique_name])
+	docker.highlight_category(in_category_name)
 
 
 func close_workspace_no_prompt(in_workspace: Workspace) -> void:

--- a/godot_project/editor/controls/menu_bar/menu_select/menu_select.gd
+++ b/godot_project/editor/controls/menu_bar/menu_select/menu_select.gd
@@ -57,7 +57,7 @@ func _on_id_pressed(in_id: int) -> void:
 		ID_DESELECT_ALL:
 			workspace_context.deselect_all()
 		ID_SELECT_BY_TYPE:
-			MolecularEditorContext.request_workspace_docker_focus(DynamicContextDocker.UNIQUE_DOCKER_NAME, &"Select Atoms by Type")
+			MolecularEditorContext.request_workspace_docker_focus(DynamicContextDocker.UNIQUE_DOCKER_NAME, &"Find Visible Atoms by Type")
 		ID_SELECT_CONNECTED:
 			workspace_context.select_connected()
 		ID_GROW_SELECTION:


### PR DESCRIPTION
- Panel was renamed, but the code of the menu was outdated
- Also added an assert to more easily discover this problem in the future

Task: BUG: Using "Select atoms by type" from visual/topbar menu does not highlight the control in the dynamic context panel