### PR TITLE
Add optional force limits to linear motors

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.gd
@@ -8,6 +8,8 @@ var _parameters_wref: WeakRef = weakref(null) # WeakRef<NanoLinearMotorParameter
 var _linear_ramp_in_time: TimeSpanPicker
 var _linear_ramp_out_time: TimeSpanPicker
 var _linear_top_speed_spin_box: SpinBoxSlider
+var _limit_force_check_button: CheckButton
+var _linear_max_force_spin_box: SpinBoxSlider
 var _linear_forward_polarity_button: Button
 var _linear_backward_polarity_button: Button
 
@@ -25,12 +27,16 @@ func _notification(what: int) -> void:
 		_linear_ramp_in_time = %LinearRampInTime as TimeSpanPicker
 		_linear_ramp_out_time = %LinearRampOutTime as TimeSpanPicker
 		_linear_top_speed_spin_box = %LinearTopSpeedSpinBox as SpinBoxSlider
+		_limit_force_check_button = %LimitForceCheckButton as CheckButton
+		_linear_max_force_spin_box = %LinearMaxForceSpinBox as SpinBoxSlider
 		_linear_forward_polarity_button = %LinearForwardPolarityButton as Button
 		_linear_backward_polarity_button = %LinearBackwardPolarityButton as Button
 		# Linear controls signals
 		_linear_ramp_in_time.time_span_changed.connect(_on_linear_ramp_in_time_time_span_changed)
 		_linear_ramp_out_time.time_span_changed.connect(_on_linear_ramp_out_time_time_span_changed)
 		_linear_top_speed_spin_box.value_confirmed.connect(_on_linear_top_speed_spin_box_value_confirmed)
+		_limit_force_check_button.toggled.connect(_on_limit_force_check_button_toggled)
+		_linear_max_force_spin_box.value_confirmed.connect(_on_linear_max_force_spin_box_value_confirmed)
 		_linear_forward_polarity_button.toggled.connect(_on_linear_forward_polarity_button_toggled)
 		_linear_backward_polarity_button.toggled.connect(_on_linear_backward_polarity_button_toggled)
 
@@ -76,8 +82,11 @@ func _on_linear_motor_parameters_changed() -> void:
 	_linear_ramp_out_time.editable = parameters.cycle_type != NanoVirtualMotorParameters.CycleType.CONTINUOUS
 	var top_speed_in_femtoseconds: float = parameters.top_speed_in_nanometers_by_nanoseconds / 1e+6
 	_linear_top_speed_spin_box.set_value_no_signal(top_speed_in_femtoseconds)
+	_linear_max_force_spin_box.set_value_no_signal(parameters.max_force)
 	_linear_forward_polarity_button.set_pressed_no_signal(parameters.polarity == NanoLinearMotorParameters.Polarity.FORWARD)
 	_linear_backward_polarity_button.set_pressed_no_signal(parameters.polarity == NanoLinearMotorParameters.Polarity.BACKWARDS)
+	_limit_force_check_button.set_pressed_no_signal(parameters.limit_maximum_force)
+	_linear_max_force_spin_box.visible = parameters.limit_maximum_force
 
 
 func _on_linear_ramp_in_time_time_span_changed(in_magnitude: float, in_unit: TimeSpanPicker.Unit) -> void:
