### PR TITLE
Several fixes to DNA Structure

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
@@ -50,7 +50,7 @@ func _on_feature_flag_toggled() -> void:
 
 func _on_create_button_pressed() -> void:
 	if _workspace_context.get_edited_dna_spline_id() != Workspace.INVALID_STRUCTURE_ID:
-		_workspace_context.stop_editing_dna_spline_no_snapshot()
+		_workspace_context.stop_editing_dna_spline()
 	var params := DnaStructureParameters.new()
 	params.dna_radius_nanometers = _dna_radius_spin_box_slider.value
 	params.bases_per_turn = _bases_per_turn_spin_box_slider.value
@@ -75,6 +75,7 @@ func _on_create_button_pressed() -> void:
 	var dna_pos: Vector3 = InputHandlerCreateObjectBase.calculate_preview_position(_workspace_context)
 	var right_dir: Vector3 = _workspace_context.get_editor_viewport().get_camera_3d().global_transform.basis.x
 	var chain_length: float = params.rise_nanometers * (_dna_sequence_text_edit.text.length() - 1)
+	chain_length = max(chain_length, 0.01)
 	dna.start_edit()
 	dna.insert_control_point(dna_pos - right_dir * chain_length / 2.0)
 	dna.insert_control_point(dna_pos + right_dir * chain_length / 2.0)

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_docker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_docker.gd
@@ -157,6 +157,7 @@ func _stop_edit_dna_spline_if_necesary() -> void:
 			and _workspace_context.create_object_parameters.get_create_mode_type()
 			!= CreateObjectParameters.CreateModeType.CREATE_DNA_CHAIN):
 		_workspace_context.stop_editing_dna_spline()
+		_workspace_context.snapshot_moment("Stop Editing DNA Spline")
 
 
 func add_control_to_category(in_category_id: StringName, in_control: DynamicContextControl) -> bool:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
@@ -34,12 +34,17 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	
 	var selected_count: int = 0
 	var structure: DnaStructure
-	for structure_context: StructureContext in _workspace_context.get_structure_contexts_with_selection():
-		if not structure_context.nano_structure is DnaStructure:
-			_set_tracked_structure(null)
-			return false
-		selected_count += 1
-		structure = structure_context.nano_structure as DnaStructure
+	var edited_spline_context: StructureContext = in_workspace_context.get_edited_dna_spline_context()
+	if edited_spline_context != null:
+		selected_count = 1
+		structure = edited_spline_context.nano_structure as DnaStructure
+	else:
+		for structure_context: StructureContext in _workspace_context.get_structure_contexts_with_selection():
+			if not structure_context.nano_structure is DnaStructure:
+				_set_tracked_structure(null)
+				return false
+			selected_count += 1
+			structure = structure_context.nano_structure as DnaStructure
 	
 	if selected_count == 0:
 		_set_tracked_structure(null)
@@ -162,12 +167,11 @@ func _on_start_stop_editing_button_pressed() -> void:
 	assert(_tracked_structure != null, "Invalid ui state")
 	if _workspace_context.get_edited_dna_spline_context() == null:
 		_workspace_context.start_editing_dna_spline(_tracked_structure.get_int_guid())
-		_workspace_context.snapshot_moment("Start Editing DNA Path")
-
+		_workspace_context.snapshot_moment("Start Editing DNA Spline")
 	else:
 		assert(_workspace_context.get_edited_dna_spline_id() == _tracked_structure.int_guid)
 		_workspace_context.stop_editing_dna_spline()
-		_workspace_context.snapshot_moment("Stop Editing DNA Path")
+		_workspace_context.snapshot_moment("Stop Editing DNA Spline")
 
 
 func _on_dna_spline_edition_started(dna_context: StructureContext) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
