### PR TITLE
Guarantee all previews are hidden when the capture image/video opens

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/screen_capture_dialog.gd
@@ -158,6 +158,7 @@ func _on_about_to_popup() -> void:
 	_is_about_to_popup = true
 	var workspace_context: WorkspaceContext = MolecularEditorContext.get_current_workspace_context()
 	assert(workspace_context != null)
+	workspace_context.get_rendering().hide_all_previews()
 	var workspace_viewport: WorkspaceEditorViewport = workspace_context.get_editor_viewport()
 	_sub_viewport_preview.world_3d = workspace_viewport.find_world_3d()
 	_workspace_environment = workspace_context.get_rendering().get_environment()

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -589,6 +589,20 @@ func update(in_delta: float) -> void:
 
 # # # # # #
 # # Preview api
+
+func hide_all_previews() -> Rendering:
+	return \
+		atom_preview_hide() \
+		.bond_preview_hide() \
+		.atom_autopose_preview_hide() \
+		.structure_preview_hide() \
+		.shape_preview_hide() \
+		.virtual_motor_preview_hide() \
+		.particle_emitter_preview_hide() \
+		.virtual_anchor_preview_hide() \
+		.spring_preview_hide()
+
+
 #region atom_preview
 func is_atom_preview_visible() -> bool:
 	if not enabled: return false


### PR DESCRIPTION
Task: BUG: Preview of Anchors and Virtual Motors appears in "Capture Camera Image" dialog