### PR TITLE
Ensure simulation playback is paused when RecordSimulationVideoDialog opens

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -71,6 +71,7 @@ func _ensure_workspace_initialized(out_workspace_context: WorkspaceContext) -> v
 		_workspace_context = out_workspace_context
 		out_workspace_context.about_to_apply_simulation.connect(_on_workspace_context_about_to_apply_simulation)
 		out_workspace_context.alerts_panel_visibility_changed.connect(_on_workspace_context_alerts_panel_visibility_changed)
+		out_workspace_context.pause_simulation_playback_requested.connect(_on_pause_simulation_playback_requested)
 		out_workspace_context.tree_exiting.connect(_on_workspace_closed)
 		_open_mm_failure_tracker.set_workspace_context(out_workspace_context)
 		# Initialize UI
@@ -145,6 +146,11 @@ func _notification(in_what: int) -> void:
 func _on_workspace_context_about_to_apply_simulation() -> void:
 	if _status == Status.PLAYING:
 		# This ensures _physics_process won't try to seek simulation
+		_status = Status.PAUSED
+
+
+func _on_pause_simulation_playback_requested() -> void:
+	if _status == Status.PLAYING:
 		_status = Status.PAUSED
 
 

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -27,6 +27,7 @@ signal simulation_background_processing_completed()
 signal simulation_finished()
 signal about_to_apply_simulation()
 signal simulation_state_applied()
+signal pause_simulation_playback_requested()
 
 signal async_work_started()
 signal async_work_finished()
@@ -623,6 +624,10 @@ func seek_simulation(in_frame: float) -> void:
 	for emitter: NanoParticleEmitter in get_particle_emitters():
 		emitter.seek_simulation(in_frame)
 	WorkspaceUtils.apply_simulation_state(self, payload, state)
+
+
+func request_pause_simulation_playback() -> void:
+	pause_simulation_playback_requested.emit()
 
 
 func abort_simulation_if_running() -> void:

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -1228,6 +1228,7 @@ static func _extract_embedded_thumbnail(in_filepath: String) -> Texture2D:
 
 static func _open_record_simulation_video_dialog(in_workspace_context: WorkspaceContext) -> void:
 	assert(in_workspace_context and in_workspace_context.is_simulating())
+	in_workspace_context.request_pause_simulation_playback()
 	var workspace_main_view: WorkspaceMainView = in_workspace_context.workspace_main_view
 	workspace_main_view.record_simulation_video_dialog.popup_centered_ratio(0.8)
 


### PR DESCRIPTION
Task: BUG: Opening "Save simulation as video" dialog while simulation is playing doesn't pause it