### PR TITLE
Fix intrusive first frame in video recording

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd
@@ -290,8 +290,11 @@ func _bake_video(in_filepath: String) -> void:
 		var simulation_frame: int = int(_simulation_elapsed_time_femtoseconds / femtoseconds_per_simulation_frame)
 		# This will in cause the simulation to be updated
 		_time_slider.value = simulation_frame
-		# ensure rendered
+		# HACK: Label.queue_redraw() waits until the end of the frame, so RenderingServer.force_redraw
+		# will still show the old text unless we ensure it's execution
 		await get_tree().process_frame
+		# ensure rendered
+		RenderingServer.force_draw()
 		var capture_image: Image = _sub_viewport_preview.get_texture().get_image()
 		if _check_button_crop.button_pressed:
 			capture_image = capture_image.get_region(Rect2i(
@@ -302,8 +305,6 @@ func _bake_video(in_filepath: String) -> void:
 			))
 		_recorder.add_frame(capture_image)
 		_update_progress()
-		# ensure encoded
-		await get_tree().process_frame
 		_simulation_elapsed_time_femtoseconds += femtoseconds_per_video_frame
 	if _aborted:
 		_recorder = null

--- a/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.tscn
+++ b/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.tscn
@@ -180,9 +180,7 @@ value = 17.0
 [node name="SubViewportPreview" parent="VBoxContainer/HBoxContainer/PreviewControls" index="0"]
 render_target_update_mode = 4
 
-[node name="CanvasLayer" type="CanvasLayer" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview" index="3"]
-
-[node name="CropRectControl" type="MarginContainer" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview/CanvasLayer" index="0"]
+[node name="CropRectControl" type="MarginContainer" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview" index="3"]
 unique_name_in_owner = true
 anchors_preset = 15
 anchor_right = 1.0
@@ -194,7 +192,7 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="TimeLabel" type="Label" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview/CanvasLayer/CropRectControl" index="0"]
+[node name="TimeLabel" type="Label" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview/CropRectControl" index="0"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8


### PR DESCRIPTION
- Before this change, the first frame of the video would show whatever timestamp was selected in the timeline instead of 0.0

Task: BUG: Intrusive first frame in the simulation video