### PR TITLE
Prevent new objects previews from being shown when another object is being hovered

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
@@ -95,7 +95,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 			rendering.bond_preview_show()
 			rendering.atom_preview_set_position(atom_pos)
 			rendering.atom_preview_show()
-		elif has_modifiers or not create_mode_enabled:
+		elif has_modifiers or not create_mode_enabled or _workspace_context.has_hovered_object():
 			rendering.atom_preview_hide()
 			rendering.bond_preview_hide()
 		else:

--- a/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
@@ -103,6 +103,9 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 			_update_springs_end_candidates()
 			update_preview_position()
 			rendering.virtual_anchor_preview_show()
+		elif _workspace_context.has_hovered_object():
+			_render_candidates = false
+			rendering.virtual_anchor_preview_hide()
 		else:
 			_render_candidates = false
 			_update_springs_end_candidates()

--- a/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
@@ -57,7 +57,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, in_structur
 		var fragment_transform: Transform3D = _rendering.structure_preview_get_transform()
 		if fragment_transform == null:
 			return false # Ray normal is parallel to the PLANE_XY
-		if input_has_modifiers(in_input_event):
+		if input_has_modifiers(in_input_event) or _workspace_context.has_hovered_object():
 			_rendering.structure_preview_hide()
 			return false
 		_rendering.structure_preview_show()

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1186,6 +1186,10 @@ func set_hovered_structure_context(in_structure_context: StructureContext, in_at
 			_hovered_atom_id, _hovered_bond_id, _hovered_spring_id)
 
 
+func has_hovered_object() -> bool:
+	return _hovered_structure_context != null
+
+
 func change_current_structure_context(out_new_current_structure_context: StructureContext) -> void:
 	var nano_structure: NanoStructure = out_new_current_structure_context.nano_structure
 	if not nano_structure.get_visible():


### PR DESCRIPTION
Task: BUG: Presing ALT or CONTROL while hovering a virtual object will show the preview of atom or virtual anchor