### PR TITLE
fix incorrect selection state after opening the 'Capture camera image' popup

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
@@ -74,6 +74,7 @@ var _is_about_to_popup: bool = false
 var prev_size_preset: SizePresets = SizePresets.RES_MATCH_EDITOR
 var high_resolution_rendering_confirmed: bool = false
 var workspace_snapshot: Dictionary
+var structures_with_selection: Array[StructureContext]
 
 # Note: this is overriden in RecordSimulationVideoDialog subclass
 var _update_mode: SubViewport.UpdateMode = SubViewport.UPDATE_ONCE
@@ -164,6 +165,7 @@ func _on_about_to_popup() -> void:
 	_on_option_button_size_preset_item_selected(_option_button_size_preset.get_selected_id())
 	# Store existing selection and deselect everything
 	workspace_snapshot = workspace_context.create_state_snapshot()
+	structures_with_selection = workspace_context.get_structure_contexts_with_selection()
 	workspace_context.clear_all_selection()
 	_is_about_to_popup = false
 
@@ -215,7 +217,9 @@ func _on_visibility_changed() -> void:
 	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
 	assert(workspace_context != null)
 	workspace_context.apply_state_snapshot(workspace_snapshot)
+	workspace_context.selection_in_structures_changed.emit(structures_with_selection)
 	workspace_snapshot.clear()
+	structures_with_selection.clear()
 
 
 func _on_main_window_size_changed() -> void:


### PR DESCRIPTION
Fixes: BUG: Opening the "Capture Camera Image" makes several sections of the application believe there's no selection