### PR TITLE
Expand docker category panels when highlighted from menues

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -295,6 +295,7 @@ func request_workspace_docker_focus(in_docker_unique_name: StringName, in_catego
 	if in_category_name == StringName():
 		return
 	# Wait one frame to allow controls update their visibility
+	docker.ensure_category_expanded(in_category_name)
 	await get_tree().process_frame
 	if docker.has_category(in_category_name):
 		docker.highlight_category(in_category_name)

--- a/godot_project/editor/controls/dockers/workspace_docker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker.gd
@@ -157,6 +157,14 @@ func create_category(in_id: StringName,
 func has_category(in_id: StringName) -> bool:
 	return _categories.has(in_id)
 
+
+func ensure_category_expanded(in_id: StringName) -> void:
+	var category: Category = _categories[in_id] as Category
+	if category.container_type != Category.ContainerType.COLLAPSABLE_CATEGORY_CONTAINER:
+		return
+	category.category_control.expanded = true
+
+
 func highlight_category(in_id: StringName) -> void:
 	assert(_categories.has(in_id))
 	var category: Category = _categories[in_id] as Category


### PR DESCRIPTION
Task: UX: When a ring/topbar menu highlights a collapsed category in the dynamic context panel, automatically expand it