### PR TITLE
Add tooltips to Element Picker Buttons showing the name of the elements

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker.tscn
@@ -26,6 +26,7 @@ layout_mode = 2
 [node name="H" parent="ButtonsContainer" instance=ExtResource("2_vt21c")]
 custom_minimum_size = Vector2(48, 48)
 layout_mode = 2
+element = 1
 
 [node name="C" parent="ButtonsContainer" instance=ExtResource("2_vt21c")]
 custom_minimum_size = Vector2(48, 48)

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/element_picker_button.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/element_picker_button.gd
@@ -4,7 +4,7 @@ class_name ElementPickerButton extends Button
 const COLOR_DISABLE: Color = Color(0.4,0.4,0.4, 1.0)
 const COLOR_ENABLE: Color = Color(1.0, 1.0, 1.0, 1.0)
 
-@export var element: int = 1:
+@export var element: int:
 	set(v):
 		element = v
 		if !is_instance_valid(_element_preview):

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/element_picker_button.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/element_picker_button.tscn
@@ -46,6 +46,7 @@ offset_right = 64.0
 offset_bottom = 64.0
 focus_mode = 0
 script = ExtResource("1_0cxmc")
+element = 1
 
 [node name="ElementPreview" parent="." instance=ExtResource("1_tws4x")]
 unique_name_in_owner = true

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/element_preview.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/element_preview.gd
@@ -73,6 +73,7 @@ func set_element_data(in_data: ElementData) -> void:
 		symbol.text = "?"
 		element_name.text = "Unknown"
 		mass.text = "0.0"
+		tooltip_text = "?: Unknown"
 		background_stylebox.bg_color = Color.BLACK
 		general_label_settings.font_color = Color.WHITE
 		symbol_label_settings.font_color = Color.WHITE
@@ -80,6 +81,7 @@ func set_element_data(in_data: ElementData) -> void:
 	else:
 		symbol.text = in_data.symbol
 		element_name.text = in_data.name
+		tooltip_text = "%s: %s" % [in_data.symbol, in_data.name]
 		mass.text = str(in_data.mass)
 		background_stylebox.bg_color = in_data.color
 		general_label_settings.font_color = in_data.font_color


### PR DESCRIPTION
Task: UX: In the element picker, each button should show name of each element