### PR TITLE
Use full path to ffmpeg as part of the recording command

### DIFF
--- a/godot_project/utils/video_recorder/video_recorder_ffmpeg.gd
+++ b/godot_project/utils/video_recorder/video_recorder_ffmpeg.gd
@@ -16,9 +16,24 @@ var _crf: int = 17
 
 # Note: These behaves as constants, but cannot be constants because of OS.get_name() access
 static var _is_windows: bool = OS.get_name().to_lower() == "windows"
-static var _cmd: String = "ffmpeg.exe" if _is_windows else "ffmpeg"
+static var _cmd: String:
+	get():
+		if _cmd.is_empty():
+			if _is_windows:
+				_cmd = "ffmpeg.exe"
+			else:
+				var out := Array()
+				var exit_code: int = OS.execute("bash", ["-l", "-c", "which ffmpeg"], out)
+				_cmd = "" if exit_code != 0 else str(out[0]).rstrip("\n")
+				if _cmd.is_empty():
+					# bash could not find the path, MacOS could be using zsh
+					exit_code = OS.execute("zsh", ["-l", "-c", "which ffmpeg"], out)
+					_cmd = "" if exit_code != 0 else str(out[0]).rstrip("\n")
+		return _cmd
 
 static func is_available() -> bool:
+	if _cmd.is_empty():
+		return false
 	var a: int = OS.execute(_cmd, [])
 	return a >= 0
 


### PR DESCRIPTION
- This fixes a crash on macos because execute_with_pipe cannot run the command because the lack of the $PATH environment variable

Task: CRASH - Saving MP4 files on mac
