### PR TITLE
Update Focus on Visible/Selected objects shortcuts on macos to not conflict with system's Spootlight shortcut

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_view/menu_view.tscn
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_view.tscn
@@ -23,8 +23,8 @@
 
 [sub_resource type="InputEventKey" id="InputEventKey_dap46"]
 device = -1
-command_or_control_autoremap = true
 shift_pressed = true
+ctrl_pressed = true
 keycode = 32
 
 [sub_resource type="Shortcut" id="Shortcut_2fwj8"]
@@ -32,7 +32,7 @@ events = [SubResource("InputEventKey_dap46")]
 
 [sub_resource type="InputEventKey" id="InputEventKey_trvs4"]
 device = -1
-command_or_control_autoremap = true
+ctrl_pressed = true
 keycode = 32
 unicode = 32
 


### PR DESCRIPTION
Solved by using Control+Space and Control+Shift+Space in all platforms
Notice this time we are not using Command instead of Control as we usually do, is the button named Control

Task: BUG: MACOS: Shortcut for "focus on selection" (Cmd+Space) cnoflicts with system's "Spotlight" shortcut