### PR TITLE
Dont make created object's preview visible when ring menu opens a dialog

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
@@ -223,6 +223,8 @@ func _on_ring_menu_closed() -> void:
 	if get_workspace_context().create_object_parameters.get_create_mode_type() == \
 			CreateObjectParameters.CreateModeType.CREATE_ATOMS_AND_BONDS \
 			and get_workspace_context().create_object_parameters.get_create_mode_enabled():
+		if DisplayServer.window_get_active_popup() != DisplayServer.MAIN_WINDOW_ID:
+			return
 		update_preview_position()
 		get_workspace_context().get_rendering().atom_preview_show()
 

--- a/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
@@ -234,6 +234,8 @@ func _on_ring_menu_closed() -> void:
 	if get_workspace_context().create_object_parameters.get_create_mode_type() == \
 			CreateObjectParameters.CreateModeType.CREATE_ANCHORS_AND_SPRINGS \
 			and get_workspace_context().create_object_parameters.get_create_mode_enabled():
+		if DisplayServer.window_get_active_popup() != DisplayServer.MAIN_WINDOW_ID:
+			return
 		update_preview_position()
 		get_workspace_context().get_rendering().virtual_anchor_preview_show()
 

--- a/godot_project/editor/input_handlers/molecular_structures/create_reference_shape_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_reference_shape_input_handler.gd
@@ -43,6 +43,8 @@ func _on_ring_menu_closed() -> void:
 	if get_workspace_context().create_object_parameters.get_create_mode_type() == \
 			CreateObjectParameters.CreateModeType.CREATE_SHAPES \
 			and get_workspace_context().create_object_parameters.get_create_mode_enabled():
+		if DisplayServer.window_get_active_popup() != DisplayServer.MAIN_WINDOW_ID:
+			return
 		update_preview_position()
 		_rendering.shape_preview_show()
 

--- a/godot_project/editor/input_handlers/molecular_structures/create_virtual_motor_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_virtual_motor_input_handler.gd
@@ -63,6 +63,8 @@ func _on_ring_menu_closed() -> void:
 	if get_workspace_context().create_object_parameters.get_create_mode_type() == \
 			CreateObjectParameters.CreateModeType.CREATE_VIRTUAL_MOTORS \
 			and get_workspace_context().create_object_parameters.get_create_mode_enabled():
+		if DisplayServer.window_get_active_popup() != DisplayServer.MAIN_WINDOW_ID:
+			return
 		update_preview_position()
 		_rendering.virtual_motor_preview_show()
 

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -933,8 +933,9 @@ func _refresh_viewport_background() -> void:
 	_structure_preview.set_transparency(preview_transparency)
 
 
-func spring_preview_hide() -> void:
+func spring_preview_hide() -> Rendering:
 	_spring_preview.hide_preview()
+	return self
 
 
 func _on_workspace_context_simulation_started() -> void:


### PR DESCRIPTION
Task: BUG: Preview of Anchors and Virtual Motors appears in "Capture Camera Image" dialog