### PR TITLE
Add missing functionality to the DNA create panel

### DIFF
--- a/godot_project/autoloads/dna_builder/DnaBuilder.gd
+++ b/godot_project/autoloads/dna_builder/DnaBuilder.gd
@@ -6,10 +6,15 @@ var DNA_BASES_OFFSET: float = 0.6
 const DNA_COMPLEMENT: Dictionary[String, String] = {'A': 'T', 'T': 'A', 'G': 'C', 'C': 'G'}
 
 class Parameters:
+	enum StrandPolicy {
+		A,
+		B,
+		DOUBLE
+	}
 	var bases_per_turn: float = 10.0
 	var rise_nanometers: float = 0.34
 	var dna_radius_nanometers: float = 1.0
-	var double_strands: bool = true
+	var strand_policy:= StrandPolicy.DOUBLE
 	var include_hydrogens: bool = true
 
 var _base_templates: Dictionary[String, PackedMolecule] = {}
@@ -26,10 +31,15 @@ func is_dev_tool_enabled() -> bool:
 ##   in_parameters: a DnaBuilder.Parameters object, or null for default
 func build_dna_structure(in_sequence: String, in_params := Parameters.new()) -> AtomicStructure:
 	var structure := AtomicStructure.create()
-	var strand_count: int = 2 if in_params.double_strands else 1
+	var STRANDS_TO_CREATE: Dictionary[Parameters.StrandPolicy, PackedInt32Array] = {
+		Parameters.StrandPolicy.A      : [0],
+		Parameters.StrandPolicy.B      : [1],
+		Parameters.StrandPolicy.DOUBLE : [0, 1],
+	}
+	var strands: PackedInt32Array = STRANDS_TO_CREATE[in_params.strand_policy]
 	
 	structure.start_edit()
