### PR TITLE
Some fixes to simulation video generation

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd
@@ -68,10 +68,17 @@ func _notification(what: int) -> void:
 		_time_slider.value_changed.connect(_on_time_slider_value_changed)
 		_stop_button.pressed.connect(_on_stop_button_pressed)
 		_abort_button.pressed.connect(_abort_button_pressed)
-	if what == NOTIFICATION_WM_CLOSE_REQUEST:
-		if _is_baking == true:
-			return
-		hide()
+
+
+# OVERRIDE
+func _on_visibility_changed() -> void:
+	if !visible and _is_baking == true:
+		# prevent the window from hiding
+		set_deferred(&"visible", true)
+		DisplayServer.beep()
+		return
+	else:
+		super._on_visibility_changed()
 
 
 # OVERRIDE

--- a/godot_project/utils/video_recorder/video_recorder_ffmpeg.gd
+++ b/godot_project/utils/video_recorder/video_recorder_ffmpeg.gd
@@ -58,11 +58,19 @@ func abort() -> void:
 	if not is_running():
 		return
 	OS.kill(_pid)
-	while is_running():
+	_dispose_video_file(_pid, _filename)
+
+static func _dispose_video_file(child_pid: int, filename: String) -> void:
+	while OS.is_process_running(child_pid):
 		await Engine.get_main_loop().process_frame
-	var err: Error = DirAccess.remove_absolute(_filename)
+	var err: Error = ERR_FILE_NOT_FOUND
+	var i := 0
+	while err != OK and i < 10:
+		err = DirAccess.remove_absolute(filename)
+		i += 1
+		await Engine.get_main_loop().physics_frame
 	if err != OK:
-		push_error("Failed to delete ", _filename, " with error '", error_string(err), "'")
+		push_error("Failed to delete ", filename, " with error '", error_string(err), "'")
 
 
 func has_error() -> bool:


### PR DESCRIPTION
- Added more guarding to ensure mp4 file is deleted if bakign is aborted
- Prevented user from closing the dialog while video is baking

Task: BUG: Is possible to close **RecordSimulationVideoDialog** while video is processing without aborting the record