### PR TITLE
Keep the outdated warning consistent with the undo redo history

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/atomic_structure_model_validator.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/atomic_structure_model_validator.gd
@@ -18,7 +18,7 @@ var _thread: Thread
 var _overlaps: Dictionary[OverlapData, int] = {} # Overlap data : Alert ID
 var _data: Dictionary[Metadata, int] = {} # Data : Alert ID
 var _workspace_context: WorkspaceContext = null
-var _last_validation_frame: int = -1
+var _last_validation_version: int = -1
 
 
 func set_workspace_context(in_workspace_context: WorkspaceContext) -> void:
@@ -28,8 +28,9 @@ func set_workspace_context(in_workspace_context: WorkspaceContext) -> void:
 
 
 func _on_history_changed() -> void:
-	if _last_validation_frame < 0:
+	if _last_validation_version < 0 or _last_validation_version == _workspace_context.get_version():
 		return
+	
 	var last_action: String = _workspace_context.get_last_snapshot_name()
 	if not History.is_operation_whitelisted_during_simulation(last_action):
 		_update_alerts()
@@ -99,7 +100,7 @@ func _validate_bonds_in_thread(
 func validate_atomic_model(atom_set: AtomicStructure.AtomSet) -> void:
 	if _thread and _thread.is_alive():
 		return
-	_last_validation_frame = Engine.get_process_frames()
+	_last_validation_version = _workspace_context.get_version() + 1
 	var promise: Promise = Promise.new()
 	_thread = Thread.new()
 	_thread.start(_validate_bonds_in_thread.bind(_workspace_context.get_all_structure_contexts(), promise, atom_set))

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.gd
@@ -55,6 +55,7 @@ func _ensure_initialized(in_workspace_context: WorkspaceContext) -> void:
 		in_workspace_context.create_object_parameters.validate_bonds_requested.connect(_on_create_object_parameters_validate_bonds_requested)
 		in_workspace_context.alerts_panel_visibility_changed.connect(_on_workspace_context_alerts_panel_visibility_changed)
 		_atomic_structure_model_validator.set_workspace_context(in_workspace_context)
+		_workspace_context.register_snapshotable(self)
 		ScriptUtils.call_deferred_once(_update_panel_state)
 
 
@@ -140,6 +141,7 @@ func _on_atomic_structure_model_validator_validation_finished(in_found_overlaps:
 	if _workspace_context.has_alerts():
 		_workspace_context.show_alerts_panel()
 	ScriptUtils.call_deferred_once(_update_view_alerts_button)
+	_workspace_context.snapshot_moment("Validate Model")
 
 
 func _on_atomic_structure_model_validator_alert_selected(in_has_invisible_atoms: bool) -> void:
@@ -154,3 +156,13 @@ func _update_view_alerts_button() -> void:
 	var alerts_count: int = _workspace_context.get_alerts_count()
 	_button_view_alerts.visible = (not _workspace_context.is_alerts_panel_visible()) and alerts_count > 0
 	_button_view_alerts.text = tr_n(&"View %d alert", &"View %d alerts", alerts_count) % alerts_count
+
+
+func create_state_snapshot() -> Dictionary:
+	return {
+		"outdated_results" : _outdated_results_label.visible,
+	}
+
+
+func apply_state_snapshot(in_snapshot: Dictionary) -> void:
+	_outdated_results_label.visible = in_snapshot["outdated_results"]

--- a/godot_project/project_workspace/workspace_context/history/history.gd
+++ b/godot_project/project_workspace/workspace_context/history/history.gd
@@ -80,8 +80,9 @@ var _workspace_context: WorkspaceContext
 var _snapshotable_systems: Array[Object]
 var _snapshot_stack: Array[Dictionary]
 var _name_stack: Array[String] = []
+var _version_stack: Array[int] = []
 var _stack_pointer: int = -1
-var _version: int
+var _highest_version: int = -1
 var _last_snapshot_taken_at_frame: int = Engine.get_frames_drawn() - 1
 var _last_snapshot_name: String = ""
 
@@ -131,18 +132,21 @@ func _add_snapshot_to_stack(in_snapshot: Dictionary, in_snapshot_name: String) -
 	if need_to_drop_stack:
 		_snapshot_stack.resize(_stack_pointer + 1)
 		_name_stack.resize(_stack_pointer + 1)
+		_version_stack.resize(_stack_pointer + 1)
 	
+	_highest_version += 1
 	_snapshot_stack.append(in_snapshot)
 	_name_stack.append(in_snapshot_name)
+	_version_stack.append(_highest_version)
 	_stack_pointer = _snapshot_stack.size() - 1
 	
 	var max_undo_count: int = MolecularEditorContext.msep_editor_settings.editor_max_undo_count
 	while _snapshot_stack.size() > max_undo_count:
 		_snapshot_stack.pop_front()
 		_name_stack.pop_front()
+		_version_stack.pop_front()
 		_stack_pointer -= 1
 	
-	_version += 1
 	_last_snapshot_taken_at_frame = Engine.get_frames_drawn()
 	_last_snapshot_name = in_snapshot_name
 	changed.emit()
@@ -157,7 +161,6 @@ func apply_previous_snapshot() -> void:
 	var undone_snapshot_name: String = _name_stack[_stack_pointer]
 	_stack_pointer -= 1
 	_apply_snapshot_from_stack(_stack_pointer)
-	_version -= 1
 	# IMPORTANT: if a method uses call_deferred part of the snapshot, that would make the
 	#            "aplication of the snapshot" incomplete until the next frame.
 	#            I have confirmed this happens at least when the snapshot is creating a new group,
@@ -174,6 +177,7 @@ func _wait_one_frame() -> void:
 	await Engine.get_main_loop().process_frame
 	viewport.gui_disable_input = false
 
+
 func apply_next_snapshot() -> void:
 	var cannot_move_forward: bool = _stack_pointer >= (_snapshot_stack.size() - 1)
 	if cannot_move_forward:
@@ -181,7 +185,6 @@ func apply_next_snapshot() -> void:
 	_stack_pointer += 1
 	_apply_snapshot_from_stack(_stack_pointer)
 	var snapshot_name: String = _name_stack[_stack_pointer]
-	_version += 1
 	changed.emit()
 	snapshot_applied.emit()
 	next_snapshot_applied.emit(snapshot_name)
@@ -233,7 +236,7 @@ func get_redo_name() -> String:
 
 
 func get_version() -> int:
-	return _version
+	return _version_stack[_stack_pointer]
 
 
 func get_last_snapshot_name() -> String:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1526,6 +1526,10 @@ func apply_next_snapshot() -> void:
 		seek_simulation(current_simulation_time)
 
 
+func get_version() -> int:
+	return _history.get_version()
+
+
 func get_last_snapshot_name() -> String:
 	return _history.get_last_snapshot_name()
 


### PR DESCRIPTION
Fixes: BUG - Project announces it has been changed since last validation, but validation has never been run

This PR does 2 things:

+ It makes the validation panel a snapshotable system (so it can track when to show the warning label)
+ It changes how history version is calculated

Currently, version is a simple int, it goes up when an action happens, and down on undo, which leads to version numbers being reused for different snapshots.

```
Snap A -> v1
Snap B -> v2
Undo (Back to A) -> v1
Snap C -> v2  (but it should be v3)
```

Instead, this PR adds a new array to track the snapshot versions (just like the names), it's increased on each new snapshot, reused on redo, but new actions created after an undo will resume from the highest version number.