-	for strand in strand_count:
+	for strand in strands:
 		_create_strand(structure, in_sequence.to_upper(), in_params, strand)
 	structure.end_edit()
 	

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_sequence_text_edit.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_sequence_text_edit.gd
@@ -1,0 +1,87 @@
+@tool
+extends TextEdit
+
+const ACCEPTED_CHARS: String = "ACGTacgt"
+
+@onready var clipboard_error_label: Label = %ClipboardErrorLabel
+
+
+var _clipboard_error_tween: Tween
+
+
+func _draw() -> void:
+	if text.is_empty():
+		return
+	var font: Font = get_theme_font("font", theme_type_variation)
+	var font_size: int = get_theme_font_size("font_size", theme_type_variation)
+	var char_offset := Vector2(0, -font_size * 1.8)
+	var last_y: float = get_pos_at_line_column(0, 0).y
+	for l in get_line_count():
+		var line: String = get_line(l)
+		for col in line.length():
+			var char_pos: Vector2 = get_pos_at_line_column(l, col + 1)
+			# HACK: char_pos returns the next line one character early when wrapping the line, so this would ideally fix that
+			if last_y != char_pos.y:
+				last_y = char_pos.y
+				char_pos = get_pos_at_line_column(l, col + 0)
+				const CHAR_SEPARATION = -3
+				char_pos.x += font.get_string_size(line[col-1]).x + CHAR_SEPARATION
+			var compliment: String = DnaBuilder.DNA_COMPLEMENT.get(line[col], "?")
+			char_pos += char_offset
+			var color: Color = Color.WHITE
+			if syntax_highlighter != null:
+				color = syntax_highlighter.get_char_color(compliment)
+			color.a = 0.5
+			draw_string(
+				font,
+				char_pos,
+				compliment,
+				HORIZONTAL_ALIGNMENT_LEFT,
+				-1,
+				font_size,
+				color
+			)
+
+
+func _handle_unicode_input(unicode_char: int, _in_caret_index: int) -> void:
+	if char(unicode_char) in ACCEPTED_CHARS:
+		insert_text_at_caret(char(unicode_char).to_upper())
+
+func _paste(in_caret_index: int) -> void:
+	_handle_paste(DisplayServer.clipboard_get(), in_caret_index)
+
+
+func _paste_primary_clipboard(in_caret_index: int) -> void:
+	_handle_paste(DisplayServer.clipboard_get_primary(), in_caret_index)
+
+
+func _handle_paste(in_text: String, in_caret_index: int) -> void:
+	for k: String in in_text:
+		if not k in ACCEPTED_CHARS:
+			if in_caret_index in [0, -1]:
+				_show_invalid_clipboard_message()
+			return
+	insert_text_at_caret(in_text.to_upper(), in_caret_index)
+
+
+func _show_invalid_clipboard_message() -> void:
+	# Note: clipboard error label is a toplevel node, so we set it's global position
+	var pos: Vector2 = get_caret_draw_pos(0)
+	var global_pos: Vector2 = get_global_rect().position + pos
+	const Y_OFFSET = 22
+	global_pos.y -= (clipboard_error_label.size.y + Y_OFFSET)
+	if global_pos.x + clipboard_error_label.size.x > get_viewport_rect().size.x:
+		global_pos.x -= clipboard_error_label.size.x
+	clipboard_error_label.position = global_pos
+	if _clipboard_error_tween != null:
+		_clipboard_error_tween.kill()
+	clipboard_error_label.self_modulate.a = 1
+	_clipboard_error_tween = create_tween()
+	_clipboard_error_tween.tween_property(clipboard_error_label, ^"self_modulate:a", 0, 0.2).set_delay(1)
+
+
+func _gui_input(in_event: InputEvent) -> void:
+	if in_event is InputEventKey:
+		# block non unicode characters
+		if in_event.keycode in [KEY_TAB, KEY_ENTER]:
+			get_viewport().set_input_as_handled()

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_sequence_text_edit.gd.uid
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_sequence_text_edit.gd.uid
@@ -1,0 +1,1 @@
+uid://dkaufhlxrp25m

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_sequence_text_edit.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_sequence_text_edit.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=3 format=3 uid="uid://qwxweev3tdf8"]
+
+[ext_resource type="Script" uid="uid://dkaufhlxrp25m" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_sequence_text_edit.gd" id="1_0520e"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0520e"]
+content_margin_left = 6.0
+content_margin_top = 2.0
+content_margin_right = 6.0
+content_margin_bottom = 2.0
+bg_color = Color(0.862745, 0.0784314, 0.235294, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="DnaSequenceTextEdit" type="TextEdit"]
+offset_right = 176.0
+offset_bottom = 77.0
+theme_override_constants/line_spacing = 18
+theme_override_font_sizes/font_size = 16
+emoji_menu_enabled = false
+wrap_mode = 1
+autowrap_mode = 1
+scroll_fit_content_height = true
+script = ExtResource("1_0520e")
+
+[node name="ClipboardErrorLabel" type="Label" parent="."]
+unique_name_in_owner = true
+self_modulate = Color(1, 1, 1, 0)
+top_level = true
+layout_mode = 0
+offset_right = 120.0
+offset_bottom = 14.0
+theme_override_font_sizes/font_size = 14
+theme_override_styles/normal = SubResource("StyleBoxFlat_0520e")
+text = "Invalid clipboard content"

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_syntax_highlighter.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_syntax_highlighter.gd
@@ -1,0 +1,21 @@
+@tool
+class_name DnaSyntaxHighlighter extends SyntaxHighlighter
+
+func _get_line_syntax_highlighting(in_line: int) -> Dictionary:
+	var hl: Dictionary = {}
+	var text: String = get_text_edit().text.get_slice("\n", in_line)
+
+	for c in text.length():
+		hl[c] = {
+			"color": get_char_color(text[c])
+		}
+	return hl
+
+func get_char_color(c: String) -> Color:
+	const DNA_COLORS: Dictionary = {
+		"A": Color(0.627, 0.0, 0.259),   # Deep Red
+		"T": Color(0.996, 0.855, 0.055),  # Yellow
+		"G": Color(0.098, 1.0, 0.098),    # Bright Green
+		"C": Color(0.098, 0.098, 1.0)     # Bright Blue
+	}
+	return DNA_COLORS.get(c, Color.WHITE)

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_syntax_highlighter.gd.uid
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_syntax_highlighter.gd.uid
@@ -1,0 +1,1 @@
+uid://dwikyk270ga6

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
@@ -1,12 +1,19 @@
 extends DynamicContextControl
 
-var _sequence_text_edit: TextEdit
+
+var _dna_sequence_text_edit: TextEdit
 var _dna_radius_spin_box_slider: SpinBoxSlider
-var _double_strand_check_button: CheckButton
+var _bases_per_turn_spin_box_slider: SpinBoxSlider
+var _rise_nanometers_spin_box_slider: SpinBoxSlider
+var _strand_a_button: Button
+var _strand_b_button: Button
+var _strand_double_button: Button
 var _include_hydrogens_check_button: CheckButton
 var _create_button: Button
 
+
 var _workspace_context: WorkspaceContext
+
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	_workspace_context = in_workspace_context
@@ -20,40 +27,69 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	
 	return true
 
+
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_SCENE_INSTANTIATED:
-		_sequence_text_edit = %SequenceTextEdit as TextEdit
+		_dna_sequence_text_edit = %DnaSequenceTextEdit as TextEdit
 		_dna_radius_spin_box_slider = %DnaRadiusSpinBoxSlider as SpinBoxSlider
