### PR TITLE
Add a _file_format_version field to Workspace files

### DIFF
--- a/godot_project/project_workspace/file_format/workspace_format_loader.gd
+++ b/godot_project/project_workspace/file_format/workspace_format_loader.gd
@@ -42,4 +42,11 @@ func _load(path: String, _original_path: String, _use_sub_threads: bool, cache_m
 		if workspace != null:
 			workspace.take_over_path(path)
 	d.remove(tmp_path)
+	if workspace._file_format_version < Workspace.get_most_recent_file_format_version():
+		push_warning("This workspace file was written with an older file format version: ",
+			Workspace.FileFormatVersion.find_key(workspace._file_format_version))
+	elif workspace._file_format_version > Workspace.get_most_recent_file_format_version():
+		push_error("This workspace file was written with an newer file format version: ",
+			workspace._file_format_version)
+		
 	return workspace

--- a/godot_project/project_workspace/file_format/workspace_format_saver.gd
+++ b/godot_project/project_workspace/file_format/workspace_format_saver.gd
@@ -11,6 +11,7 @@ func _get_recognized_extensions(resource: Resource) -> PackedStringArray:
 
 func _save(resource: Resource, path: String, flags: int) -> Error:
 	_update_msep_vertsion_history(resource)
+	_update_file_format_version(resource)
 	_update_simulation_forcefield_hashes(resource)
 	_embed_thumbnail_if_needed(resource)
 	var tmp_path: String = path + ".tres"
@@ -25,6 +26,10 @@ func _save(resource: Resource, path: String, flags: int) -> Error:
 func _update_msep_vertsion_history(out_workspace: Workspace) -> void:
 	var timestamp: String = Time.get_datetime_string_from_system()
 	out_workspace.msep_version_history[timestamp] = Editor_Utils.get_msep_version()
+
+
+func _update_file_format_version(out_workspace: Workspace) -> void:
+	out_workspace._file_format_version = Workspace.get_most_recent_file_format_version()
 
 
 func _update_simulation_forcefield_hashes(out_workspace: Workspace) -> void:

--- a/godot_project/project_workspace/workspace.gd
+++ b/godot_project/project_workspace/workspace.gd
@@ -12,8 +12,18 @@ const INVALID_STRUCTURE_ID := 0
 const INVALID_OBJECT_INDEX = -1
 const MAX_SIGNED_32_BIT_INT = 2147483647
 
+enum FileFormatVersion {
+	FORMAT_UNDEFINED = 0,
+	FORMAT_1,
+}
+
 static var instance_counter: int = 0
 
+
+@warning_ignore("unused_private_class_variable")
+@export_storage var _file_format_version := FileFormatVersion.FORMAT_UNDEFINED
+static func get_most_recent_file_format_version() -> FileFormatVersion:
+	return FileFormatVersion.values().back()
 
 @export_storage var _thumbnail: PackedByteArray = []
 @export_storage var is_last_thumbnail_user_generated: bool = false


### PR DESCRIPTION
- This could allow us to react when loading a version of a file that doesn't match expectations
- An older file may be not supported, or need an upgrade on load
- Files newer to the current version of MSEP could show a warning to the user requiring to download a newer version of MSEP

Task; Add version flag to the msep1 files