### PR TITLE
Adds user feedback when correcting overlapping atoms from the ring menu

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
+++ b/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
@@ -1,4 +1,5 @@
-extends Control
+class_name EditorViewportContainer
+extends SubViewportContainer
 
 var rendering: Rendering
 var editor_viewport: WorkspaceEditorViewport
@@ -103,6 +104,10 @@ func get_ring_menu() -> NanoRingMenu:
 
 func get_camera_widget() -> CameraWidget:
 	return _camera_widget
+
+
+func show_info_in_message_bar(in_message: String) -> void:
+	_message_bar.show_message(in_message)
 
 
 func show_warning_in_message_bar(in_message: String) -> void:

--- a/godot_project/editor/controls/workspace_view/WorkspaceMainView.gd
+++ b/godot_project/editor/controls/workspace_view/WorkspaceMainView.gd
@@ -4,7 +4,7 @@ var editor_dockers: Dictionary #[StringName,WorkspaceDocker]
 
 @onready var dock_area_left: Control = %DockAreaLeft
 @onready var dock_area_right: Control = %DockAreaRight
-@onready var editor_viewport_container: SubViewportContainer = %EditorViewportContainer
+@onready var editor_viewport_container: EditorViewportContainer = %EditorViewportContainer
 @onready var workspace_tools_container: Control = %WorkspaceToolsContainer
 @onready var screen_capture_dialog: ConfirmationDialog = $ScreenCaptureDialog
 @onready var record_simulation_video_dialog: ConfirmationDialog = $RecordSimulationVideoDialog

--- a/godot_project/editor/controls/workspace_view/controls/alerts_panel/alerts_panel.gd
+++ b/godot_project/editor/controls/workspace_view/controls/alerts_panel/alerts_panel.gd
@@ -115,6 +115,33 @@ func mark_as_invalid(in_alert_id: int) -> void:
 	_update_mask_buttons()
 
 
+func toggle_all(in_enabled: bool) -> void:
+	toggle_fixed(in_enabled)
+	toggle_warnings(in_enabled)
+	toggle_errors(in_enabled)
+	toggle_invalid(in_enabled)
+
+
+func toggle_fixed(in_enabled: bool) -> void:
+	_fixed_mask_button.button_pressed = in_enabled
+	_on_fixed_mask_button_toggled(in_enabled)
+
+
+func toggle_warnings(in_enabled: bool) -> void:
+	_warnings_mask_button.button_pressed = in_enabled
+	_on_warnings_mask_button_toggled(in_enabled)
+
+
+func toggle_errors(in_enabled: bool) -> void:
+	_errors_mask_button.button_pressed = in_enabled
+	_on_errors_mask_button_toggled(in_enabled)
+
+
+func toggle_invalid(in_enabled: bool) -> void:
+	_invalid_mask_button.button_pressed = in_enabled
+	_on_invalid_mask_button_toggled(in_enabled)
+
+
 func create_state_snapshot() -> Dictionary:
 	var copy: Dictionary = {}
 	for alert_id: int in _data:

--- a/godot_project/editor/ring_menu_levels/atoms/ring_action_correct_overlapping_atoms.gd
+++ b/godot_project/editor/ring_menu_levels/atoms/ring_action_correct_overlapping_atoms.gd
@@ -36,5 +36,15 @@ func get_icon() -> RingMenuIcon:
 
 func _execute_action() -> void:
 	_ring_menu.close()
+	_workspace_context.clear_alerts()
+	var editor_viewport_container: EditorViewportContainer = _workspace_context.get_editor_viewport_container()
 	await _model_validator.validate_atomic_model(AtomicStructure.AtomSet.ALL)
-	_model_validator.fix_overlapping_atoms()
+	if _model_validator.has_overlapping_atoms():
+		_model_validator.fix_overlapping_atoms()
+		_workspace_context.show_alerts_panel()
+		var alerts_panel: AlertsPanel = _workspace_context.get_alerts_panel()
+		alerts_panel.toggle_all(false)
+		alerts_panel.toggle_fixed(true)
+		editor_viewport_container.show_info_in_message_bar(tr("Fixed overlapping atoms. See the alerts panel for details."))
+	else:
+		editor_viewport_container.show_info_in_message_bar(tr("No overlapping atoms found."))

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -420,6 +420,10 @@ func pause_inputs(duration: float) -> void:
 	get_editor_viewport().pause_inputs(duration)
 
 
+func get_alerts_panel() -> AlertsPanel:
+	return workspace_main_view.get_alerts_panel()
+
+
 ## Returns true if there's at least 1 alert
 func has_alerts() -> bool:
 	return get_alerts_count() > 0
@@ -1126,7 +1130,7 @@ func get_selection_aabb() -> AABB:
 
 # # Viewport and Input
 # # # # # #
-func get_editor_viewport_container() -> SubViewportContainer:
+func get_editor_viewport_container() -> EditorViewportContainer:
 	if is_instance_valid(workspace_main_view):
 		return workspace_main_view.editor_viewport_container
 	return null


### PR DESCRIPTION
Card: ENHANCEMENT: Make the Correct Overlapping Atoms action open the validation menu

Opening the validation menu is not very useful in this case. Instead, it opens the alerts panels and only show the fixed overlaps. It also displays a message in the message bar in case there's nothing to fix.

<img width="945" height="594" alt="image" src="https://github.com/user-attachments/assets/83b15771-f45b-4000-86d6-cd6f4ec94bd1" />