@@ -88,6 +97,7 @@ func _on_linear_ramp_in_time_time_span_changed(in_magnitude: float, in_unit: Tim
 	_get_linear_parameters().ramp_in_time_in_nanoseconds = in_magnitude
 	_take_snapshot_if_configured(tr(&"Ramp-In Time"))
 
+
 func _on_linear_ramp_out_time_time_span_changed(in_magnitude: float, in_unit: TimeSpanPicker.Unit) -> void:
 	if in_unit != TimeSpanPicker.Unit.NANOSECOND:
 		# Convert magnitude to nanoseconds
@@ -96,15 +106,29 @@ func _on_linear_ramp_out_time_time_span_changed(in_magnitude: float, in_unit: Ti
 	_get_linear_parameters().ramp_out_time_in_nanoseconds = in_magnitude
 	_take_snapshot_if_configured(tr(&"Ramp-Out Time"))
 
+
 func _on_linear_top_speed_spin_box_value_confirmed(in_top_speed_in_femtoseconds: float) -> void:
 	var top_speed_in_nanoseconds: float = in_top_speed_in_femtoseconds * 1e+6
 	_get_linear_parameters().top_speed_in_nanometers_by_nanoseconds = top_speed_in_nanoseconds
 	_take_snapshot_if_configured(tr(&"Top Speed"))
 
+
+func _on_limit_force_check_button_toggled(in_toggled: bool) -> void:
+	_get_linear_parameters().limit_maximum_force = in_toggled
+	_take_snapshot_if_configured(tr(&"Limit Maximum Force"))
+	_linear_max_force_spin_box.visible = in_toggled
+
+
+func _on_linear_max_force_spin_box_value_confirmed(in_max_force: float) -> void:
+	_get_linear_parameters().max_force = in_max_force
+	_take_snapshot_if_configured(tr(&"Maximum Force"))
+
+
 func _on_linear_forward_polarity_button_toggled(in_button_pressed: bool) -> void:
 	if in_button_pressed:
 		_get_linear_parameters().polarity = NanoLinearMotorParameters.Polarity.FORWARD
 		_take_snapshot_if_configured(tr(&"Use Forward Polarity"))
+
 
 func _on_linear_backward_polarity_button_toggled(in_button_pressed: bool) -> void:
 	if in_button_pressed:

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.tscn
@@ -69,6 +69,29 @@ allow_greater = true
 suffix = "nm / fs"
 custom_arrow_step = 0.001
 
+[node name="LimitForceLabel" type="Label" parent="."]
+custom_minimum_size = Vector2(0, 38)
+layout_mode = 2
+size_flags_horizontal = 3
+text = " ・ Limit Max Force"
+vertical_alignment = 1
+
+[node name="LimitForceHBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="LimitForceCheckButton" type="CheckButton" parent="LimitForceHBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="LinearMaxForceSpinBox" parent="LimitForceHBoxContainer" instance=ExtResource("2_crlk1")]
+unique_name_in_owner = true
+layout_mode = 2
+step = 0.001
+value = 5.0
+allow_greater = true
+suffix = "aN"
+custom_arrow_step = 0.001
+
 [node name="Label5" type="Label" parent="."]
 custom_minimum_size = Vector2(0, 38)
 layout_mode = 2

--- a/godot_project/project_workspace/structs/nano_linear_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_linear_motor_parameters.gd
@@ -9,7 +9,8 @@ enum Polarity {
 	set = _set_top_speed_in_nanometers_by_nanoseconds
 @export var polarity: Polarity = Polarity.FORWARD:
 	set = _set_polarity
-
+@export var max_force: float = 1.0 * 1e6:
+	set = _set_max_force
 
 var _state_snapshot_dirty: bool = true
 var _state_snapshot: Dictionary = {}
@@ -61,6 +62,12 @@ func _set_polarity(in_polarity: Polarity) -> void:
 	emit_changed()
 
 
+func _set_max_force(in_max_force: float) -> void:
+	if max_force == in_max_force:
+		return
+	max_force = in_max_force
+	emit_changed()
+
 
 func create_state_snapshot() -> Dictionary:
 	if _state_snapshot_dirty:
@@ -76,12 +83,14 @@ func create_state_snapshot() -> Dictionary:
 			"cycle_swap_polarity" = cycle_swap_polarity,
 			"cycle_eventually_stops" = cycle_eventually_stops,
 			"cycle_stop_after_n_cycles" = cycle_stop_after_n_cycles,
-			# Rotary specific properties
+			# Linear specific properties
 			"top_speed_in_nanometers_by_nanoseconds" = top_speed_in_nanometers_by_nanoseconds,
 			"polarity" = polarity,
+			"max_force" = max_force,
 		}
 		_state_snapshot_dirty = false
 	return _state_snapshot.duplicate(true)
+
 
 func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	# prevent `changed` and any other signal from being emited while state snapshot is being applied
@@ -102,4 +111,5 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	# Rotary specific properties
 	top_speed_in_nanometers_by_nanoseconds = in_snapshot.top_speed_in_nanometers_by_nanoseconds
 	polarity = in_snapshot.polarity
+	max_force = in_snapshot.max_force
 	set_block_signals(was_blocking_signals)

--- a/godot_project/project_workspace/structs/nano_virtual_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_virtual_motor_parameters.gd
@@ -47,6 +47,8 @@ var motor_type: Type = Type.UNKNOWN:
 @export var cycle_stop_after_n_cycles: int = 1:
 	set = _set_cycle_stop_after_n_cycles
 
+@export var limit_maximum_force: bool = false
+
 
 func get_tooltip_text() -> String:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
@@ -129,4 +131,3 @@ func create_state_snapshot() -> Dictionary:
 func apply_state_snapshot(_in_snapshot: Dictionary) -> void:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
 	return
-

--- a/godot_project/python/scripts/openmm_server.py
+++ b/godot_project/python/scripts/openmm_server.py
@@ -409,6 +409,7 @@ class MotorForce:
 		self.motor_type: MotorType = motor_force_data["parameters"]["motor_type"]
 		
 		self.ramp_in_time_in_nanoseconds: float = motor_force_data["parameters"]["ramp_in_time_in_nanoseconds"]
+		self.limit_maximum_force: bool = motor_force_data["parameters"]["limit_maximum_force"]
 		match self.motor_type:
 			case MotorType.ROTARY:
 				rotary_polarity: RotaryPolarity = motor_force_data["parameters"]["polarity"]
@@ -425,6 +426,7 @@ class MotorForce:
 				linear_polarity: LinearPolarity = motor_force_data["parameters"]["polarity"]
 				self.polarity: float = 1.0 if linear_polarity == LinearPolarity.FORWARD else -1.0
 				self.top_speed_in_nanometers_by_nanoseconds = motor_force_data["parameters"]["top_speed_in_nanometers_by_nanoseconds"]
+				self.max_force = motor_force_data["parameters"]["max_force"] * 1e-18 # Convert attoNewtons to Newtons
 			case _:
 				logging.error(f"Unknown motor type '{self.motor_type}'!")
 				pass
@@ -537,7 +539,8 @@ class MotorForce:
 		self.cycle_started_to_stop_at_time: float = 0
 		self.cycle_pause_time_accum: float = 0.0
 		self.cycle_paused: bool = False
-		self.print_counter: int = 0
+		self.print_counter: int = -1
+		self.max_acceleration: float = -1.0
 		added_particles = 0
 		is_rotary: bool = self.motor_type == MotorType.ROTARY
 		for i in range(topology_payload.atoms_count):
@@ -646,6 +649,17 @@ class MotorForce:
 			# Nothing to do here
 			return
 		
+		if self.limit_maximum_force and self.max_acceleration < 0:
+			average_particle_mass: float = 0.0
+			for i in range(len(self.atom_ids)):
+				atom_id: int = self.atom_ids[i]
+				average_particle_mass += simulation.system.getParticleMass(atom_id)._value
+			average_particle_mass /= len(self.atom_ids)
+			average_particle_mass *= 1.66053907e-27 # Convert Daltons to Kilograms
+			self.max_acceleration = self.max_force / average_particle_mass
+			if MOTOR_DEBUG_PRINTS:
+				logging.info(f"Max force: {self.max_force}N, Max acceleration: {self.max_acceleration}m/s^2")
+		
 		self.time_accum += simulation.time_step_in_nanoseconds
 		new_motor_velocity: Vec3 = Vec3(0,0,0) # new motor velocity is the same for all particles linked to the motor
 		speed: float = self._calculate_speed(simulation.time_step_in_nanoseconds)
@@ -662,9 +676,19 @@ class MotorForce:
 		new_velocities = prev_velocities.copy()
 		for i in range(len(self.atom_ids)):
 			atom_id: int = self.atom_ids[i]
-			current_velocity_in_desired_direction = self.axis_direction * dot_Vec3(prev_velocities[atom_id], self.axis_direction) * prev_velocities[atom_id].unit
-			delta_velocity = new_motor_velocity - current_velocity_in_desired_direction
-			new_velocities[atom_id] = prev_velocities[atom_id] + delta_velocity
+			previous_velocity: Vec3 = prev_velocities[atom_id]
+			final_velocity: Vec3 = new_motor_velocity
+			current_velocity_in_desired_direction = self.axis_direction * dot_Vec3(previous_velocity, self.axis_direction) * previous_velocity.unit
+			delta_velocity = final_velocity - current_velocity_in_desired_direction
+			
+			if self.limit_maximum_force:
+				acceleration: Vec3 = delta_velocity / (simulation.time_step_in_nanoseconds * nanosecond)
+				acceleration_len: float = length_Vec3(acceleration)
+				if acceleration_len > 0.0:
+					ratio: float = max(0, min(1, self.max_acceleration / acceleration_len))
+					delta_velocity *= ratio
+			
+			new_velocities[atom_id] = previous_velocity + delta_velocity
 		simulation.context.setVelocities(new_velocities)
 		return
 


### PR DESCRIPTION
Card: Research how we might implement "force-based" motors.

---

[force_based_motors.webm](https://github.com/user-attachments/assets/c68b8999-2444-49bf-adcd-ec28663b83fe)

This only applies to Linear motors for now.

This works by extracting the force applied to the molecule to make it satisfy the motor constraint.

We have the previous velocity, and the new velocity imposed by the motor, using `Acceleration = Delta V / Time`, we compare the particle acceleration to the maximal theoretical acceleration (calculated from the user provided `max force`) and limit the new change in velocity if necessary.

~~Note: The UI mentions the force is in nanoNewtons, but that's not exactly true, it's in (Da . nm) / ns², and I'm not sure how to get a proper conversion to nN from there, if it even makes sense to begin with.~~

UI is now in attoNewtons (even 1fN is already too much in my test scene and working with small decimal numbers is not great from a UX perspective) 
