### PR TITLE
Fix the outdated validation warning when modifying the workspace

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/atomic_structure_model_validator.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/atomic_structure_model_validator.gd
@@ -23,13 +23,14 @@ var _workspace_context: WorkspaceContext = null
 func set_workspace_context(in_workspace_context: WorkspaceContext) -> void:
 	assert(not is_instance_valid(_workspace_context), "Already initialized")
 	_workspace_context = in_workspace_context
-	in_workspace_context.structure_contents_changed.connect(_on_workspace_context_structure_contents_changed)
-	in_workspace_context.structure_about_to_remove.connect(_on_workspace_context_structure_about_to_remove)
 	in_workspace_context.history_changed.connect(_on_history_changed)
 
 
 func _on_history_changed() -> void:
-	_update_alerts()
+	var last_action: String = _workspace_context.get_last_snapshot_name()
+	if not History.is_operation_whitelisted_during_simulation(last_action):
+		_update_alerts()
+		results_outdated.emit()
 
 
 func _validate_bonds_in_thread(
@@ -330,23 +331,11 @@ func _on_alert_selected(in_alert_id: int, show_hidden: bool = false) -> void:
 	_workspace_context.snapshot_moment("Select Atoms")
 
 
-func _on_workspace_context_structure_contents_changed(_structure: StructureContext) -> void:
-	ScriptUtils.call_deferred_once(_update_alerts)
-
-
-func _on_workspace_context_structure_about_to_remove(_in_struct: NanoStructure) -> void:
-	ScriptUtils.call_deferred_once(_update_alerts)
-
-
 func _update_alerts() -> void:
-	var is_outdated: bool = false
 	for data: Metadata in _data:
 		if data.has_invalid_atoms():
-			is_outdated = true
 			var alert_id: int = _data[data]
 			_workspace_context.mark_alert_as_invalid(alert_id)
-	if is_outdated:
-		results_outdated.emit()
 
 
 func show_hidden_atoms(in_selected_alert: int) -> void:

--- a/godot_project/project_workspace/workspace_context/history/history.gd
+++ b/godot_project/project_workspace/workspace_context/history/history.gd
@@ -189,6 +189,7 @@ func apply_next_snapshot() -> void:
 
 func _apply_snapshot_from_stack(in_stack_index: int) -> void:
 	apply_snapshot(_snapshot_stack[in_stack_index])
+	_last_snapshot_name = _name_stack[in_stack_index]
 
 
 func apply_snapshot(in_state_snapshot: Dictionary) -> void:
@@ -233,6 +234,10 @@ func get_redo_name() -> String:
 
 func get_version() -> int:
 	return _version
+
+
+func get_last_snapshot_name() -> String:
+	return _last_snapshot_name
 
 
 func _validate_extern_snapshot(in_snapshot: Dictionary) -> bool:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1526,6 +1526,10 @@ func apply_next_snapshot() -> void:
 		seek_simulation(current_simulation_time)
 
 
+func get_last_snapshot_name() -> String:
+	return _history.get_last_snapshot_name()
+
+
 func get_undo_name() -> String:
 	return _history.get_undo_name()
 


### PR DESCRIPTION
Card: BUG - Project announces it has been changed since last validation, but validation has never been 
Follow up to #453 
 
The `results_outdated` signal is now emitted anytime an action that actually changes the workspace contents happens.

This ensure the warning in the validation panel won't appear by simply changing the selection, but still appears when changing atoms unrelated to the ones that were already validated. 