### PR TITLE
When selecting a motor, update 'Move For' and 'Swap polarity' controls to reflect actual configured value

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/motor_cycle_parameters_editor.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/motor_cycle_parameters_editor.gd
@@ -171,9 +171,11 @@ func _on_parameters_changed() -> void:
 		_linear_distance_spin_box.set_value_no_signal(parameters.cycle_distance_limit)
 	else:
 		_rotary_distance_spin_box.set_value_no_signal(parameters.cycle_distance_limit)
+	_time_span_picker_pause_time.time_span_femtoseconds = parameters.cycle_pause_time_in_femtoseconds
 	_stop_after_check_box.set_pressed_no_signal(parameters.cycle_eventually_stops)
 	_stop_after_spin_box.editable = parameters.cycle_eventually_stops
 	_stop_after_spin_box.set_value_no_signal(parameters.cycle_stop_after_n_cycles)
+	_check_button_swap_polarity.set_pressed_no_signal(parameters.cycle_swap_polarity)
 	ScriptUtils.call_deferred_once(_update_stop_cycles_suffix)
 	ScriptUtils.call_deferred_once(_update_controls_visibility)
 

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/motor_cycle_parameters_editor.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/motor_cycle_parameters_editor.tscn
@@ -609,5 +609,5 @@ text = "・ Swap polarity between cycles"
 
 [node name="StateAnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
-"": SubResource("AnimationLibrary_1v0wx")
+&"": SubResource("AnimationLibrary_1v0wx")
 }


### PR DESCRIPTION
Task: BUG: Checkbox "Swap polarity between cycles" is not updated when selecting a different motor