### PR TITLE
Fix incorrect snapshot names when going above the maximum undo count

### DIFF
--- a/godot_project/project_workspace/workspace_context/history/history.gd
+++ b/godot_project/project_workspace/workspace_context/history/history.gd
@@ -139,6 +139,7 @@ func _add_snapshot_to_stack(in_snapshot: Dictionary, in_snapshot_name: String) -
 	var max_undo_count: int = MolecularEditorContext.msep_editor_settings.editor_max_undo_count
 	while _snapshot_stack.size() > max_undo_count:
 		_snapshot_stack.pop_front()
+		_name_stack.pop_front()
 		_stack_pointer -= 1
 	
 	_version += 1


### PR DESCRIPTION
The snapshot stack was updated but not the name stack. This might also be related to older cards about undo redo names being incorrect.