### PR TITLE
Make all dialog use CrystalButton style for consistency

### DIFF
--- a/godot_project/autoloads/ui_behavior/ui_behavior.gd
+++ b/godot_project/autoloads/ui_behavior/ui_behavior.gd
@@ -18,6 +18,16 @@ func _on_node_added(node: Node) -> void:
 		if node.text_submitted.is_connected(_on_line_edit_text_submitted):
 			return
 		node.text_submitted.connect(_on_line_edit_text_submitted.bind(node), CONNECT_DEFERRED)
+	if node is AcceptDialog:
+		var child_count: int = node.get_child_count(true)
+		var buttons_container: HBoxContainer
+		for i in range(child_count-1, -1, -1):
+			if node.get_child(i, true) is HBoxContainer:
+				buttons_container = node.get_child(i, true)
+				break
+		for child in buttons_container.get_children(true):
+			if child is Button:
+				child.theme_type_variation = &"CrystalButton"
 
 func _on_line_edit_text_submitted(_new_text: String, in_line_edit: LineEdit) -> void:
 	# unfocus the line edit

--- a/godot_project/theme/theme.tres
+++ b/godot_project/theme/theme.tres
@@ -99,9 +99,9 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mvylp"]
-content_margin_left = 10.0
+content_margin_left = 20.0
 content_margin_top = 10.0
-content_margin_right = 10.0
+content_margin_right = 20.0
 content_margin_bottom = 10.0
 bg_color = Color(1, 1, 1, 0.156863)
 corner_radius_top_left = 999
@@ -125,9 +125,9 @@ corner_radius_bottom_right = 999
 corner_radius_bottom_left = 999
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6rff2"]
-content_margin_left = 10.0
+content_margin_left = 20.0
 content_margin_top = 10.0
-content_margin_right = 10.0
+content_margin_right = 20.0
 content_margin_bottom = 10.0
 bg_color = Color(0.305882, 0.305882, 0.305882, 0.486275)
 border_width_left = 1
@@ -140,9 +140,9 @@ corner_radius_bottom_right = 999
 corner_radius_bottom_left = 999
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hcnai"]
-content_margin_left = 10.0
+content_margin_left = 20.0
 content_margin_top = 10.0
-content_margin_right = 10.0
+content_margin_right = 20.0
 content_margin_bottom = 10.0
 bg_color = Color(0.501961, 0.501961, 0.501961, 0.470588)
 corner_radius_top_left = 999
@@ -151,9 +151,9 @@ corner_radius_bottom_right = 999
 corner_radius_bottom_left = 999
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_w8tsu"]
-content_margin_left = 10.0
+content_margin_left = 20.0
 content_margin_top = 10.0
-content_margin_right = 10.0
+content_margin_right = 20.0
 content_margin_bottom = 10.0
 bg_color = Color(0.25, 0.25, 0.25, 0.486275)
 border_width_left = 1


### PR DESCRIPTION
No Task

|Before|After|
|---|---|
|<img width="397" height="153" alt="image" src="https://github.com/user-attachments/assets/1383fcb4-ef7f-4f4a-bba5-c5fc38f18385" /> |<img width="414" height="165" alt="image" src="https://github.com/user-attachments/assets/93ae597a-ccf1-4584-b9f0-f9a3d1cd8c34" />|
|<img width="635" height="429" alt="image" src="https://github.com/user-attachments/assets/d5ec386d-8e2d-45d1-b323-6dcf4c2ec5b7" />|<img width="626" height="370" alt="image" src="https://github.com/user-attachments/assets/206f641d-27c8-4632-bfe6-57945a75d978" />|