### PR TITLE
Automatically generate thumbnails when a workspace is saved

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
@@ -19,6 +19,7 @@ enum {
 	_PREVIEW_SCALE_EXPAND = 1
 }
 
+const PROJECT_THUMBNAIL_SIZE: SizePresets = SizePresets.RES_HD
 
 const SIZE_PRESETS_MAP: Dictionary = {
 	SizePresets.RES_LD: Vector2i(854, 480),
@@ -152,6 +153,26 @@ func _on_about_to_popup() -> void:
 	workspace_snapshot = workspace_context.create_state_snapshot()
 	workspace_context.clear_all_selection()
 	_is_about_to_popup = false
+
+
+func generate_thumbnail() -> Image:
+	_on_about_to_popup()
+	var _prev_options: Array = [
+		_sub_viewport_preview.size, # in case resolution was custom
+		_radio_background_environment.button_group.get_pressed_button(),
+	]
+	_sub_viewport_preview.size = SIZE_PRESETS_MAP[PROJECT_THUMBNAIL_SIZE]
+	_radio_background_environment.button_pressed = true
+	_update_preview_background()
+	visible = true
+	RenderingServer.force_draw(false)
+	var image: Image = _sub_viewport_preview.get_texture().get_image()
+	visible = false
+	# Revert dialog options to original value
+	_sub_viewport_preview.size = _prev_options[0]
+	_prev_options[1].button_pressed = true
+	_update_preview_background()
+	return image
 
 
 func _set_remote_camera(in_camera_3d: Camera3D) -> void:

--- a/godot_project/project_workspace/file_format/workspace_format_saver.gd
+++ b/godot_project/project_workspace/file_format/workspace_format_saver.gd
@@ -12,6 +12,7 @@ func _get_recognized_extensions(resource: Resource) -> PackedStringArray:
 func _save(resource: Resource, path: String, flags: int) -> Error:
 	_update_msep_vertsion_history(resource)
 	_update_simulation_forcefield_hashes(resource)
+	_embed_thumbnail_if_needed(resource)
 	var tmp_path: String = path + ".tres"
 	var result: Error = ResourceSaver.save(resource, tmp_path, flags)
 	if result == OK:
@@ -33,3 +34,9 @@ func _update_simulation_forcefield_hashes(out_workspace: Workspace) -> void:
 	out_workspace.simulation_settings_msep_extensions_md5 = OpenMMUtils.hash_forcefield_extension(
 		out_workspace.simulation_settings_forcefield_extension
 	)
+
+func _embed_thumbnail_if_needed(resource: Workspace) -> void:
+	if resource.has_thumbnail() and resource.is_last_thumbnail_user_generated:
+		return
+	var thumbnail: Image = WorkspaceUtils.generate_thumbnail(resource)
+	resource.set_thumbnail(thumbnail, false)

--- a/godot_project/project_workspace/workspace.gd
+++ b/godot_project/project_workspace/workspace.gd
@@ -15,6 +15,9 @@ const MAX_SIGNED_32_BIT_INT = 2147483647
 static var instance_counter: int = 0
 
 
+@export_storage var _thumbnail: PackedByteArray = []
+@export_storage var is_last_thumbnail_user_generated: bool = false
+
 @export var _structures: Dictionary = {
 	# ID<int> : NanoStructure
 }
@@ -161,6 +164,9 @@ var _main_structure_int_guid: int = 0
 var _id: int
 
 
+var _thumbnail_cache: Texture2D = null
+
+
 func _init() -> void:
 	# prevent changed and representation_settings_changed signals from being emitted
 	# when executing _set_representation_settings
@@ -182,6 +188,32 @@ func post_load() -> void:
 		var structure: NanoStructure = _structures[structure_id]
 		if structure.int_parent_guid == INVALID_STRUCTURE_ID:
 			_main_structure_int_guid = structure_id
+
+
+func has_thumbnail() -> bool:
+	return not _thumbnail.is_empty()
+
+
+func get_thumbnail() -> Texture2D:
+	if not has_thumbnail():
+		return null
+	if _thumbnail_cache == null:
+		var img := Image.new()
+		img.load_png_from_buffer(_thumbnail)
+		_thumbnail_cache = ImageTexture.create_from_image(img)
+	return _thumbnail_cache
+
+
+func set_thumbnail(in_image: Image, in_is_user_generated: bool = false) -> void:
+	assert(is_last_thumbnail_user_generated == false or in_is_user_generated == true,
+		"Once a user generates a thumbnail it should never be replaced by an automatic thumbnail")
+	if in_image == null:
+		_thumbnail = []
+		_thumbnail_cache = null
+		return
+	_thumbnail = in_image.save_png_to_buffer()
+	is_last_thumbnail_user_generated = in_is_user_generated
+	_thumbnail_cache = ImageTexture.create_from_image(in_image)
 
 
 func get_nmb_of_structures() -> int:

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -110,6 +110,14 @@ static func open_camera_position_dialog() -> void:
 	Editor_Utils.get_editor().camera_position_dialog.popup_centered()
 
 
+static func generate_thumbnail(in_workspace: Workspace) -> Image:
+	return _generate_thumbnail(in_workspace)
+
+
+static func extract_embedded_thumbnail(in_filepath: String) -> Texture2D:
+	return _extract_embedded_thumbnail(in_filepath)
+
+
 static func open_quick_search_dialog(in_workspace_context: WorkspaceContext) -> void:
 	_open_quick_search_dialog(in_workspace_context)
 
@@ -1187,6 +1195,31 @@ static func _open_screen_capture_dialog(in_workspace_context: WorkspaceContext) 
 	assert(in_workspace_context)
 	var workspace_main_view: WorkspaceMainView = in_workspace_context.workspace_main_view
 	workspace_main_view.screen_capture_dialog.popup_centered_ratio(0.5)
+
+
+static func _generate_thumbnail(in_workspace: Workspace) -> Image:
+	var context: WorkspaceContext = MolecularEditorContext.get_workspace_context(in_workspace)
+	if context == null:
+		push_error("Cannot generate thumbnail for a project without context")
+		return null
+	var workspace_main_view: WorkspaceMainView = context.workspace_main_view
+	return workspace_main_view.screen_capture_dialog.generate_thumbnail()
+
+
+static func _extract_embedded_thumbnail(in_filepath: String) -> Texture2D:
+	var f := FileAccess.open(in_filepath, FileAccess.READ)
+	if f == null:
+		return null
+	while f.is_open() and not f.eof_reached():
+		var line: String = f.get_line()
+		if line.begins_with("_thumbnail = "):
+			f.close()
+			var str_var: String = line.substr("_thumbnail = ".length())
+			var buffer: PackedByteArray = str_to_var(str_var)
+			var img := Image.new()
+			img.load_png_from_buffer(buffer)
+			return ImageTexture.create_from_image(img)
+	return null
 
 
 static func _open_quick_search_dialog(in_workspace_context: WorkspaceContext) -> void:


### PR DESCRIPTION
- Also added an utility function to extract the thumbnail embedded en workspace files without loading them

Task: Save a thumbnail of the project embedded in msep1 files