### PR TITLE
Add an option to include hidden atoms in validation & relaxation

### DIFF
--- a/godot_project/autoloads/openmm/openmm.gd
+++ b/godot_project/autoloads/openmm/openmm.gd
@@ -251,11 +251,11 @@ func relaunch_openmm_server() -> void:
 func request_relax(
 		in_workspace_context: WorkspaceContext,
 		in_temperature_in_kelvins: float,
-		in_selection_only: bool,
+		in_atom_set: AtomicStructure.AtomSet,
 		in_include_springs: bool,
 		in_lock_atoms: bool,
 		in_passivate_molecules: bool) -> RelaxRequest:
-	return _request_relax(in_workspace_context, in_temperature_in_kelvins, in_selection_only,
+	return _request_relax(in_workspace_context, in_temperature_in_kelvins, in_atom_set,
 		in_include_springs, in_lock_atoms, in_passivate_molecules)
 
 
@@ -302,7 +302,7 @@ func request_quit_server() -> void:
 func _request_relax(
 		in_workspace_context: WorkspaceContext,
 		in_temperature_in_kelvins: float,
-		in_selection_only: bool,
+		in_atom_set: AtomicStructure.AtomSet,
 		in_include_springs: bool,
 		in_lock_atoms: bool,
 		in_passivate_molecules: bool) -> RelaxRequest:
@@ -313,7 +313,7 @@ func _request_relax(
 		
 	const DONT_INCLUDE_VIRTUAL_OBJECTS: bool = false
 	const NUDGE_ATOMS_FIX: bool = true
-	var payload: OpenMMPayload = _create_payload(in_workspace_context , in_selection_only,
+	var payload: OpenMMPayload = _create_payload(in_workspace_context , in_atom_set,
 			DONT_INCLUDE_VIRTUAL_OBJECTS, in_include_springs, in_lock_atoms, in_passivate_molecules, NUDGE_ATOMS_FIX)
 	if _PRINT_REQUEST_AND_RESPONSE:
 		print_rich("[color=orange] Header: %s[/color]" % str(payload.header))
@@ -321,7 +321,7 @@ func _request_relax(
 		print_rich("[color=orange] Shapes: %s[/color]" % str(payload.shapes_data))
 		print_rich("[color=orange] Motors: %s[/color]" % str(payload.motors_data))
 		print_rich("[color=orange] State: %s[/color]" % str(payload.state))
-	var relax_request := RelaxRequest.new(in_temperature_in_kelvins, in_selection_only, in_include_springs, in_lock_atoms, in_passivate_molecules)
+	var relax_request := RelaxRequest.new(in_temperature_in_kelvins, in_atom_set, in_include_springs, in_lock_atoms, in_passivate_molecules)
 	relax_request.original_payload = payload
 	if _subscription_thread == null:
 		_subscription_thread = Thread.new()
@@ -342,6 +342,7 @@ func _request_start_simulation(
 		_bus_thread.start(_launch_openmm_server_in_thread.bind(utils.globalize_path("user://python")))
 	
 	const INCLUDE_VIRTUAL_OBJECTS = true
+	const ATOM_SET = AtomicStructure.AtomSet.ALL
 	const LOCK_ATOMS = true
 	const INCLUDE_SPRINGS = true
 	const PASSIVATE_MOLECULES = false
@@ -349,7 +350,7 @@ func _request_start_simulation(
 	# Before creating the payload, prewarm the atoms of particle emitters
 	for emitter: NanoParticleEmitter in in_workspace_context.get_particle_emitters():
 		emitter.revalidate_all_instances()
-	out_simulation_data.original_payload = _create_payload(in_workspace_context, false,
+	out_simulation_data.original_payload = _create_payload(in_workspace_context, ATOM_SET,
 			INCLUDE_VIRTUAL_OBJECTS, INCLUDE_SPRINGS, LOCK_ATOMS, PASSIVATE_MOLECULES, NUDGE_ATOMS_FIX)
 	out_simulation_data.push_frame(0, out_simulation_data.original_payload.initial_positions)
 	for emitter: NanoParticleEmitter in in_workspace_context.get_particle_emitters():
@@ -409,7 +410,7 @@ func _request_export(
 	in_workspace_context: WorkspaceContext,
 	out_promise: Promise) -> void:
 	
-	const SELECTION_ONLY: bool = false
+	const SELECTION_ONLY: AtomicStructure.AtomSet = AtomicStructure.AtomSet.ALL
 	const INCLUDE_VIRTUAL_OBJECTS: bool = false
 	const INCLUDE_SPRINGS: bool = false
 	const LOCK_ATOMS: bool = false
@@ -873,7 +874,7 @@ func _dispose_thread_when_done(out_promise: Promise, out_thread: Thread) -> void
 
 func _create_payload(
 			in_workspace_context: WorkspaceContext,
-			in_selection_only: bool,
+			in_atom_set: AtomicStructure.AtomSet,
 			in_virtual_objects: bool,
 			in_include_springs: bool,
 			in_lock_atoms: bool,
@@ -881,8 +882,11 @@ func _create_payload(
 			in_nudge_atoms_fix: bool = false) -> OpenMMPayload:
 	var structure_contexts: Array[StructureContext] = in_workspace_context.get_all_structure_contexts()
 	var virtual_object_contexts: Array[StructureContext] = structure_contexts.filter(_is_virtual_object_context)
-	if in_selection_only:
-		structure_contexts = structure_contexts.filter(_has_selected_atoms)
+	match in_atom_set:
+		AtomicStructure.AtomSet.SELECTED_ONLY:
+			structure_contexts = structure_contexts.filter(_has_selected_atoms)
+		AtomicStructure.AtomSet.ALL_VISIBLE:
+			structure_contexts = structure_contexts.filter(_has_visible_atoms)
 	var payload: OpenMMPayload = OpenMMPayload.new(in_workspace_context.workspace)
 	payload.nudge_atoms_fix_enabled = in_nudge_atoms_fix
 	payload.lock_atoms = in_lock_atoms
@@ -891,14 +895,18 @@ func _create_payload(
 	var extension: String = in_workspace_context.workspace.simulation_settings_forcefield_extension
 	if not extension.is_empty():
 		payload.forcefield_files.push_back(extension)
+	var partial_set: bool = in_atom_set != AtomicStructure.AtomSet.ALL
 	for context: StructureContext in structure_contexts:
 		var structure: NanoStructure = context.nano_structure
 		if structure is AtomicStructure:
 			var atom_ids: PackedInt32Array = context.nano_structure.get_valid_atoms()
 			var bond_ids: PackedInt32Array = context.nano_structure.get_valid_bonds()
 			var springs_ids: PackedInt32Array = context.nano_structure.springs_get_all()
-			if in_selection_only:
-				atom_ids = context.get_selected_atoms()
+			if partial_set:
+				if in_atom_set == AtomicStructure.AtomSet.SELECTED_ONLY:
+					atom_ids = context.get_selected_atoms()
+				elif in_atom_set == AtomicStructure.AtomSet.ALL_VISIBLE:
+					atom_ids = structure.get_visible_atoms()
 				# Ignore selected bonds, instead we will find existing bonds between selected atoms
 				var all_bonds_ids: PackedInt32Array = bond_ids
 				bond_ids = []
@@ -913,7 +921,7 @@ func _create_payload(
 					# Only add the spring if the atom is also selected
 					if structure.spring_get_atom_id(spring_id) in atom_ids:
 						springs_ids.push_back(spring_id)
-			var is_partially_selected: bool = in_selection_only and not context.is_fully_selected()
+			var is_partially_selected: bool = atom_ids.size() != structure.get_valid_atoms_count()
 			payload.add_structure(structure, atom_ids, bond_ids, is_partially_selected)
 		
 			if in_include_springs:
@@ -938,7 +946,10 @@ func _has_selected_atoms(in_structure_context: StructureContext) -> bool:
 
 
 func _has_visible_atoms(in_structure_context: StructureContext) -> bool:
-	return in_structure_context.nano_structure.get_valid_atoms().size() > 0
+	var structure: AtomicStructure = in_structure_context.nano_structure
+	if not structure:
+		return false
+	return structure.get_visible() and structure.get_visible_atoms().size() > 0
 
 
 func _is_virtual_object_context(in_structure_context: StructureContext) -> bool:

--- a/godot_project/autoloads/openmm/relax_request.gd
+++ b/godot_project/autoloads/openmm/relax_request.gd
@@ -5,7 +5,7 @@ signal retry_discarded()
 
 var id: int: get = _get_simulation_id
 var temperature_in_kelvins: float: get = _get_temperature_in_kelvins, set = _set_read_only
-var selection_only: bool:          get = _get_selection_only,         set = _set_read_only
+var atom_set: AtomicStructure.AtomSet: get = _get_atom_set,           set = _set_read_only
 var include_springs: bool:         get = _get_include_springs,        set = _set_read_only
 var lock_atoms: bool:              get = _get_lock_atoms,             set = _set_read_only
 var passivate_molecules: bool:     get = _get_passivate_molecules,    set = _set_read_only
@@ -14,7 +14,7 @@ var retried: bool = false
 var promise := Promise.new()
 var original_payload: OpenMMPayload = null
 var _temperature_in_kelvins: float
-var _selection_only: bool = false
+var _atom_set: AtomicStructure.AtomSet
 var _include_springs: bool = false
 var _lock_atoms: bool = false
 var _passivate_molecules: bool = false
@@ -22,9 +22,9 @@ var _has_error: bool = false
 
 
 
-func _init(in_temperature_in_kelvins: float, in_selection_only: bool, in_include_springs: bool, in_lock_atoms: bool, in_passivate_molecules: bool) -> void:
+func _init(in_temperature_in_kelvins: float, in_atom_set: AtomicStructure.AtomSet, in_include_springs: bool, in_lock_atoms: bool, in_passivate_molecules: bool) -> void:
 	_temperature_in_kelvins = in_temperature_in_kelvins
-	_selection_only = in_selection_only
+	_atom_set = in_atom_set
 	_include_springs = in_include_springs
 	_lock_atoms = in_lock_atoms
 	_passivate_molecules = in_passivate_molecules
@@ -48,8 +48,8 @@ func notify_retry_discarded() -> void:
 func _get_temperature_in_kelvins() -> float:
 	return _temperature_in_kelvins
 
-func _get_selection_only() -> bool:
-	return _selection_only
+func _get_atom_set() -> AtomicStructure.AtomSet:
+	return _atom_set
 
 func _get_include_springs() -> bool:
 	return _include_springs

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
@@ -99,7 +99,7 @@ func _on_create_from_selection_button_pressed() -> void:
 	var selected_contexts: Array[StructureContext] = _workspace_context.get_atomic_structure_contexts_with_selection()
 	# 2. Validate topology of selection
 	_workspace_context.start_async_work(tr(&"Validating topology"))
-	const SELECTION_ONLY = true
+	const SELECTION_ONLY = AtomicStructure.AtomSet.SELECTED_ONLY
 	const NO_SPRINGS = false
 	const NO_LOCKS = false
 	const NO_PASSIVATION = false
@@ -242,4 +242,3 @@ func _update_escape_velocity_warning() -> void:
 		_escape_velocity_warning_label.message = tr("Initial speed may be not large enough to leave emission space without crowding the space.\nThis could lead to a simulation Failure.\nYou may want to increase the [b]'Initial Speed'[/b] or [b]'Every'[/b] rate to ensure simulation doesn't fail")
 		_escape_velocity_warning_label.show()
 	
-

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/atomic_structure_model_validator.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/atomic_structure_model_validator.gd
@@ -33,22 +33,29 @@ func _on_history_changed() -> void:
 
 
 func _validate_bonds_in_thread(
-		in_visible_structure_contexts: Array[StructureContext],
+		in_structure_contexts: Array[StructureContext],
 		out_promise: Promise,
-		in_selection_only: bool) -> void:
+		in_atom_set: AtomicStructure.AtomSet) -> void:
 	var validation_results: Array[Metadata] = []
 	var spatial_hash_grid: SpatialHashGridOverlaps = SpatialHashGridOverlaps.new(MAX_COVALENT_RADIUS)
 	
-	for structure_context: StructureContext in in_visible_structure_contexts:
+	for structure_context: StructureContext in in_structure_contexts:
 		if not structure_context.nano_structure is AtomicStructure:
 			continue
 		var atomic_structure: AtomicStructure = structure_context.nano_structure as AtomicStructure
 		var ignored_springs: Array[Metadata] = []
 		var atoms: PackedInt32Array
-		if in_selection_only:
-			atoms = structure_context.get_selected_atoms()
-		else:
-			atoms = atomic_structure.get_visible_atoms()
+		match in_atom_set:
+			AtomicStructure.AtomSet.SELECTED_ONLY:
+				atoms = structure_context.get_selected_atoms()
+			AtomicStructure.AtomSet.ALL_VISIBLE:
+				if atomic_structure.get_visible():
+					atoms = atomic_structure.get_visible_atoms()
+			AtomicStructure.AtomSet.ALL:
+				atoms = atomic_structure.get_valid_atoms()
+		
+		if atoms.is_empty():
+			continue
 		
 		for atom_id: int in atoms:
 			var atom_data: AtomData = AtomData.new(atom_id, structure_context)
@@ -69,14 +76,14 @@ func _validate_bonds_in_thread(
 	validation_results.append_array(spatial_hash_grid.get_overlaps())
 	
 	var drastically_bad_sp3_groups: Array[Dictionary] = WorkspaceUtils.collect_drastically_invalid_tetrahedral_structure(
-		in_visible_structure_contexts, in_selection_only)
+		in_structure_contexts, in_atom_set)
 	
 	for group: Dictionary in drastically_bad_sp3_groups:
 		var bad_bond_angle_data := DrasticSp3Data.new(group.atoms_ids, group.bond_ids, group.structure_context)
 		validation_results.append(bad_bond_angle_data)
 	
 	var bad_bond_angles_groups: Array[Dictionary] = WorkspaceUtils.collect_invalid_bond_angles(
-		in_visible_structure_contexts, in_selection_only)
+		in_structure_contexts, in_atom_set)
 	
 	for group: Dictionary in bad_bond_angles_groups:
 		var bad_bond_angle_data := InvalidSp123Data.new(group.type, group.atoms_ids, group.bond_ids, group.structure_context)
@@ -85,12 +92,12 @@ func _validate_bonds_in_thread(
 	out_promise.fulfill.bind(validation_results).call_deferred()
 
 
-func validate_atomic_model(in_selection_only: bool) -> void:
+func validate_atomic_model(atom_set: AtomicStructure.AtomSet) -> void:
 	if _thread and _thread.is_alive():
 		return
 	var promise: Promise = Promise.new()
 	_thread = Thread.new()
-	_thread.start(_validate_bonds_in_thread.bind(_workspace_context.get_visible_structure_contexts(), promise, in_selection_only))
+	_thread.start(_validate_bonds_in_thread.bind(_workspace_context.get_all_structure_contexts(), promise, atom_set))
 	
 	_workspace_context.start_async_work(_workspace_context.tr("Validating model ..."))
 	await promise.wait_for_fulfill()

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/relax_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/relax_tools_panel.gd
@@ -90,7 +90,7 @@ func _on_workspace_context_alerts_panel_visibility_changed(in_is_visible: bool) 
 
 
 func _update_button_run_relaxation_state() -> void:
-	var can_relax: bool = WorkspaceUtils.can_relax(_workspace_context, _is_relax_selection_only_selected())
+	var can_relax: bool = WorkspaceUtils.can_relax(_workspace_context, _get_atom_set())
 	_button_run_relaxation.disabled = not can_relax
 
 
@@ -100,31 +100,37 @@ func _on_option_group_pressed(_in_button: BaseButton) -> void:
 
 func _on_button_run_relaxation_pressed() -> void:
 	var temperature_in_kelvins: float = _temperature_picker.temperature_kelvins
-	var selection_only: bool = _is_relax_selection_only_selected()
+	var atom_set: AtomicStructure.AtomSet = _get_atom_set()
 	var request: RelaxRequest = null
-	if WorkspaceUtils.can_relax(_workspace_context, selection_only):
+	if WorkspaceUtils.can_relax(_workspace_context, atom_set):
 		if not _workspace_context.ignored_warnings.invalid_tetrahedral_structure:
-			var found_bad_angle: bool = WorkspaceUtils.has_invalid_tetrahedral_structure(_workspace_context, selection_only)
+			var found_bad_angle: bool = WorkspaceUtils.has_invalid_tetrahedral_structure(_workspace_context, atom_set)
 			if found_bad_angle:
 				var warning_promise: Promise = _workspace_context.show_warning_dialog(
 						tr("This model has incorrect tetrahedral bonds. Run \"Validation\" to identify the issues."), tr("Run Validation"), tr("Continue Relaxation"), &"invalid_tetrahedral_structure")
 				await warning_promise.wait_for_fulfill()
 				if warning_promise.get_result() == true:
 					# "Run Validation" button selected
-					_workspace_context.create_object_parameters.request_validate_bonds(selection_only)
+					_workspace_context.create_object_parameters.request_validate_bonds(atom_set)
 					return
 		var include_springs: bool = _check_box_include_springs.button_pressed
 		var lock_atoms: bool = _check_box_maintain_locks.button_pressed
 		var passivate_molecules: bool = _check_box_passivate_molecules.button_pressed
-		request = WorkspaceUtils.relax(_workspace_context, temperature_in_kelvins, selection_only, include_springs, lock_atoms, passivate_molecules)
+		request = WorkspaceUtils.relax(_workspace_context, temperature_in_kelvins, atom_set, include_springs, lock_atoms, passivate_molecules)
 	if is_instance_valid(request) and is_instance_valid(request.promise):
 		_workspace_context.clear_alerts()
 		_open_mm_failure_tracker.track_openmm_relax_request(request)
 
 
-func _is_relax_selection_only_selected() -> bool:
+func _get_atom_set() -> AtomicStructure.AtomSet:
 	assert(_option_group != null, "Option ButtonGroup is null, was this function called too early?")
-	return _option_group.get_pressed_button() == _option_selection_only
+	match _option_group.get_pressed_button():
+		_option_selection_only:
+			return AtomicStructure.AtomSet.SELECTED_ONLY
+		_option_all_visible:
+			return AtomicStructure.AtomSet.ALL_VISIBLE
+		_:
+			return AtomicStructure.AtomSet.ALL
 
 
 func _on_button_view_alerts_pressed() -> void:
@@ -133,8 +139,12 @@ func _on_button_view_alerts_pressed() -> void:
 
 
 func _on_open_mm_failure_tracker_results_collected() -> void:
-	var selection_only: bool = _option_selection_only.button_pressed
-	_atomic_structure_model_validator.validate_atomic_model(selection_only)
+	var atom_set: AtomicStructure.AtomSet
+	if _option_selection_only.button_pressed:
+		atom_set = AtomicStructure.AtomSet.SELECTED_ONLY
+	else:
+		atom_set = AtomicStructure.AtomSet.ALL_VISIBLE
+	_atomic_structure_model_validator.validate_atomic_model(atom_set)
 	ScriptUtils.call_deferred_once(_update_view_alerts_button)
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/relax_tools_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/relax_tools_panel.tscn
@@ -36,6 +36,12 @@ text = "Selection only"
 unique_name_in_owner = true
 layout_mode = 2
 button_group = SubResource("ButtonGroup_cya10")
+text = "All visible"
+
+[node name="OptionAll" type="CheckBox" parent="PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+button_group = SubResource("ButtonGroup_cya10")
 text = "All molecules"
 
 [node name="TemperaturePicker" parent="PanelContainer/VBoxContainer" instance=ExtResource("2_k633u")]

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -516,7 +516,7 @@ func _on_button_start_pause_pressed() -> void:
 			params.steps_per_report = int(_spin_box_steps_per_report.value)
 			params.total_step_count = int(_spin_box_steps_per_report.value) * int(_spin_box_report_count.value)
 			
-			if _relax_before_sim_button.button_pressed and WorkspaceUtils.can_relax(_workspace_context, false):
+			if _relax_before_sim_button.button_pressed and WorkspaceUtils.can_relax(_workspace_context, AtomicStructure.AtomSet.ALL):
 				# Disabling the button is not necesary at all
 				# I am doing this to catch any case in the future where promise returned by
 				# _relax_before_simulation() is leaking in the future without being fulfilled under
@@ -575,7 +575,8 @@ func _on_button_start_pause_pressed() -> void:
 
 func _relax_before_simulation() -> Promise:
 	var promise: Promise = Promise.new()
-	var request: RelaxRequest = WorkspaceUtils.relax(_workspace_context, _temperature_picker.temperature_kelvins, false, true, true, false)
+	const ATOM_SET = AtomicStructure.AtomSet.ALL
+	var request: RelaxRequest = WorkspaceUtils.relax(_workspace_context, _temperature_picker.temperature_kelvins, ATOM_SET, true, true, false)
 	_track_relax_request(promise, request)
 	return promise
 

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.gd
@@ -10,6 +10,7 @@ const MAX_RELAX_ITERATIONS: int = 5
 
 @onready var _only_selected_checkbox: CheckBox = %OnlySelectedCheckBox
 @onready var _all_visible_check_box: CheckBox = %AllVisibleCheckBox
+@onready var _all_check_box: CheckBox = %AllCheckBox
 @onready var _invisible_selection_label: InfoLabel = %InvisibleSelectionLabel
 @onready var _no_selection_label: InfoLabel = %NoSelectionLabel
 @onready var _outdated_results_label: InfoLabel = %OutdatedResultsLabel
@@ -77,10 +78,17 @@ func _update_panel_state() -> void:
 	_fix_overlapping_atoms_button.visible = has_overlaps
 
 
+func _get_atom_set() -> AtomicStructure.AtomSet:
+	if _only_selected_checkbox.button_pressed:
+		return AtomicStructure.AtomSet.SELECTED_ONLY
+	if _all_visible_check_box.button_pressed:
+		return AtomicStructure.AtomSet.ALL_VISIBLE
+	return AtomicStructure.AtomSet.ALL
+
+
 func _on_validate_button_pressed() -> void:
 	_workspace_context.clear_alerts()
-	var selection_only: bool = _only_selected_checkbox.button_pressed
-	_atomic_structure_model_validator.validate_atomic_model(selection_only)
+	_atomic_structure_model_validator.validate_atomic_model(_get_atom_set())
 
 
 func _on_button_view_alerts_pressed() -> void:
@@ -93,12 +101,13 @@ func _on_fix_overlapping_atoms_button_pressed() -> void:
 	_fix_overlapping_atoms_button.hide()
 
 
-func _on_create_object_parameters_validate_bonds_requested(in_selection_only: bool) -> void:
+func _on_create_object_parameters_validate_bonds_requested(in_atom_set: AtomicStructure.AtomSet) -> void:
 	# Validating bonds was requested from another UI, we ensure this UI is visible and proceed with validation
 	_workspace_context.create_object_parameters.set_simulation_type(
 			CreateObjectParameters.SimulationType.VALIDATION)
-	_only_selected_checkbox.set_pressed_no_signal(in_selection_only)
-	_all_visible_check_box.set_pressed_no_signal(not in_selection_only)
+	_only_selected_checkbox.set_pressed_no_signal(in_atom_set == AtomicStructure.AtomSet.SELECTED_ONLY)
+	_all_visible_check_box.set_pressed_no_signal(in_atom_set == AtomicStructure.AtomSet.ALL_VISIBLE)
+	_all_check_box.set_pressed_no_signal(in_atom_set == AtomicStructure.AtomSet.ALL)
 	if ScriptUtils.is_callable_queued(_update_panel_state):
 		ScriptUtils.flush_now(_update_panel_state)
 	else:

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.tscn
@@ -37,6 +37,12 @@ layout_mode = 2
 button_group = SubResource("ButtonGroup_olgfw")
 text = "All visible atoms"
 
+[node name="AllCheckBox" type="CheckBox" parent="PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+button_group = SubResource("ButtonGroup_olgfw")
+text = "All atoms"
+
 [node name="FixOverlappingAtomsButton" type="Button" parent="."]
 unique_name_in_owner = true
 layout_mode = 2

--- a/godot_project/editor/ring_menu_levels/atoms/ring_action_correct_overlapping_atoms.gd
+++ b/godot_project/editor/ring_menu_levels/atoms/ring_action_correct_overlapping_atoms.gd
@@ -36,5 +36,5 @@ func get_icon() -> RingMenuIcon:
 
 func _execute_action() -> void:
 	_ring_menu.close()
-	await _model_validator.validate_atomic_model(false)
+	await _model_validator.validate_atomic_model(AtomicStructure.AtomSet.ALL)
 	_model_validator.fix_overlapping_atoms()

--- a/godot_project/project_workspace/structs/atomic_structure.gd
+++ b/godot_project/project_workspace/structs/atomic_structure.gd
@@ -10,6 +10,11 @@ enum AABB_BoundsType {
 	ContactRadius,  # get_aabb will grow based on each atom's contact radius
 }
 
+enum AtomSet {
+	SELECTED_ONLY,
+	ALL_VISIBLE,
+	ALL,
+}
 
 signal atoms_visibility_changed(atoms: PackedInt32Array)
 signal bonds_visibility_changed(bonds: PackedInt32Array)
@@ -36,9 +41,6 @@ const INVALID_ATOM_ID = -1
 const INVALID_ATOMIC_NUMBER = -1
 const INVALID_BOND_ID = -1
 const INVALID_SPRING_ID = -1
-
-
-
 
 
 @export var connected_motor: int = 0: set = _set_connected_motor

--- a/godot_project/project_workspace/workspace_context/create_object_parameters.gd
+++ b/godot_project/project_workspace/workspace_context/create_object_parameters.gd
@@ -18,7 +18,7 @@ signal spring_constant_force_changed(force: float)
 signal spring_equilibrium_length_is_auto_changed(is_auto: bool)
 signal spring_equilibrium_manual_length_changed(manual_length: float)
 # validate_bonds_requested signal is used as intermediator between relax_tools_panel and validate_bonds_panel
-signal validate_bonds_requested(selection_only: bool)
+signal validate_bonds_requested(atom_set: AtomicStructure.AtomSet)
 
 
 enum CreateModeType {
@@ -93,8 +93,10 @@ var _default_shape: int = 0
 
 static var _tmp_nano_shape := NanoShape.new()
 
-func request_validate_bonds(in_selection_only: bool) -> void:
-	validate_bonds_requested.emit(in_selection_only)
+
+func request_validate_bonds(in_atom_set: AtomicStructure.AtomSet) -> void:
+	validate_bonds_requested.emit(in_atom_set)
+
 
 func _get_property_list() -> Array[Dictionary]:
 	var custom_props: Array[Dictionary] = []

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -121,10 +121,14 @@ static func apply_simulation_state(
 	_apply_simulation_state(out_workspace_context, in_payload, in_positions)
 
 
-static func can_relax(in_workspace_context: WorkspaceContext, in_selection_only: bool) -> bool:
-	if in_selection_only:
-		return _can_relax_selection(in_workspace_context)
-	return _can_relax_all(in_workspace_context)
+static func can_relax(in_workspace_context: WorkspaceContext, in_atom_set: AtomicStructure.AtomSet) -> bool:
+	match in_atom_set:
+		AtomicStructure.AtomSet.SELECTED_ONLY:
+			return _can_relax_selection(in_workspace_context)
+		AtomicStructure.AtomSet.ALL_VISIBLE:
+			return _can_relax_all_visible(in_workspace_context)
+		AtomicStructure.AtomSet.ALL, _:
+			return _can_relax_all(in_workspace_context)
 
 
 static func can_move_selection_to_another_group(in_workspace_context: WorkspaceContext) -> bool:
@@ -145,9 +149,9 @@ static func is_particle_emitter_escape_velocity_safe(
 	)
 
 
-static func has_invalid_tetrahedral_structure(in_workspace_context: WorkspaceContext, in_selection_only: bool) -> bool:
-	assert(can_relax(in_workspace_context, in_selection_only))
-	return _has_bad_tetrahedral_angle(in_workspace_context, in_selection_only)
+static func has_invalid_tetrahedral_structure(in_workspace_context: WorkspaceContext, in_atom_set: AtomicStructure.AtomSet) -> bool:
+	assert(can_relax(in_workspace_context, in_atom_set))
+	return _has_bad_tetrahedral_angle(in_workspace_context, in_atom_set)
 
 
 static func has_emitters_affected_by_motors(in_workspace_context: WorkspaceContext) -> bool:
@@ -168,15 +172,19 @@ static func structure_context_has_drastically_invalid_tetrahedral_structure(in_s
 	return _structure_context_has_drastically_invalid_tetrahedral_structure(in_structure_context, in_atoms)
 
 
-static func _has_bad_tetrahedral_angle(in_workspace_context: WorkspaceContext, in_selection_only: bool) -> bool:
-	var structure_contexts: Array[StructureContext] = in_workspace_context.get_visible_structure_contexts()
+static func _has_bad_tetrahedral_angle(in_workspace_context: WorkspaceContext, in_atom_set: AtomicStructure.AtomSet) -> bool:
+	var structure_contexts: Array[StructureContext]
+	if in_atom_set == AtomicStructure.AtomSet.ALL:
+		structure_contexts = in_workspace_context.get_all_structure_contexts()
+	else:
+		in_workspace_context.get_visible_structure_contexts()
 	for structure_ctx: StructureContext in structure_contexts:
 		var structure: AtomicStructure = structure_ctx.nano_structure as AtomicStructure
 		if not is_instance_valid(structure):
 			# not atomic structure, is a virtual object
 			continue
 		var atom_ids: PackedInt32Array = []
-		if in_selection_only:
+		if in_atom_set == AtomicStructure.AtomSet.SELECTED_ONLY:
 			atom_ids = structure_ctx.get_selected_atoms()
 		else:
 			atom_ids = structure.get_valid_atoms()
@@ -263,7 +271,7 @@ static func _structure_context_has_drastically_invalid_tetrahedral_structure(
 
 static func collect_drastically_invalid_tetrahedral_structure(
 		in_visible_strucutre_contexts: Array[StructureContext],
-		in_selection_only: bool) -> Array[Dictionary]:
+		in_atom_set: AtomicStructure.AtomSet) -> Array[Dictionary]:
 	var out_bad_tetrahedral_groups: Array[Dictionary] = [
 	#	{
 	#		structure_context = StructureContext
@@ -277,10 +285,14 @@ static func collect_drastically_invalid_tetrahedral_structure(
 			# not atomic structure, is a virtual object
 			continue
 		var atom_ids: PackedInt32Array = []
-		if in_selection_only:
-			atom_ids = structure_ctx.get_selected_atoms()
-		else:
-			atom_ids = structure.get_valid_atoms()
+		match in_atom_set:
+			AtomicStructure.AtomSet.SELECTED_ONLY:
+				atom_ids = structure_ctx.get_selected_atoms()
+			AtomicStructure.AtomSet.ALL_VISIBLE:
+				if structure.get_visible():
+					atom_ids = structure.get_visible_atoms()
+			AtomicStructure.AtomSet.ALL:
+				atom_ids = structure.get_valid_atoms()
 		_collect_drastically_invalid_tetrahedral_structure(structure_ctx, atom_ids, out_bad_tetrahedral_groups)
 	return out_bad_tetrahedral_groups
 
@@ -332,7 +344,7 @@ static func _find_plane_normal_away_from_atom(in_plane: Plane, in_atom_pos: Vect
 
 
 static func collect_invalid_bond_angles(in_visible_strucutre_contexts: Array[StructureContext],
-		in_selection_only: bool) -> Array[Dictionary]:
+		in_atom_set: AtomicStructure.AtomSet) -> Array[Dictionary]:
 	var out_invalid_angle_atom_groups: Array[Dictionary] = [
 	#	{
 	#		type = StringName [ &"sp1" | &"sp2" | &"sp3" ]
@@ -343,14 +355,14 @@ static func collect_invalid_bond_angles(in_visible_strucutre_contexts: Array[Str
 	]
 	for context: StructureContext in in_visible_strucutre_contexts:
 		if context.nano_structure is AtomicStructure:
-			_collect_invalid_bond_angles_atom_groups(context, in_selection_only, out_invalid_angle_atom_groups)
+			_collect_invalid_bond_angles_atom_groups(context, in_atom_set, out_invalid_angle_atom_groups)
 	return out_invalid_angle_atom_groups
 
 
 static func _collect_invalid_bond_angles_atom_groups(
-		in_structure_context: StructureContext, in_selection_only: bool,
+		in_structure_context: StructureContext, in_atom_set: AtomicStructure.AtomSet,
 		out_invalid_angle_atom_groups: Array[Dictionary]) -> void:
-	var structure: NanoStructure = in_structure_context.nano_structure
+	var structure: AtomicStructure = in_structure_context.nano_structure
 	var atom_ids: PackedInt32Array = []
 	const GROUP_TYPES_FROM_BOND_COUNT: Dictionary = {
 		2 : &"sp1",
@@ -367,10 +379,13 @@ static func _collect_invalid_bond_angles_atom_groups(
 		sp2 = 170.0,
 		sp3 = 170.0,
 	}
-	if in_selection_only:
-		atom_ids = in_structure_context.get_selected_atoms()
-	else:
-		atom_ids = structure.get_valid_atoms()
+	match in_atom_set:
+		AtomicStructure.AtomSet.SELECTED_ONLY:
+			atom_ids = in_structure_context.get_selected_atoms()
+		AtomicStructure.AtomSet.ALL_VISIBLE:
+			atom_ids = structure.get_visible_atoms()
+		AtomicStructure.AtomSet.ALL:
+			atom_ids = structure.get_valid_atoms()
 	for atom_id: int in atom_ids:
 		var bond_ids: PackedInt32Array = structure.atom_get_bonds(atom_id)
 		if not bond_ids.size() in GROUP_TYPES_FROM_BOND_COUNT.keys():
@@ -408,9 +423,9 @@ static func _collect_invalid_bond_angles_atom_groups(
 
 
 static func relax(out_workspace_context: WorkspaceContext, in_temperature_in_kelvins: float,
-			in_selection_only: bool,in_include_springs: bool, in_lock_atoms: bool,
-			in_passivate_molecules: bool) -> RelaxRequest:
-	return _relax(out_workspace_context, in_temperature_in_kelvins, in_selection_only, in_include_springs,
+			atom_set: AtomicStructure.AtomSet, in_include_springs: bool,
+			in_lock_atoms: bool, in_passivate_molecules: bool) -> RelaxRequest:
+	return _relax(out_workspace_context, in_temperature_in_kelvins, atom_set, in_include_springs,
 		in_lock_atoms, in_passivate_molecules, true)
 
 
@@ -1206,7 +1221,7 @@ static func _can_relax_selection(in_workspace_context: WorkspaceContext) -> bool
 	return false
 
 
-static func _can_relax_all(in_workspace_context: WorkspaceContext) -> bool:
+static func _can_relax_all_visible(in_workspace_context: WorkspaceContext) -> bool:
 	var visible_structures: Array[StructureContext] = \
 			in_workspace_context.get_visible_structure_contexts()
 	for context in visible_structures:
@@ -1214,6 +1229,17 @@ static func _can_relax_all(in_workspace_context: WorkspaceContext) -> bool:
 			continue
 		if context.nano_structure.get_valid_atoms_count() > 0:
 			# At least 1 visible atom
+			return true
+	return false
+
+
+static func _can_relax_all(in_workspace_context: WorkspaceContext) -> bool:
+	var visible_structures: Array[StructureContext] = \
+			in_workspace_context.get_all_structure_contexts()
+	for context in visible_structures:
+		if not context.nano_structure is AtomicStructure:
+			continue
+		if context.nano_structure.get_valid_atoms_count() > 0:
 			return true
 	return false
 
@@ -1396,13 +1422,13 @@ static func _precalculate_particle_emitter_instance_offset(in_instance_idx: int,
 static func _relax(
 		out_workspace_context: WorkspaceContext,
 		in_temperature_in_kelvins: float,
-		in_selection_only: bool,
+		in_atom_set: AtomicStructure.AtomSet,
 		in_include_springs: bool,
 		in_lock_atoms: bool,
 		in_passivate_molecules: bool,
 		in_animate: bool) -> RelaxRequest:
 	var request: RelaxRequest = OpenMM.request_relax(out_workspace_context,
-			in_temperature_in_kelvins, in_selection_only, in_include_springs, in_lock_atoms, in_passivate_molecules)
+			in_temperature_in_kelvins, in_atom_set, in_include_springs, in_lock_atoms, in_passivate_molecules)
 	_process_relax_request(request, out_workspace_context, in_animate)
 	return request
 
@@ -1416,11 +1442,11 @@ static func _retry_relax(
 			out_relax_request.original_payload.raw_initial_positions)
 	# 2. repeat relax request
 	var temperature_in_kelvins: float = out_relax_request.temperature_in_kelvins
-	var selection_only: bool = out_relax_request.selection_only
+	var atom_set: AtomicStructure.AtomSet = out_relax_request.atom_set
 	var include_springs: bool = out_relax_request.include_springs
 	var lock_atoms: bool = out_relax_request.lock_atoms
 	var passivate_molecules: bool = out_relax_request.passivate_molecules
-	var request: RelaxRequest = OpenMM.request_relax(out_workspace_context, temperature_in_kelvins, selection_only, include_springs, lock_atoms, passivate_molecules)
+	var request: RelaxRequest = OpenMM.request_relax(out_workspace_context, temperature_in_kelvins, atom_set, include_springs, lock_atoms, passivate_molecules)
 	out_relax_request.retried = true
 	out_relax_request.notify_retry(request)
 	_process_relax_request(request, out_workspace_context, true)
@@ -1494,7 +1520,7 @@ static func _do_tween_atom_positions(
 
 
 static func _validate_relax_result(out_workspace_context: WorkspaceContext, in_relax_request: RelaxRequest) -> void:
-	in_relax_request.bad_tetrahedral_bonds_detected = has_invalid_tetrahedral_structure(out_workspace_context, in_relax_request.selection_only)
+	in_relax_request.bad_tetrahedral_bonds_detected = has_invalid_tetrahedral_structure(out_workspace_context, in_relax_request.atom_set)
 	if out_workspace_context.ignored_warnings.invalid_relaxed_tetrahedral_structure:
 		# Warning was disabled, skip
 		return


### PR DESCRIPTION
Fixes: FEATURE REQUEST: add ability to validate everything, including hidden structures

Currently, simulations uses the whole workspace, while relaxation & validation can only operate on the selection, or on the visible atoms.

This PR adds a third option to validate the whole workspace, including hidden items.

Because the relax code had to change (because it runs some validations first), I've added the option there too for feature parity.

(The simulation part was not changed, but if the design team ever wants it, this also allows for running simulations only on the selection or visible atoms too)

<img width="460" height="229" alt="image" src="https://github.com/user-attachments/assets/c60738e0-e503-49df-9f31-b6aa5b6a2f31" />
