### PR TITLE
Forward modifier events to input handlers, even when mouse is on top of dynamic context panel

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/editor_viewport.gd
+++ b/godot_project/editor/controls/editor_viewport_container/editor_viewport.gd
@@ -16,6 +16,10 @@ const INPUT_EVENT_ACTIONS_WHITELIST: Array[StringName] = [
 	&"toggle_ring_menu"
 ]
 
+const INPUT_KEYS_WHITELIST: Array[Key] = [
+	KEY_ALT
+]
+
 ## Returns the WorkspaceContext associated to the active workspace
 ## Any node inside this viewport can access to it with the following code
 ## [code]
@@ -141,10 +145,13 @@ func forward_viewport_input(event: InputEvent) -> void:
 		return
 	if not _input_forwarding_enabled:
 		var is_whitelisted: bool = false
-		for action in INPUT_EVENT_ACTIONS_WHITELIST:
-			if event.is_action(action):
-				is_whitelisted = true
-				break
+		if event is InputEventKey and event.keycode in INPUT_KEYS_WHITELIST:
+			is_whitelisted = true
+		else:
+			for action in INPUT_EVENT_ACTIONS_WHITELIST:
+				if event.is_action(action):
+					is_whitelisted = true
+					break
 		if not is_whitelisted:
 			return
 	_viewport_input.forward_viewport_input(event, self, _get_structure_context())


### PR DESCRIPTION
- Note: issue only happened when hovering the dynamic context panel with the mouse while pressing the buttons, It also didn't replicate if Ctrl was slightly released before Option

Task: BUG - CNTL-Option can toggle app into a state where the editor does not match the 'Show Potential Atom Positions" control in the Workspace tab