### PR TITLE
Fix motors having a cycle_stop_after_n_cycles default value of 0 when 1 is expected

### DIFF
--- a/godot_project/project_workspace/structs/nano_virtual_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_virtual_motor_parameters.gd
@@ -44,8 +44,9 @@ var motor_type: Type = Type.UNKNOWN:
 	set = _set_cycle_swap_polarity
 @export var cycle_eventually_stops: bool = false:
 	set = _set_cycle_eventually_stops
-@export var cycle_stop_after_n_cycles: int = 0:
+@export var cycle_stop_after_n_cycles: int = 1:
 	set = _set_cycle_stop_after_n_cycles
+
 
 func _get_motor_type() -> Type:
 	assert(false, "Implement in subclass")


### PR DESCRIPTION
NOTE: Old files will still be loaded with value 0, but the simulation runs the first cycle anyways before stopping

Task: BUG: default number of cycles to stop motor is 0, despite spinbox shows 1