### PR TITLE
More fixes and improvements to DNA Structure

### DIFF
--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -16,6 +16,11 @@ enum ClipboardContentType {
 
 
 func copy(in_workspace_context: WorkspaceContext) -> void:
+	if in_workspace_context.get_edited_dna_spline_id():
+		if not in_workspace_context.get_edited_dna_spline_context().is_dna_structure_fully_selected():
+			in_workspace_context.workspace_main_view.editor_viewport_container.show_warning_in_message_bar(
+				tr(&"Cannot copy DNA spline control points"))
+			return
 	var selection_result: Array[Dictionary] = _get_selected_structure_and_atoms(in_workspace_context)
 	if selection_result.is_empty():
 		return
@@ -49,6 +54,8 @@ func copy(in_workspace_context: WorkspaceContext) -> void:
 				_copy_anchor(structure_context, nano_structure, new_content)
 			&"ParticleEmitter":
 				_copy_particle_emitter(structure_context, nano_structure, new_content)
+			&"DnaStructure":
+				_copy_dna_structure(structure_context, nano_structure, new_content)
 			_:
 				push_warning("Nano structure type not implemented for copy")
 	var root_group_id: int = -1
@@ -254,7 +261,18 @@ func _copy_particle_emitter(
 	_copy_structure(in_structure_context, in_emitter, out_content)
 
 
+func _copy_dna_structure(in_structure_context: StructureContext,
+	in_emitter: DnaStructure,
+	out_content: Array[Dictionary]) -> void:
+	_copy_structure(in_structure_context, in_emitter, out_content)
+
+
 func cut(out_workspace_context: WorkspaceContext) -> void:
+	if out_workspace_context.get_edited_dna_spline_id():
+		if not out_workspace_context.get_edited_dna_spline_context().is_dna_structure_fully_selected():
+			out_workspace_context.workspace_main_view.editor_viewport_container.show_warning_in_message_bar(
+				tr(&"Cannot cut DNA spline control points"))
+			return
 	copy(out_workspace_context)
 	if out_workspace_context.has_selection():
 		out_workspace_context.action_delete.execute()
@@ -386,6 +404,8 @@ func paste(out_workspace_context: WorkspaceContext, in_auto_bond_order: int) -> 
 				new_motor.disconnect_structure_by_id(original_id)
 				new_motor.connect_structure_by_id(new_id)
 	if did_create_undo_action:
+		if out_workspace_context.get_edited_dna_spline_id() != Workspace.INVALID_STRUCTURE_ID:
+			out_workspace_context.stop_editing_dna_spline()
 		for structure_context: StructureContext in selection_per_structure.keys():
 			structure_context.clear_selection()
 		out_workspace_context.snapshot_moment("Paste clipboard content")

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
@@ -82,6 +82,9 @@ func _on_create_button_pressed() -> void:
 	dna.end_edit()
 	var parent_context: StructureContext = _workspace_context.get_current_structure_context()
 	_workspace_context.workspace.add_structure(dna, parent_context.nano_structure)
+	_workspace_context.clear_all_selection()
+	_workspace_context.get_structure_context(dna.int_guid).set_dna_spline_selected(true)
+	WorkspaceUtils.focus_camera_on_aabb(_workspace_context, dna.get_aabb())
 	_workspace_context.snapshot_moment("Create DNA Chain")
 
 

--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -367,7 +367,7 @@ func _on_hovered_structure_context_changed(toplevel_hovered_structure_context: S
 
 
 func _on_path_representation_drawn() -> void:
-	if is_queued_for_deletion() or not _is_selectable:
+	if is_queued_for_deletion() or not _is_selectable or Engine.is_editor_hint():
 		return
 	var dna_structure: DnaStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id) as DnaStructure
 	var path: PackedVector3Array = dna_structure.get_baked_path(_temp_curve)

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -13,7 +13,8 @@ enum Strand {
 const StrandPolicy = DnaStructureParameters.StrandPolicy
 const INVALID_CONTROL_POINT_IDX: int = -1
 
-@export var _curve: Curve3D
+@export var _curve: Curve3D:
+	set = _set_curve
 @export var _twists_offset_radians: float
 @export var _sequence: String
 @export var _parameters: DnaStructureParameters
@@ -36,12 +37,18 @@ static func create(out_parameters: DnaStructureParameters, in_sequence: String =
 
 
 func _init() -> void:
+	if _parameters == null:
+		_parameters = DnaStructureParameters.new()
 	if _curve == null:
 		# Newly created object
 		_curve = Curve3D.new()
 		_curve.bake_interval = 0.02
-	if _parameters == null:
-		_parameters = DnaStructureParameters.new()
+
+
+func _set_curve(in_curve: Curve3D) -> void:
+	if _curve != null and _curve.changed.is_connected(_on_curve_changed):
+		_curve.changed.disconnect(_on_curve_changed)
+	_curve = in_curve
 	_curve.changed.connect(_on_curve_changed)
 
 

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -591,6 +591,7 @@ func start_editing_dna_spline(in_dna_id: int) -> void:
 	var structure_context: StructureContext = get_nano_structure_context_from_id(in_dna_id)
 	assert(structure_context != null)
 	_edited_dna_spline_id = in_dna_id
+	structure_context.set_dna_spline_selected(false)
 	get_rendering().notify_dna_path_being_edited(in_dna_id)
 	dna_spline_edit_started.emit(structure_context)
 	_emit_new_editable_structures()
@@ -598,9 +599,11 @@ func start_editing_dna_spline(in_dna_id: int) -> void:
 
 func stop_editing_dna_spline() -> void:
 	if _edited_dna_spline_id != Workspace.INVALID_STRUCTURE_ID:
+		var structure_context: StructureContext = get_edited_dna_spline_context()
 		_edited_dna_spline_id = Workspace.INVALID_STRUCTURE_ID
 		get_rendering().notify_dna_path_being_edited(Workspace.INVALID_STRUCTURE_ID)
 		_emit_new_editable_structures()
+		structure_context.set_dna_spline_selected(true)
 		dna_spline_edit_ended.emit()
 # # /Edited DNA Spline
 # # # # # #


### PR DESCRIPTION
- Copy/Cut/Paste is now supported
- Coping/cutting only control points is dissallowed
- When creting structure, it starts selected, and camera zooms out to show it completely
- When starting/finishing edit path, selection of the curve is updated, forcing to update the transform gizmo

Task. Creating and Editing DNA


https://github.com/user-attachments/assets/ee18e7b1-1f07-4b63-add9-ba6fe6e21c9a

