### PR TITLE
Fix ffmpeg generating unplayable mp4 videos when a non standard resolution is used

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.tscn
+++ b/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.tscn
@@ -26,6 +26,20 @@ script = ExtResource("2_vnntt")
 [node name="VBoxContainer" parent="." index="3"]
 offset_bottom = 678.0
 
+[node name="SpinBoxSliderWidth" parent="VBoxContainer/HBoxContainer/ScrollContainer/SettingsControls/PanelContainerCaptureSize/GridContainer" index="3"]
+step = 2.0
+
+[node name="SpinBoxSliderHeight" parent="VBoxContainer/HBoxContainer/ScrollContainer/SettingsControls/PanelContainerCaptureSize/GridContainer" index="5"]
+step = 2.0
+
+[node name="SpinBoxSliderCropWidth" parent="VBoxContainer/HBoxContainer/ScrollContainer/SettingsControls/PanelContainerCrop/GridContainer" index="5"]
+min_value = 2.0
+step = 2.0
+
+[node name="SpinBoxSliderCropHeight" parent="VBoxContainer/HBoxContainer/ScrollContainer/SettingsControls/PanelContainerCrop/GridContainer" index="7"]
+min_value = 2.0
+step = 2.0
+
 [node name="RadioBackgroundEnvironment" parent="VBoxContainer/HBoxContainer/ScrollContainer/SettingsControls/PanelContainerBackground/HBoxContainer" index="0"]
 button_group = SubResource("ButtonGroup_fxhsi")
 

--- a/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
@@ -333,8 +333,8 @@ func _update_preview_background() -> void:
 
 
 func _on_texture_rect_capture_preview_crop_rect_changed(in_rect: Rect2) -> void:
-	_spin_box_slider_crop_width.value = in_rect.size.x
-	_spin_box_slider_crop_height.value = in_rect.size.y
+	_spin_box_slider_crop_width.value = snapped(in_rect.size.x, _spin_box_slider_crop_width.step)
+	_spin_box_slider_crop_height.value = snapped(in_rect.size.y, _spin_box_slider_crop_height.step)
 	_spin_box_slider_h_offset.value = in_rect.position.x
 	_spin_box_slider_v_offset.value = in_rect.position.y
 


### PR DESCRIPTION
- This change makes ffmpeg to always generate frames with even sizes

Before this, if you used the crop tool, and selected an area with an odd size (in example 918x587) that would make ffmpeg to generate a video that is unplayable because of some known limitation on H.264 and rbg data