### PR TITLE
Add 'Selection Tab Policy' editor setting

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/ui_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/ui_settings.gd
@@ -1,19 +1,34 @@
 extends DynamicContextControl
 
-
+@onready var _widget_scale_label: Label = %WidgetScaleLabel
 @onready var _widget_scale_spinbox: SpinBox = %WidgetScaleSpinbox
+@onready var _selection_option_button: OptionButton = %SelectionOptionButton
 
 
 func _ready() -> void:
 	_widget_scale_spinbox.value_changed.connect(_on_widget_scale_spinbox_value_changed)
+	_selection_option_button.item_selected.connect(_on_selection_option_button_item_selected)
 
 
 func should_show(_in_workspace_context: WorkspaceContext)-> bool:
-	_widget_scale_spinbox.set_value_no_signal( \
+	_widget_scale_spinbox.set_value_no_signal(
 		MolecularEditorContext.msep_editor_settings.ui_widget_scale)
-	var panel_enabled: bool = FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_ALLOW_SCALE_WIDGETS)
-	return panel_enabled
+	_selection_option_button.set_block_signals(true)
+	_selection_option_button.select(
+		MolecularEditorContext.msep_editor_settings.selection_tab_policy)
+	_selection_option_button.set_block_signals(false)
+	
+	var scale_widget_enabled: bool = FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_ALLOW_SCALE_WIDGETS)
+	_widget_scale_label.visible = scale_widget_enabled
+	_widget_scale_spinbox.visible = scale_widget_enabled
+	return true
 
 
 func _on_widget_scale_spinbox_value_changed(in_new_value: float) -> void:
 	MolecularEditorContext.msep_editor_settings.ui_widget_scale = in_new_value
+
+
+func _on_selection_option_button_item_selected(in_new_policy: int) -> void:
+	MolecularEditorContext.msep_editor_settings.selection_tab_policy = \
+		in_new_policy as MSEPSettings.SelectionTabPolicy
+

--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/ui_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/ui_settings.tscn
@@ -19,18 +19,37 @@ theme_type_variation = &"SubcategoryPanel"
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+[node name="GridContainer" type="GridContainer" parent="PanelContainer/VBoxContainer"]
 layout_mode = 2
+columns = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/HBoxContainer"]
+[node name="WidgetScaleLabel" type="Label" parent="PanelContainer/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Widgets scale"
 
-[node name="WidgetScaleSpinbox" type="SpinBox" parent="PanelContainer/VBoxContainer/HBoxContainer"]
+[node name="WidgetScaleSpinbox" type="SpinBox" parent="PanelContainer/VBoxContainer/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 0.25
 max_value = 2.5
 step = 0.05
 value = 1.25
+
+[node name="Label2" type="Label" parent="PanelContainer/VBoxContainer/GridContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "When selection changes"
+
+[node name="SelectionOptionButton" type="OptionButton" parent="PanelContainer/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+selected = 0
+fit_to_longest_item = false
+item_count = 2
+popup/item_0/text = "Focus Selection tab"
+popup/item_0/id = 0
+popup/item_1/text = "Stay in focused tab"
+popup/item_1/id = 1

--- a/godot_project/editor/input_handlers/molecular_structures/drag_drop_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/drag_drop_input_handler.gd
@@ -84,7 +84,8 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, _in_context
 			elif MolecularEditorContext.is_workspace_docker_active(GroupsDocker.UNIQUE_DOCKER_NAME):
 				# User is managing groups, dont bother him/her
 				pass
-			else:
+			elif MolecularEditorContext.msep_editor_settings.selection_tab_policy == \
+						MSEPSettings.SelectionTabPolicy.FOCUS_TAB_ON_SELECTION_CHANGE:
 				MolecularEditorContext.request_workspace_docker_focus(DynamicContextDocker.UNIQUE_DOCKER_NAME)
 		_is_mouse_down = false
 		return false

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -90,7 +90,8 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 			elif MolecularEditorContext.is_workspace_docker_active(GroupsDocker.UNIQUE_DOCKER_NAME):
 				# User is managing groups, dont bother him/her
 				pass
-			else:
+			elif MolecularEditorContext.msep_editor_settings.selection_tab_policy == \
+						MSEPSettings.SelectionTabPolicy.FOCUS_TAB_ON_SELECTION_CHANGE:
 				MolecularEditorContext.request_workspace_docker_focus(DynamicContextDocker.UNIQUE_DOCKER_NAME)
 		return input_consumed
 	
@@ -122,7 +123,8 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 				if MolecularEditorContext.is_workspace_docker_active(DynamicContextDocker.UNIQUE_DOCKER_NAME):
 					# DynamicContextDocker docker is no longer relevant, switch to another docker if the selection docker is active
 					MolecularEditorContext.request_workspace_docker_focus(CreateDocker.UNIQUE_DOCKER_NAME)
-			else:
+			elif MolecularEditorContext.msep_editor_settings.selection_tab_policy == \
+						MSEPSettings.SelectionTabPolicy.FOCUS_TAB_ON_SELECTION_CHANGE:
 				MolecularEditorContext.request_workspace_docker_focus(DynamicContextDocker.UNIQUE_DOCKER_NAME)
 		return input_consumed
 	

--- a/godot_project/editor/settings/msep_settings.gd
+++ b/godot_project/editor/settings/msep_settings.gd
@@ -3,6 +3,11 @@ class_name MSEPSettings
 
 const SETTINGS_RESOURCE_PATH = "user://editor/msep_settings.tres"
 
+enum SelectionTabPolicy {
+	FOCUS_TAB_ON_SELECTION_CHANGE = 0,
+	STAY_IN_FOCUSED_TAB_ON_SELECTION_CHANGE = 1,
+}
+
 enum OpenMMLoggingReporters {
 	PDBxReporter       = 1 << 0,
 	PDBReporter        = 1 << 1,
@@ -40,6 +45,8 @@ var _ui_sfx_bus_index: int =  AudioServer.get_bus_index(&"Ui Sfx")
 	set = set_custom_selection_outline_color_enabled
 @export var ui_widget_scale: float = 1.0:
 	set = set_ui_widget_scale
+@export var selection_tab_policy := SelectionTabPolicy.FOCUS_TAB_ON_SELECTION_CHANGE:
+	set = set_selection_tab_policy
 @export var openmm_server_allow_modified_script: bool = false:
 	set = set_openmm_server_allow_modified_script
 @export var is_simulation_logging_enabled: bool = false:
@@ -104,6 +111,11 @@ func set_custom_selection_outline_color_enabled(enabled: bool) -> void:
 
 func set_ui_widget_scale(in_value: float) -> void:
 	ui_widget_scale = in_value
+	changed.emit()
+
+
+func set_selection_tab_policy(in_policy: SelectionTabPolicy) -> void:
+	selection_tab_policy = in_policy
 	changed.emit()
 
 


### PR DESCRIPTION
- You can now remain in  the previous selected tab when selection changes

Task: Add user-settable flag in Workspace, where guest can set the application to not automatically go to the "Selection" tab on object selection. Should default to "Do go to Selection" on select.