-		_double_strand_check_button = %DoubleStrandCheckButton as CheckButton
+		_bases_per_turn_spin_box_slider = %BasesPerTurnSpinBoxSlider as SpinBoxSlider
+		_rise_nanometers_spin_box_slider = %RiseNanometersSpinBoxSlider as SpinBoxSlider
+		_strand_a_button = %StrandAButton as Button
+		_strand_b_button = %StrandBButton as Button
+		_strand_double_button = %StrandDoubleButton as Button
 		_include_hydrogens_check_button = %IncludeHydrogensCheckButton as CheckButton
 		_create_button = %CreateButton as Button
 		var default_params := DnaBuilder.Parameters.new()
 		_dna_radius_spin_box_slider.value = default_params.dna_radius_nanometers
+		_bases_per_turn_spin_box_slider.value = default_params.bases_per_turn
+		_rise_nanometers_spin_box_slider.value = default_params.rise_nanometers
+		match default_params.strand_policy:
+			DnaBuilder.Parameters.StrandPolicy.A:
+				_strand_a_button.button_pressed = true
+			DnaBuilder.Parameters.StrandPolicy.B:
+				_strand_b_button.button_pressed = true
+			DnaBuilder.Parameters.StrandPolicy.DOUBLE:
+				_strand_double_button.button_pressed = true
 		_include_hydrogens_check_button.button_pressed = default_params.include_hydrogens
-		_sequence_text_edit.text_changed.connect(_on_sequence_text_edit_text_changed)
+		_dna_sequence_text_edit.text_changed.connect(_on_dna_sequence_text_edit_text_changed)
 		_create_button.pressed.connect(_on_create_button_pressed)
 		_create_button.disabled = true
 		%OffsetSpinBoxSlider.value = DnaBuilder.DNA_BASES_OFFSET
 		FeatureFlagManager.on_feature_flag_toggled.connect(_on_feature_flag_toggled.unbind(2))
 		_on_feature_flag_toggled()
 
+
 func _on_feature_flag_toggled() -> void:
 	%DevToolLabel.visible = OS.is_debug_build() and DnaBuilder.is_dev_tool_enabled()
 	%OffsetSpinBoxSlider.visible = OS.is_debug_build() and DnaBuilder.is_dev_tool_enabled()
 
+
 func _on_create_button_pressed() -> void:
 	var params := DnaBuilder.Parameters.new()
 	params.dna_radius_nanometers = _dna_radius_spin_box_slider.value
-	params.double_strands = _double_strand_check_button.button_pressed
+	params.bases_per_turn = _bases_per_turn_spin_box_slider.value
+	params.rise_nanometers = _rise_nanometers_spin_box_slider.value
+	var strand_button: Button = _strand_a_button.button_group.get_pressed_button()
+	match strand_button:
+		_strand_a_button:
+			params.strand_policy = DnaBuilder.Parameters.StrandPolicy.A
+		_strand_b_button:
+			params.strand_policy = DnaBuilder.Parameters.StrandPolicy.B
+		_strand_double_button:
+			params.strand_policy = DnaBuilder.Parameters.StrandPolicy.DOUBLE
+		_:
+			push_error("Invalid strand polocy_button: ",
+				"<null>" if strand_button == null else str(get_path_to(strand_button)))
 	params.include_hydrogens = _include_hydrogens_check_button.button_pressed
 	if OS.is_debug_build() and DnaBuilder.is_dev_tool_enabled():
 		DnaBuilder.DNA_BASES_OFFSET = %OffsetSpinBoxSlider.value
 
-	var dna: AtomicStructure = DnaBuilder.build_dna_structure(_sequence_text_edit.text, params)
+	var dna: AtomicStructure = DnaBuilder.build_dna_structure(_dna_sequence_text_edit.text, params)
 	dna.set_structure_name("DNA Chain%d" % _workspace_context.workspace.get_nmb_of_structures())
 	var parent_context: StructureContext = _workspace_context.get_current_structure_context()
 	_workspace_context.workspace.add_structure(dna, parent_context.nano_structure)
 	_workspace_context.snapshot_moment("Create DNA Chain")
 
-func _on_sequence_text_edit_text_changed() -> void:
-	_create_button.disabled = _sequence_text_edit.text.is_empty()
+
+func _on_dna_sequence_text_edit_text_changed() -> void:
+	_create_button.disabled = _dna_sequence_text_edit.text.is_empty()

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.tscn
@@ -1,7 +1,10 @@
-[gd_scene load_steps=3 format=3 uid="uid://dmnib7j4ygl8j"]
+[gd_scene load_steps=5 format=3 uid="uid://dmnib7j4ygl8j"]
 
 [ext_resource type="Script" uid="uid://d3sfr458tscsd" path="res://editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd" id="1_m000l"]
