### PR TITLE
Fix deselection shortcut in macos

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -76,7 +76,7 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 			# Selection was cleared, DynamicContextDocker is no longer relevant
 			MolecularEditorContext.request_workspace_docker_focus(CreateDocker.UNIQUE_DOCKER_NAME)
 		return input_consumed
-	elif in_input_event.is_action_pressed(&"multiselect", false, true) or _user_is_selecting_on_mac_pressed(in_input_event, false, true):
+	elif in_input_event.is_action_pressed(&"multiselect", false, true):
 		var input_consumed: bool = _select_connected_selection_logic(in_camera, in_input_event.position, editable_structures, true)
 		if input_consumed == false:
 			input_consumed = _screen_selection_logic(in_camera, in_input_event.position, editable_structures, true)

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -258,7 +258,7 @@ cancel={
 }
 unselect_mac={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"button_mask":2,"position":Vector2(498, 35),"global_position":Vector2(1186, 494),"factor":1.0,"button_index":2,"canceled":false,"pressed":true,"double_click":false,"script":null)
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":true,"button_mask":1,"position":Vector2(208, 14),"global_position":Vector2(217, 62),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
 ]
 }
 select_mac={


### PR DESCRIPTION
- Command+click will unselect the hovered atom or object
- Command+doubleclick will unselect all atoms connected to the hovered atom

Task: UX SUGGESTION: Double clicking an atom that is part of the active group, selects all linked atoms