@@ -120,12 +120,14 @@ text = "Double"
 
 [node name="DevToolLabel" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 0.498039, 0.313726, 1)
 text = "Bases Offset"
 
 [node name="OffsetSpinBoxSlider" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer" instance=ExtResource("3_w42n7")]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 tooltip_text = "This is a DEV TOOL, should never be visible on release"
 min_value = 0.5

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -346,7 +346,7 @@ func _activate_selection_logic(
 						_workspace_context.snapshot_moment("Insert DNA control cpoint")
 				else:
 					get_workspace_context().start_editing_dna_spline(affected_context.get_int_guid())
-					_workspace_context.snapshot_moment("Start Editing DNA Path")
+					get_workspace_context().snapshot_moment("Start Editing DNA Spline")
 				return true
 			get_workspace_context().change_current_structure_context(affected_context)
 			_workspace_context.snapshot_moment("Change Selection")
@@ -561,7 +561,7 @@ func _screen_selection_logic(
 									need_to_create_snapshot = true
 					else:
 						if is_editing:
-							_workspace_context.stop_editing_dna_spline_no_snapshot()
+							_workspace_context.stop_editing_dna_spline()
 						if hit_context.is_dna_structure_fully_selected():
 							hit_context.set_dna_spline_selected(false)
 							if not need_to_create_snapshot:

--- a/godot_project/editor/rendering/dna_structure_renderer/assets/dna_base_representation.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/assets/dna_base_representation.gd
@@ -30,7 +30,7 @@ class_name DnaBaseRepresentation extends PathFollow3D
 
 
 var _applying_snapshot: bool = false
-
+var _transform_override := Transform3D()
 
 static func create() -> DnaBaseRepresentation:
 	return preload("uid://cgh1pcn88ip1a").instantiate()
@@ -63,6 +63,14 @@ func _set_base(in_base: String) -> void:
 	b_strand[&"Base2"].visible = base in ["T", "C"]
 
 
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_SCENE_INSTANTIATED:
+		set_notify_local_transform(true)
+	if what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
+		if _transform_override != Transform3D() and _transform_override != transform:
+			transform = _transform_override
+
+
 func _set_base_offset(in_offset: float) -> void:
 	base_offset = in_offset
 	if _applying_snapshot == true: return
@@ -71,9 +79,10 @@ func _set_base_offset(in_offset: float) -> void:
 		var t: Transform3D = _get_curve_final_transform()
 		var remaining_offset: float = in_offset - max_progress
 		t.origin += t.basis.z * remaining_offset
-		transform = t
+		_transform_override = t
 	else:
 		progress = in_offset
+		_transform_override = Transform3D()
 
 
 func _set_dna_radius(in_radius: float) -> void:

--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -137,14 +137,11 @@ func _on_parameters_changed(in_parameters: DnaStructureParameters) -> void:
 
 
 func _on_curve_changed() -> void:
-	assert(curve.get_baked_length() > 0, "Invalid curve, dna chain should be deleted in this case")
+	assert(curve.point_count > 1, "Invalid curve, dna chain should be deleted in this case")
 	_path_representation.queue_redraw()
 	_transform_helper.progress_ratio = 1
 	for base: DnaBaseRepresentation in _bases:
-		const NEEDS_UPDATE_THRESHOLD: float = 0.9
-		if base.progress_ratio >= NEEDS_UPDATE_THRESHOLD:
-			# recalculate transform of trailing bases
-			base.set_deferred(&"base_offset", base.base_offset)
+		base.set_deferred(&"base_offset", base.base_offset)
 
 
 func notify_dna_path_being_edited(in_structure_id: int) -> void:

--- a/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
+++ b/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
@@ -66,7 +66,7 @@ func _action_delete_objects(context: StructureContext, out_already_deleted_conte
 	if out_already_deleted_contexts.has(context):
 		return
 	if _workspace_context.get_edited_dna_spline_id() != Workspace.INVALID_STRUCTURE_ID:
-		_workspace_context.stop_editing_dna_spline_no_snapshot()
+		_workspace_context.stop_editing_dna_spline()
 	var workspace: Workspace = _workspace_context.workspace
 	if !_did_create_undo_action:
 		_did_create_undo_action = true

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -415,7 +415,7 @@ func set_current_structure_context(in_structure_context: StructureContext) -> vo
 		return
 	# Activating an object cancels create mode
 	abort_creating_object()
-	stop_editing_dna_spline_no_snapshot()
+	stop_editing_dna_spline()
 	workspace.active_structure_int_guid = in_structure_context.get_int_guid()
 	_current_structure_context_id = in_structure_context.get_int_guid()
 	current_structure_context_changed.emit(in_structure_context)
@@ -594,15 +594,6 @@ func start_editing_dna_spline(in_dna_id: int) -> void:
 	get_rendering().notify_dna_path_being_edited(in_dna_id)
 	dna_spline_edit_started.emit(structure_context)
 	_emit_new_editable_structures()
-	snapshot_moment("Start Editing DNA Spline")
-
-
-func stop_editing_dna_spline_no_snapshot() -> void:
-	if _edited_dna_spline_id != Workspace.INVALID_STRUCTURE_ID:
-		_edited_dna_spline_id = Workspace.INVALID_STRUCTURE_ID
-		get_rendering().notify_dna_path_being_edited(Workspace.INVALID_STRUCTURE_ID)
-		_emit_new_editable_structures()
-		dna_spline_edit_ended.emit()
 
 
 func stop_editing_dna_spline() -> void:
@@ -611,7 +602,6 @@ func stop_editing_dna_spline() -> void:
 		get_rendering().notify_dna_path_being_edited(Workspace.INVALID_STRUCTURE_ID)
 		_emit_new_editable_structures()
 		dna_spline_edit_ended.emit()
-		snapshot_moment("Stop Editing DNA Spline")
 # # /Edited DNA Spline
 # # # # # #
 

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -454,7 +454,7 @@ static func hide_selected_objects(out_workspace_context: WorkspaceContext) -> vo
 	if structures_with_selection.is_empty():
 		return
 	
-	out_workspace_context.stop_editing_dna_spline_no_snapshot()
+	out_workspace_context.stop_editing_dna_spline()
 	for structure_context: StructureContext in structures_with_selection:
 		if structure_context.is_anchor_selected():
 			var workspace: Workspace = out_workspace_context.workspace
@@ -468,7 +468,7 @@ static func hide_selected_objects(out_workspace_context: WorkspaceContext) -> vo
 			structure_context.nano_structure.set_visible(false)
 		elif structure_context.nano_structure is DnaStructure and structure_context.is_dna_structure_fully_selected():
 			if out_workspace_context.get_edited_dna_spline_id() == structure_context.get_int_guid():
-				out_workspace_context.stop_editing_dna_spline_no_snapshot()
+				out_workspace_context.stop_editing_dna_spline()
 			structure_context.set_dna_spline_selected(false)
 			structure_context.nano_structure.set_visible(false)
 		elif structure_context.nano_structure.is_virtual_object() and structure_context.is_virtual_object_selected():


### PR DESCRIPTION
- Fixed a crash when creating a DNA chain with only 1 base
- Dna Edit Panel sometimes didn't show while editing the spline path
- UndoRedo for start/stop editing path was registering twice in the same frame
- While editing the path, bases placed after the end of the path would not be visible until releasing the mouse button

Task: Creating and Editing DNA