+[ext_resource type="PackedScene" uid="uid://qwxweev3tdf8" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/dna_sequence_text_edit.tscn" id="2_8e3dj"]
 [ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="2_y5jvm"]
+
+[sub_resource type="ButtonGroup" id="ButtonGroup_8e3dj"]
 
 [node name="CreateDnaPanel" type="MarginContainer"]
 offset_right = 462.0
@@ -15,14 +18,9 @@ layout_mode = 2
 layout_mode = 2
 text = "Sequence"
 
-[node name="SequenceTextEdit" type="TextEdit" parent="VBoxContainer"]
+[node name="DnaSequenceTextEdit" parent="VBoxContainer" instance=ExtResource("2_8e3dj")]
 unique_name_in_owner = true
 layout_mode = 2
-placeholder_text = "ATGC"
-emoji_menu_enabled = false
-middle_mouse_paste_enabled = false
-wrap_mode = 1
-scroll_fit_content_height = true
 
 [node name="PanelContainer" type="PanelContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -54,6 +52,71 @@ allow_greater = true
 suffix = "nm"
 custom_arrow_step = 0.1
 
+[node name="Label3" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer"]
+layout_mode = 2
+text = "Bases per turn"
+
+[node name="BasesPerTurnSpinBoxSlider" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer" instance=ExtResource("2_y5jvm")]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 2.0
+max_value = 15.0
+step = 0.1
+value = 10.0
+allow_greater = true
+custom_arrow_step = 1.0
+
+[node name="Label4" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer"]
+layout_mode = 2
+text = "Rise"
+
+[node name="RiseNanometersSpinBoxSlider" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer" instance=ExtResource("2_y5jvm")]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.1
+max_value = 1.0
+step = 0.01
+value = 0.34
+allow_greater = true
+suffix = "nm"
+custom_arrow_step = 0.1
+
+[node name="Label2" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer"]
+layout_mode = 2
+text = "Strands"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer"]
+layout_mode = 2
+theme_override_constants/separation = 0
+
+[node name="StrandAButton" type="Button" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"StructureSelectorButton"
+toggle_mode = true
+button_group = SubResource("ButtonGroup_8e3dj")
+text = "A"
+
+[node name="StrandBButton" type="Button" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"StructureSelectorTernary"
+toggle_mode = true
+button_group = SubResource("ButtonGroup_8e3dj")
+text = "B"
+
+[node name="StrandDoubleButton" type="Button" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"StructureSelectorMoreButton"
+toggle_mode = true
+button_pressed = true
+button_group = SubResource("ButtonGroup_8e3dj")
+text = "Double"
+
 [node name="DevToolLabel" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -72,12 +135,6 @@ allow_greater = true
 suffix = "nm"
 custom_arrow_step = 0.1
 
-[node name="DoubleStrandCheckButton" type="CheckButton" parent="VBoxContainer/PanelContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-button_pressed = true
-text = "Double Strand"
-
 [node name="IncludeHydrogensCheckButton" type="CheckButton" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -89,4 +146,4 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 theme_type_variation = &"CrystalButton"
-text = "Create Sequence as New Group"
+text = "Create DNA Group"

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -121,6 +121,7 @@ import/blender/enabled=false
 [gui]
 
 theme/custom="res://theme/theme.tres"
+theme/default_font_multichannel_signed_distance_field=true
 
 [input]
 

--- a/godot_project/theme/Gidole-Regular.ttf.import
+++ b/godot_project/theme/Gidole-Regular.ttf.import
@@ -16,7 +16,7 @@ Rendering=null
 antialiasing=1
 generate_mipmaps=false
 disable_embedded_bitmaps=true
-multichannel_signed_distance_field=false
+multichannel_signed_distance_field=true
 msdf_pixel_range=8
 msdf_size=48
 allow_system_fallback=true
@@ -35,7 +35,7 @@ preload=[{
 "glyphs": [],
 "name": "New Configuration",
 "size": Vector2i(16, 0),
-"variation_embolden": 0.0
+&"variation_embolden": 0.0
 }]
 language_support={}
 script_support={}


### PR DESCRIPTION
- Can now select to create A,B, or both strands
- shows complementary DNA chain
- Can select base rise and twist (bases per turn)

Task: Creating and Editing DNA

<img width="1720" height="780" alt="image" src="https://github.com/user-attachments/assets/4b83e014-8d64-4d1b-9b12-ee109ca595ad" />
