### PR TITLE
Hide the outdated validation warning on start

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.gd
@@ -33,6 +33,7 @@ func _ready() -> void:
 	_atomic_structure_model_validator.validation_finished.connect(_on_atomic_structure_model_validator_validation_finished)
 	_atomic_structure_model_validator.alert_selected.connect(_on_atomic_structure_model_validator_alert_selected)
 	_atomic_structure_model_validator.results_outdated.connect(_on_atomic_structure_model_validator_results_outdated)
+	_outdated_results_label.hide()
 
 
 func should_show(in_workspace_context: WorkspaceContext) -> bool:


### PR DESCRIPTION
Fixes: BUG - Project announces it has been changed since last validation, but validation has never been run

The validation logic is already working as expected, the label was just visible by default.