### PR TITLE
DNA Structures can now temporary convert to atoms and bonds for small editions and simulations, however it's contents cannot be modified

### DIFF
--- a/godot_project/autoloads/class_utils/class_utils.gd
+++ b/godot_project/autoloads/class_utils/class_utils.gd
@@ -162,7 +162,12 @@ func _do_check(in_class_to_check: ClassDescription) -> void:
 	var all_implemented_functions: Dictionary = _find_all_implemented_functions(in_class_to_check)
 	for function_desc: FunctionDescription in functions_which_needs_to_be_implemented:
 		var is_implemented: bool = all_implemented_functions.has(function_desc.function_name)
-		assert(is_implemented, "Class " + in_class_to_check.name_of_class + " needs to implement abstract function: " + function_desc.function_name)
+		# Assert is done in a separate callback to not interrupt the for loop in case it happens
+		_do_assert(is_implemented, "Class " + in_class_to_check.name_of_class + " needs to implement abstract function: " + function_desc.function_name)
+
+func _do_assert(condition: bool, message: String) -> void:
+	assert(condition, message)
+	pass
 
 
 func _find_ancestor_abstract_functions(in_class: ClassDescription) -> Array[FunctionDescription]:

--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -404,8 +404,6 @@ func paste(out_workspace_context: WorkspaceContext, in_auto_bond_order: int) -> 
 				new_motor.disconnect_structure_by_id(original_id)
 				new_motor.connect_structure_by_id(new_id)
 	if did_create_undo_action:
-		if out_workspace_context.get_edited_dna_spline_id() != Workspace.INVALID_STRUCTURE_ID:
-			out_workspace_context.stop_editing_dna_spline()
 		for structure_context: StructureContext in selection_per_structure.keys():
 			structure_context.clear_selection()
 		out_workspace_context.snapshot_moment("Paste clipboard content")

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
@@ -49,8 +49,6 @@ func _on_feature_flag_toggled() -> void:
 
 
 func _on_create_button_pressed() -> void:
-	if _workspace_context.get_edited_dna_spline_id() != Workspace.INVALID_STRUCTURE_ID:
-		_workspace_context.stop_editing_dna_spline()
 	var params := DnaStructureParameters.new()
 	params.dna_radius_nanometers = _dna_radius_spin_box_slider.value
 	params.bases_per_turn = _bases_per_turn_spin_box_slider.value
@@ -70,7 +68,7 @@ func _on_create_button_pressed() -> void:
 	if OS.is_debug_build() and DnaBuilder.is_dev_tool_enabled():
 		DnaBuilder.DNA_BASES_OFFSET = %OffsetSpinBoxSlider.value
 
-	var dna: DnaStructure = DnaStructure.create(params, _dna_sequence_text_edit.text)
+	var dna: DnaStructure = DnaStructure.create_dna(params, _dna_sequence_text_edit.text)
 	dna.set_structure_name("DNA Chain%d" % _workspace_context.workspace.get_nmb_of_structures())
 	var dna_pos: Vector3 = InputHandlerCreateObjectBase.calculate_preview_position(_workspace_context)
 	var right_dir: Vector3 = _workspace_context.get_editor_viewport().get_camera_3d().global_transform.basis.x

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_docker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_docker.gd
@@ -136,28 +136,11 @@ func _ensure_workspace_initialized(in_workspace_context: WorkspaceContext) -> vo
 	assert(create_object_parameters != null, "Workspace Context should always have CreateObjectParameters component")
 	if !create_object_parameters.create_mode_type_changed.is_connected(_on_create_object_parameters_create_mode_changed):
 		create_object_parameters.create_mode_type_changed.connect(_on_create_object_parameters_create_mode_changed)
-		create_object_parameters.create_mode_enabled_changed.connect(_on_create_object_parameters_create_mode_enabled_changed)
 
 
 func _on_create_object_parameters_create_mode_changed(_in_create_mode: int) -> void:
 	# Update controls visibility
 	_update_visibility(should_show(_workspace_context))
-	_stop_edit_dna_spline_if_necesary()
-
-
-func _on_create_object_parameters_create_mode_enabled_changed(_in_enabled: bool) -> void:
-	_stop_edit_dna_spline_if_necesary()
-
-
-func _stop_edit_dna_spline_if_necesary() -> void:
-	var is_editing_dna_spline: bool = _workspace_context.get_edited_dna_spline_id() != Workspace.INVALID_STRUCTURE_ID
-	if not is_editing_dna_spline:
-		return
-	if (_workspace_context.create_object_parameters.get_create_mode_enabled()
-			and _workspace_context.create_object_parameters.get_create_mode_type()
-			!= CreateObjectParameters.CreateModeType.CREATE_DNA_CHAIN):
-		_workspace_context.stop_editing_dna_spline()
-		_workspace_context.snapshot_moment("Stop Editing DNA Spline")
 
 
 func add_control_to_category(in_category_id: StringName, in_control: DynamicContextControl) -> bool:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/3d_preview.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/3d_preview.gd
@@ -25,8 +25,9 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 		# Check what is selected, return as soon as possible
 		if context.nano_structure.is_virtual_object() and context.is_virtual_object_selected():
 			return true
-		if context.nano_structure is DnaStructure and context.dna_structure_has_selection():
-			return true
+		if context.nano_structure is DnaStructure:
+			if context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath and context.dna_structure_has_selection():
+				return true
 		if context.get_selected_bonds().size():
 			return true
 		selected_atoms_count += context.get_selected_atoms().size()

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
@@ -6,9 +6,12 @@ const StrandPolicy = DnaStructure.StrandPolicy
 
 var _select_one_info_label: InfoLabel
 var _main_container: Container
-var _start_stop_editing_button: Button
+var _edit_path_button: Button
+var _edit_atoms_button: Button
 var _override_colors_check_button: CheckButton
 var _create_atoms_button: Button
+var _setup_animation_player: AnimationPlayer
+
 
 var _workspace_context: WorkspaceContext
 var _tracked_structure: DnaStructure = null
@@ -20,16 +23,18 @@ func _notification(what: int) -> void:
 		_initialized = true
 		_select_one_info_label = %SelectOneInfoLabel as InfoLabel
 		_main_container = $VBoxContainer as Container
-		_start_stop_editing_button = %StartStopEditingButton as Button
+		_edit_path_button = %EditPathButton as Button
+		_edit_atoms_button = %EditAtomsButton as Button
 		_override_colors_check_button = %OverrideColorsCheckButton as CheckButton
 		_create_atoms_button = %CreateAtomsButton as Button
+		_setup_animation_player = %SetupAnimationPlayer as AnimationPlayer
+		_edit_path_button.button_group.pressed.connect(_on_edit_mode_button_group_pressed)
 		_dna_sequence_text_edit.text_changed.connect(_on_dna_sequence_text_edit_text_changed)
 		_dna_radius_spin_box_slider.value_confirmed.connect(_on_dna_radius_spin_box_slider_value_confirmed)
 		_bases_per_turn_spin_box_slider.value_confirmed.connect(_on_bases_per_turn_spin_box_slider_value_confirmed)
 		_rise_nanometers_spin_box_slider.value_confirmed.connect(_on_rise_nanometers_spin_box_slider_value_confirmed)
 		_strand_a_button.button_group.pressed.connect(_on_strand_policy_button_group_button_pressed)
 		_include_hydrogens_check_button.toggled.connect(_on_include_hydrogens_check_button_toggled)
-		_start_stop_editing_button.pressed.connect(_on_start_stop_editing_button_pressed)
 		_create_atoms_button.pressed.connect(_on_create_atoms_button_pressed)
 
 
@@ -42,7 +47,6 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	if edited_spline_context != null:
 		selected_count = 1
 		structure = edited_spline_context.nano_structure as DnaStructure
-		_start_stop_editing_button.text = tr(&"Stop Editing Path")
 	else:
 		for structure_context: StructureContext in _workspace_context.get_structure_contexts_with_selection():
 			if not structure_context.nano_structure is DnaStructure:
@@ -67,12 +71,6 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 
 func _ensure_workspace_initialized(in_workspace_context: WorkspaceContext) -> void:
 	_workspace_context = in_workspace_context
-	if not _workspace_context.dna_spline_edit_started.is_connected(_on_dna_spline_edition_started):
-		_workspace_context.dna_spline_edit_started.connect(_on_dna_spline_edition_started)
-		_workspace_context.dna_spline_edit_ended.connect(_on_dna_spline_edition_ended)
-		# Assume not active edition during initialization
-		assert(_workspace_context.get_edited_dna_spline_id() == Workspace.INVALID_STRUCTURE_ID)
-		_on_dna_spline_edition_ended()
 
 
 func _set_tracked_structure(in_structure_or_null: DnaStructure) -> void:
@@ -83,6 +81,16 @@ func _set_tracked_structure(in_structure_or_null: DnaStructure) -> void:
 	_tracked_structure = in_structure_or_null
 	if in_structure_or_null != null:
 		_tracked_structure.sequence_changed.connect(_on_tracked_structure_sequence_changed)
+		
+		match _tracked_structure.get_edit_mode():
+			DnaStructure.EditMode.SequenceAndPath:
+				_setup_animation_player.play(&"setup_edit_path")
+				_edit_path_button.set_pressed_no_signal(true)
+				_edit_atoms_button.set_pressed_no_signal(false)
+			DnaStructure.EditMode.AtomsAndBonds:
+				_setup_animation_player.play(&"setup_edit_atoms")
+				_edit_path_button.set_pressed_no_signal(false)
+				_edit_atoms_button.set_pressed_no_signal(true)
 		_dna_sequence_text_edit.set_block_signals(true)
 		_dna_sequence_text_edit.text = _tracked_structure.get_sequence()
 		_dna_sequence_text_edit.set_block_signals(false)
@@ -100,6 +108,33 @@ func _on_tracked_structure_sequence_changed(in_sequence: String) -> void:
 		_dna_sequence_text_edit.set_block_signals(true)
 		_dna_sequence_text_edit.text = in_sequence
 		_dna_sequence_text_edit.set_block_signals(false)
+
+
+func _on_edit_mode_button_group_pressed(in_button: Button) -> void:
+	var mode_map: Dictionary[Button, DnaStructure.EditMode] = {
+		_edit_path_button: DnaStructure.EditMode.SequenceAndPath,
+		_edit_atoms_button: DnaStructure.EditMode.AtomsAndBonds,
+	}
+	var mode: DnaStructure.EditMode = mode_map[in_button]
+	if mode == _tracked_structure.get_edit_mode():
+		# Re-selected the already selected mode, nothing to do here
+		return
+	match mode:
+		DnaStructure.EditMode.SequenceAndPath:
+			var promise: Promise = _workspace_context.show_warning_dialog(
+				tr("Any modification in position of the atoms will be discarded with this operation.\n"+
+				"Do you want to proceed?"), tr("Continue"), tr("Cancel"))
+			await promise.wait_for_fulfill()
+			if promise.get_result() == false:
+				return
+			_workspace_context.get_structure_context(_tracked_structure.get_int_guid()).set_dna_spline_selected(false)
+			_tracked_structure.set_edit_mode(DnaStructure.EditMode.SequenceAndPath)
+			_setup_animation_player.play(&"setup_edit_path")
+			_workspace_context.snapshot_moment("DNA Structure: edit Path and Sequence")
+		DnaStructure.EditMode.AtomsAndBonds:
+			_tracked_structure.set_edit_mode(DnaStructure.EditMode.AtomsAndBonds)
+			_setup_animation_player.play(&"setup_edit_atoms")
+			_workspace_context.snapshot_moment("DNA Structure: show Atoms and Bonds")
 
 
 func _on_dna_sequence_text_edit_text_changed() -> void:
@@ -168,17 +203,6 @@ func _on_include_hydrogens_check_button_toggled(in_button_pressed: bool) -> void
 	_workspace_context.snapshot_moment("Set Dna Chain includes hydrogens")
 
 
-func _on_start_stop_editing_button_pressed() -> void:
-	assert(_tracked_structure != null, "Invalid ui state")
-	if _workspace_context.get_edited_dna_spline_context() == null:
-		_workspace_context.start_editing_dna_spline(_tracked_structure.get_int_guid())
-		_workspace_context.snapshot_moment("Start Editing DNA Spline")
-	else:
-		assert(_workspace_context.get_edited_dna_spline_id() == _tracked_structure.int_guid)
-		_workspace_context.stop_editing_dna_spline()
-		_workspace_context.snapshot_moment("Stop Editing DNA Spline")
-
-
 func _on_create_atoms_button_pressed() -> void:
 	assert(_tracked_structure != null, "Invalid ui state")
 	var sequence: String = _tracked_structure.get_sequence()
@@ -235,13 +259,4 @@ func _on_create_atoms_button_pressed() -> void:
 			new_group.set_color_override(atom_map.values(), STRAND_COLOR[strand])
 		new_group.end_edit()
 	_workspace_context.snapshot_moment("Create group from DNA Chain")
-
-
-func _on_dna_spline_edition_started(dna_context: StructureContext) -> void:
-	assert(_tracked_structure == dna_context.nano_structure)
-	_start_stop_editing_button.text = tr(&"Stop Editing Path")
-
-
-func _on_dna_spline_edition_ended() -> void:
-	_start_stop_editing_button.text = tr(&"Start Editing Path")
 

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
@@ -1,10 +1,208 @@
-[gd_scene load_steps=5 format=3 uid="uid://6h5ogu2meano"]
+[gd_scene load_steps=10 format=3 uid="uid://6h5ogu2meano"]
 
 [ext_resource type="PackedScene" uid="uid://bdeg2b7ycyi66" path="res://editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn" id="1_mfh7i"]
 [ext_resource type="Script" uid="uid://cdcgvv0jwwf6c" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd" id="2_q7pc7"]
 [ext_resource type="PackedScene" uid="uid://b2b25o2443x3b" path="res://editor/controls/general/info_label.tscn" id="3_673q0"]
 
+[sub_resource type="ButtonGroup" id="ButtonGroup_673q0"]
+
 [sub_resource type="ButtonGroup" id="ButtonGroup_q7pc7"]
+
+[sub_resource type="Animation" id="Animation_gmhsj"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("VBoxContainer/Label:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("VBoxContainer/DnaSequenceTextEdit:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("VBoxContainer/Label2:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("VBoxContainer/PanelContainer:visible")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("VBoxContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+
+[sub_resource type="Animation" id="Animation_y5hmy"]
+resource_name = "setup_edit_atoms"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("VBoxContainer/Label:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("VBoxContainer/DnaSequenceTextEdit:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("VBoxContainer/Label2:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("VBoxContainer/PanelContainer:visible")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("VBoxContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+
+[sub_resource type="Animation" id="Animation_673q0"]
+resource_name = "setup_edit_path"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("VBoxContainer/Label:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("VBoxContainer/DnaSequenceTextEdit:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("VBoxContainer/Label2:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("VBoxContainer/PanelContainer:visible")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("VBoxContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_y5hmy"]
+_data = {
+&"RESET": SubResource("Animation_gmhsj"),
+&"setup_edit_atoms": SubResource("Animation_y5hmy"),
+&"setup_edit_path": SubResource("Animation_673q0")
+}
 
 [node name="EditDnaPanel" instance=ExtResource("1_mfh7i")]
 script = ExtResource("2_q7pc7")
@@ -18,6 +216,49 @@ text = "[center][wave start=4 length=14 freq=0.5 sat=0.8 val=0.8 connected=1]ℹ
 message = &"Select only one DNA Chain at a time to edit it"
 effect = "wave"
 
+[node name="Label4" type="Label" parent="VBoxContainer" index="0"]
+layout_mode = 2
+text = "Edition Mode"
+
+[node name="PanelContainer3" type="PanelContainer" parent="VBoxContainer" index="1"]
+layout_mode = 2
+theme_type_variation = &"SubcategoryPanel"
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/PanelContainer3" index="0"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PanelContainer3/VBoxContainer" index="0"]
+layout_mode = 2
+theme_override_constants/separation = 0
+
+[node name="EditPathButton" type="Button" parent="VBoxContainer/PanelContainer3/VBoxContainer/HBoxContainer" index="0"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"StructureSelectorButton"
+toggle_mode = true
+button_pressed = true
+button_group = SubResource("ButtonGroup_673q0")
+text = "Path And Sequence"
+
+[node name="EditAtomsButton" type="Button" parent="VBoxContainer/PanelContainer3/VBoxContainer/HBoxContainer" index="1"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"StructureSelectorMoreButton"
+toggle_mode = true
+button_group = SubResource("ButtonGroup_673q0")
+text = "Edit Atoms and Bonds"
+
+[node name="EditModeInfoLabel" parent="VBoxContainer/PanelContainer3/VBoxContainer" index="1" instance=ExtResource("3_673q0")]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+size_flags_vertical = 4
+text = "[center]ℹ In this mode, atoms can be selected, moved, relaxed, etc, but cannot be deleted or modified. New atoms and bonds cannot b added[/center]"
+message = &"In this mode, atoms can be selected, moved, relaxed, etc, but cannot be deleted or modified. New atoms and bonds cannot b added"
+effect = "none"
+
 [node name="StrandAButton" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer/HBoxContainer" index="0"]
 button_group = SubResource("ButtonGroup_q7pc7")
 
@@ -27,19 +268,11 @@ button_group = SubResource("ButtonGroup_q7pc7")
 [node name="StrandDoubleButton" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer/HBoxContainer" index="2"]
 button_group = SubResource("ButtonGroup_q7pc7")
 
-[node name="StartStopEditingButton" type="Button" parent="VBoxContainer" index="4"]
-unique_name_in_owner = true
+[node name="Label3" type="Label" parent="VBoxContainer" index="6"]
 layout_mode = 2
-size_flags_horizontal = 4
-tooltip_text = "While editing path you can change the shape of the DNA chain, double click or Ctrl+Click adds control points, selecting points and press Delete to remove a point."
-theme_type_variation = &"CrystalButton"
-text = "Start Editing Path"
+text = "Convert to Group"
 
-[node name="Label3" type="Label" parent="VBoxContainer" index="5"]
-layout_mode = 2
-text = "Convert to Atoms"
-
-[node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer" index="6"]
+[node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer" index="7"]
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
 
@@ -63,3 +296,9 @@ size_flags_vertical = 4
 theme_type_variation = &"CrystalButton"
 text = "Create Atoms from template
 "
+
+[node name="SetupAnimationPlayer" type="AnimationPlayer" parent="." index="2"]
+unique_name_in_owner = true
+libraries = {
+&"": SubResource("AnimationLibrary_y5hmy")
+}

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
@@ -68,6 +68,9 @@ func _update_selected_info() -> void:
 			total_atoms_selected += context.get_selected_atoms().size()
 			total_bonds_selected += context.get_selected_bonds().size()
 			total_springs_selected += context.get_selected_springs().size()
+			if context.nano_structure is DnaStructure:
+				# TODO: Show DNA structure properties
+				pass
 		elif context.nano_structure is NanoShape:
 			total_shapes_selected += 1
 		elif context.nano_structure is NanoVirtualMotor:
@@ -76,8 +79,6 @@ func _update_selected_info() -> void:
 			total_emitters_selected += 1
 		elif context.nano_structure is NanoVirtualAnchor:
 			total_anchors_selected += 1
-		elif context.nano_structure is DnaStructure:
-			pass
 		else:
 			assert(false, "Untracked nano structure type: %s" % context.nano_structure.get_type())
 			pass

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker.gd
@@ -67,6 +67,6 @@ func _on_nano_structure_picker_popup_panel_nano_structure_clicked(in_structure_i
 
 func _on_current_structure_context_changed(structure_context: StructureContext) -> void:
 	var nano_structure: NanoStructure = structure_context.nano_structure
-	if not is_instance_valid(nano_structure) or nano_structure is NanoShape:
+	if not is_instance_valid(nano_structure) or not nano_structure.can_contain_child_structure():
 		return
 	selected_id = nano_structure.int_guid

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker_popup_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker_popup_panel.gd
@@ -70,7 +70,7 @@ func initialize(in_workspace_context: WorkspaceContext) -> void:
 
 
 func _can_contain_children(in_structure: NanoStructure) -> bool:
-	return not in_structure.is_virtual_object() and not in_structure is DnaStructure
+	return in_structure.can_contain_child_structure()
 
 
 func get_selected_structure_name() -> String:

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
@@ -89,7 +89,7 @@ func _on_structures_tree_can_drop_data(at_position: Vector2, data: Variant) -> b
 			null if parent_candidate_structure_id == 0 else \
 			workspace.get_structure_by_int_guid(parent_candidate_structure_id)
 	var dragged_structure: NanoStructure = workspace.get_structure_by_int_guid(dragged_structure_id)
-	return not workspace.is_a_ancestor_of_b(dragged_structure, parent_candidate)
+	return not workspace.is_a_ancestor_of_b(dragged_structure, parent_candidate) and parent_candidate.can_contain_child_structure()
 
 
 func _on_structures_tree_drop_data(at_position: Vector2, data: Variant) -> void:
@@ -416,7 +416,7 @@ func _update_structure_selection(in_groups_to_update: PackedInt32Array) -> void:
 ## NanoShape and Motors, etc can't be displayed here but shapes also extends NanoMolecularStructure
 ## so we have to be explicit on the check here.
 func _can_appear_in_tree(nano_structure: NanoStructure) -> bool:
-	return not nano_structure.is_virtual_object() and not nano_structure is DnaStructure
+	return nano_structure.can_contain_child_structure() or nano_structure is DnaStructure
 
 
 func _get_structure_tree_item_or_null(in_structure_id: int) -> TreeItem:

--- a/godot_project/editor/controls/workspace_view/WorkspaceToolsContainer.gd
+++ b/godot_project/editor/controls/workspace_view/WorkspaceToolsContainer.gd
@@ -33,7 +33,7 @@ func _on_hovered_structure_context_changed(
 			_show_hovered_spring_tooltip(in_hovered_structure_context, in_spring_id)
 		else:
 			tooltip_text = ""
-	elif in_hovered_structure_context.nano_structure is DnaStructure:
+	elif in_hovered_structure_context.nano_structure is DnaStructure and in_hovered_structure_context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 		if in_dna_control_point_idx == DnaStructure.INVALID_CONTROL_POINT_IDX:
 			tooltip_text = _get_path_to_context(in_hovered_structure_context).rstrip("\n")
 			tooltip_text += " (%s)" % in_hovered_structure_context.nano_structure.get_tooltip_text()

--- a/godot_project/editor/controls/workspace_view/box_selection/box_selection.gd
+++ b/godot_project/editor/controls/workspace_view/box_selection/box_selection.gd
@@ -81,7 +81,7 @@ func apply_selection() -> void:
 				var selected_bonds: PackedInt32Array = context.select_atoms_and_get_auto_selected_bonds(selected_atoms)
 				context.select_bonds(selected_bonds)
 				context.select_springs(selected_springs)
-		if context.nano_structure is DnaStructure:
+		if context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 			if _workspace_context.get_edited_dna_spline_context() == context:
 				var control_points_in_box: PackedInt32Array = _get_dna_control_points_within_screen_rect(context, camera)
 				context.set_dna_control_point_selection(control_points_in_box)

--- a/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_button/structure_selector_button.gd
+++ b/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_button/structure_selector_button.gd
@@ -81,7 +81,7 @@ func _has_children_not_in_path(in_nano_structure: NanoStructure) -> bool:
 
 func _is_not_in_path_to_active_structure(in_nano_structure: NanoStructure) -> bool:
 	# Shapes, Motors, and DNAStructures are intentionally hidden of the list
-	var is_valid_group: bool = not in_nano_structure.is_virtual_object() and not in_nano_structure is DnaStructure
+	var is_valid_group: bool = not in_nano_structure.is_virtual_object()
 	if not is_valid_group:
 		return false
 	var path: Array[NanoStructure] = _get_path_to_current_structure()

--- a/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_child_list/structure_child_list.gd
+++ b/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_child_list/structure_child_list.gd
@@ -130,7 +130,7 @@ func _get_child_structures() -> Array[NanoStructure]:
 		children_structures = _workspace_context.workspace.get_child_structures(
 				_parent_structure_context.nano_structure)
 	var is_valid_group: Callable = func(in_nano_structure: NanoStructure) -> bool:
-		return not in_nano_structure.is_virtual_object() and not in_nano_structure is DnaStructure
+		return not in_nano_structure.is_virtual_object()
 	return children_structures.filter(is_valid_group)
 
 

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -320,36 +320,37 @@ func _activate_selection_logic(
 			if affected_context.nano_structure.is_virtual_object():
 				# Shapes, Motors, Emitters, Springs, etc; cannot be activated, this is on purpose to have a more compact group hierarchy
 				return false
-			elif affected_context.nano_structure is DnaStructure:
-				var dna_structure: DnaStructure = affected_context.nano_structure as DnaStructure
-				if get_workspace_context().get_edited_dna_spline_id() == affected_context.get_int_guid():
-					if multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
-						affected_context.select_all()
-						_workspace_context.snapshot_moment("Change Selection")
-					else:
-						assert(multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_PATH)
-						# insert control point
-						var pos: Vector3 = multi_structure_hit_result.closest_hit_dna_pos
-						var closest_segment: int = -1
-						var closest_distance_sqrd: float = INF
-						for i in (dna_structure.get_control_point_count() - 1):
-							var p0: Vector3 = dna_structure.get_control_point_position(i)
-							var p1: Vector3 = dna_structure.get_control_point_position(i+1)
-							var closest_point: Vector3 = Geometry3D.get_closest_point_to_segment(pos, p0, p1)
-							var dist_sqrd: float = pos.distance_squared_to(closest_point)
-							if dist_sqrd < closest_distance_sqrd:
-								closest_distance_sqrd = dist_sqrd
-								closest_segment = i
-						dna_structure.start_edit()
-						dna_structure.insert_control_point(pos, closest_segment + 1)
-						dna_structure.end_edit()
-						_workspace_context.snapshot_moment("Insert DNA control cpoint")
-				else:
-					get_workspace_context().start_editing_dna_spline(affected_context.get_int_guid())
-					get_workspace_context().snapshot_moment("Start Editing DNA Spline")
-				return true
 			get_workspace_context().change_current_structure_context(affected_context)
 			_workspace_context.snapshot_moment("Change Selection")
+			return true
+		elif hit_context.nano_structure is DnaStructure \
+				and multi_structure_hit_result.hit_type in [
+					MultiStructureHitResult.HitType.HIT_DNA_PATH,
+					MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT
+				]:
+			var dna_structure: DnaStructure = hit_context.nano_structure as DnaStructure
+			if get_workspace_context().get_edited_dna_spline_id() == hit_context.get_int_guid():
+				if multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
+					hit_context.select_all()
+					_workspace_context.snapshot_moment("Change Selection")
+				else:
+					assert(multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_PATH)
+					# insert control point
+					var pos: Vector3 = multi_structure_hit_result.closest_hit_dna_pos
+					var closest_segment: int = -1
+					var closest_distance_sqrd: float = INF
+					for i in (dna_structure.get_control_point_count() - 1):
+						var p0: Vector3 = dna_structure.get_control_point_position(i)
+						var p1: Vector3 = dna_structure.get_control_point_position(i+1)
+						var closest_point: Vector3 = Geometry3D.get_closest_point_to_segment(pos, p0, p1)
+						var dist_sqrd: float = pos.distance_squared_to(closest_point)
+						if dist_sqrd < closest_distance_sqrd:
+							closest_distance_sqrd = dist_sqrd
+							closest_segment = i
+					dna_structure.start_edit()
+					dna_structure.insert_control_point(pos, closest_segment + 1)
+					dna_structure.end_edit()
+					_workspace_context.snapshot_moment("Insert DNA control cpoint")
 			return true
 	return false
 
@@ -445,7 +446,7 @@ func _screen_selection_logic(
 	if multi_structure_hit_result.did_hit():
 		# perform selection
 		var hit_context: StructureContext = multi_structure_hit_result.closest_hit_structure_context
-		const GROUP_SELECTION_BLACKLIST = [&"AnchorPoint", &"Spring", &"DnaStructure"]
+		const GROUP_SELECTION_BLACKLIST = [&"AnchorPoint", &"Spring"]
 		if hit_context != get_workspace_context().get_current_structure_context() and not hit_context.nano_structure.get_type() in GROUP_SELECTION_BLACKLIST:
 			# Clicked an object that is a child of current edited structure, select the entire group
 			if not need_to_create_snapshot:
@@ -537,7 +538,6 @@ func _screen_selection_logic(
 							need_to_create_snapshot = true
 						hit_context.set_anchor_selected(true)
 				MultiStructureHitResult.HitType.HIT_DNA_PATH, MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
-					var is_editing: bool = _workspace_context.get_edited_dna_spline_id() != Workspace.INVALID_STRUCTURE_ID
 					var is_editing_this: bool = _workspace_context.get_edited_dna_spline_id() == hit_context.int_guid
 					var hit_on_path: bool = multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_PATH
 					if is_editing_this:
@@ -560,8 +560,6 @@ func _screen_selection_logic(
 									snapshot_name = "Select DNA control point"
 									need_to_create_snapshot = true
 					else:
-						if is_editing:
-							_workspace_context.stop_editing_dna_spline()
 						if hit_context.is_dna_structure_fully_selected():
 							hit_context.set_dna_spline_selected(false)
 							if not need_to_create_snapshot:

--- a/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
@@ -120,7 +120,7 @@ func _init_initial_positions_and_determine_center() -> Vector3:
 			selection_size += 1
 			center_pos += context.nano_structure.get_position()
 			_structure_context_2_initial_object_transforms[context.get_int_guid()] = Transform3D(Basis(), context.nano_structure.get_position())
-		elif context.nano_structure is DnaStructure:
+		elif context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 			if context.has_selection():
 				var control_points: Array = range(context.nano_structure.get_control_point_count())
 				if _workspace_context.get_edited_dna_spline_id() == context.get_int_guid():
@@ -255,7 +255,7 @@ func _apply_selection_transform() -> void:
 			var new_pos: Vector3 = _helper.global_position + _helper.global_transform.basis * delta_pos
 			object_new_transform = Transform3D(final_transform.basis.orthonormalized(), new_pos)
 			object_old_transform = nano_structure.get_transform()
-		elif nano_structure is DnaStructure:
+		elif nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 			var dna := nano_structure as DnaStructure
 			var points_to_transform: PackedInt32Array = range(dna.get_control_point_count())
 			if _workspace_context.get_edited_dna_spline_id() == context.get_int_guid():
@@ -367,7 +367,7 @@ func _on_helper_transform_changed(in_translation_changed: bool, in_rotation_chan
 			var initial_nano_struct_transform: Transform3D = _structure_context_2_initial_object_transforms[context.get_int_guid()]
 			rendering.transform_object_by_external_transform(context.nano_structure, _selection_initial_position,
 					initial_nano_struct_transform, _helper.global_transform)
-		elif nano_structure is DnaStructure:
+		elif nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 			if in_translation_changed:
 				rendering.set_dna_selection_position_delta(-delta, nano_structure)
 			if in_rotation_changed:

--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -48,6 +48,7 @@ var _is_selectable: bool = true
 var _path_hovered: bool = false
 var _path_highlighted: bool = false
 var _path_being_edited: bool = false
+var _edit_mode: DnaStructure.EditMode
 var _hovered_control_point: int = -1
 var _highlighted_control_points: Dictionary[int, bool] = {}
 
@@ -99,6 +100,7 @@ func build(in_workspace_context: WorkspaceContext, in_structure: DnaStructure) -
 	_dna_radius = in_structure.get_dna_radius_nanometers()
 	_bases_per_turn = in_structure.get_bases_per_turn()
 	_initial_twist = in_structure.get_initial_twist_rad()
+	_edit_mode = in_structure.get_edit_mode()
 	_updating_parameters = false
 	_update_bases()
 	_ensure_structure_signal_connections(in_structure)
@@ -110,6 +112,7 @@ func _enter_tree() -> void:
 		return
 	var workspace_context: WorkspaceContext = editor_viewport.get_workspace_context()
 	if not workspace_context.editable_structure_context_list_changed.is_connected(_on_editable_structure_context_list_changed):
+		workspace_context.current_structure_context_changed.connect(_on_current_structure_context_changed)
 		workspace_context.editable_structure_context_list_changed.connect(_on_editable_structure_context_list_changed)
 		workspace_context.hovered_structure_context_changed.connect(_on_hovered_structure_context_changed)
 		workspace_context.selection_in_structures_changed.connect(_on_workspace_context_selection_in_structures_changed)
@@ -120,6 +123,7 @@ func _ensure_structure_signal_connections(in_structure: DnaStructure) -> void:
 		in_structure.sequence_changed.connect(_on_sequence_changed)
 		in_structure.parameters_changed.connect(_on_parameters_changed)
 		in_structure.visibility_changed.connect(_on_structure_visibility_changed)
+		in_structure.edit_mode_changed.connect(_on_edit_mode_changed)
 
 
 func _on_sequence_changed(in_sequence: String) -> void:
@@ -144,19 +148,17 @@ func _on_structure_visibility_changed(in_visible: bool) -> void:
 	_update_visibility()
 
 
+func _on_edit_mode_changed(in_mode: DnaStructure.EditMode) -> void:
+	_edit_mode = in_mode
+	_update_visibility()
+
+
 func _on_curve_changed() -> void:
 	assert(curve.point_count > 1, "Invalid curve, dna chain should be deleted in this case")
 	_path_representation.queue_redraw()
 	_transform_helper.progress_ratio = 1
 	for base: DnaBaseRepresentation in _bases:
 		base.set_deferred(&"base_offset", base.base_offset)
-
-
-func notify_dna_path_being_edited(in_structure_id: int) -> void:
-	var being_edited: bool = _structure_id == in_structure_id
-	if being_edited != _path_being_edited:
-		_path_being_edited = being_edited
-		_path_representation.queue_redraw()
 
 
 func highlight_control_points(in_control_points_to_highlight: PackedInt32Array) -> void:
@@ -344,6 +346,11 @@ func queue_redraw() -> void:
 	_path_representation.queue_redraw()
 
 
+func _on_current_structure_context_changed(structure_context: StructureContext) -> void:
+	_path_being_edited = structure_context.get_int_guid() == _structure_id
+	_update_visibility()
+
+
 func _on_editable_structure_context_list_changed(in_new_editable_structure_contexts: Array[StructureContext]) -> void:
 	_is_selectable = false
 	for context: StructureContext in in_new_editable_structure_contexts:
@@ -374,7 +381,7 @@ func _on_hovered_structure_context_changed(toplevel_hovered_structure_context: S
 
 
 func _update_visibility() -> void:
-	visible = _object_visible
+	visible = _object_visible and _edit_mode == DnaStructure.EditMode.SequenceAndPath
 	queue_redraw()
 
 
@@ -454,6 +461,7 @@ func create_state_snapshot() -> Dictionary:
 	snapshot["_initial_twist"] = _initial_twist
 	snapshot["_path_highlighted"] = _path_highlighted
 	snapshot["_path_being_edited"] = _path_being_edited
+	snapshot["_edit_mode"] = _edit_mode
 	snapshot["_highlighted_control_points"] = _highlighted_control_points.duplicate()
 	snapshot["_is_selectable"] = _is_selectable
 	snapshot["_object_visible"] = _object_visible
@@ -475,6 +483,7 @@ func apply_state_snapshot(in_state_snapshot: Dictionary) -> void:
 	_initial_twist = in_state_snapshot["_initial_twist"]
 	_path_highlighted = in_state_snapshot["_path_highlighted"]
 	_path_being_edited = in_state_snapshot["_path_being_edited"]
+	_edit_mode = in_state_snapshot["_edit_mode"]
 	_highlighted_control_points = in_state_snapshot["_highlighted_control_points"].duplicate()
 	_is_selectable = in_state_snapshot["_is_selectable"]
 	_object_visible = in_state_snapshot["_object_visible"]

--- a/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
+++ b/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
@@ -65,8 +65,6 @@ func _action_delete_atoms_bonds_springs(context: StructureContext) -> void:
 func _action_delete_objects(context: StructureContext, out_already_deleted_contexts: Array[StructureContext]) -> void:
 	if out_already_deleted_contexts.has(context):
 		return
-	if _workspace_context.get_edited_dna_spline_id() != Workspace.INVALID_STRUCTURE_ID:
-		_workspace_context.stop_editing_dna_spline()
 	var workspace: Workspace = _workspace_context.workspace
 	if !_did_create_undo_action:
 		_did_create_undo_action = true

--- a/godot_project/project_workspace/structs/atomic_structure.gd
+++ b/godot_project/project_workspace/structs/atomic_structure.gd
@@ -199,7 +199,7 @@ func add_atom(_in_args: Variant = null) -> int:
 ## and false if anything prevented from revalidating the atom
 func revalidate_atom(_in_atom_idx: int) -> bool:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
-	return INVALID_ATOM_ID
+	return false
 
 
 ## Adds multiple atoms to the structure, recieves an array of parameters.

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -1,19 +1,26 @@
-class_name DnaStructure extends NanoStructure
+class_name DnaStructure extends AtomicStructure
 
+signal edit_mode_changed(in_mode: EditMode)
+# Path related signals
 signal bases_count_changed(new_count: int)
 signal sequence_changed(new_sequence: String)
 signal path_changed()
 signal parameters_changed(read_only_parameters: DnaStructureParameters)
-
-signal atoms_color_override_changed(changed_atoms: PackedInt32Array)
 
 enum Strand {
 	A = 1,
 	B = 2,
 	BOTH = 3,
 }
+enum EditMode {
+	SequenceAndPath,
+	AtomsAndBonds,
+}
+
 const StrandPolicy = DnaStructureParameters.StrandPolicy
+const PackedMolecule = preload("res://autoloads/dna_builder/templates/packed_molecule.gd")
 const INVALID_CONTROL_POINT_IDX: int = -1
+
 
 @export var _curve: Curve3D:
 	set = _set_curve
@@ -21,6 +28,7 @@ const INVALID_CONTROL_POINT_IDX: int = -1
 @export var _sequence: String
 @export var _parameters: DnaStructureParameters
 @export var _color_overrides: Dictionary[int, Color] = {}
+@export var _edit_mode := EditMode.SequenceAndPath
 
 # Atoms and Bases caches
 var _base_transform_cache: Dictionary[int, Transform3D]
@@ -33,15 +41,18 @@ var _bonds_cache: Dictionary[int, Vector3i]
 static var _unpacked_atom_ids: Dictionary[int, UnpackedAtomId]
 static var _unpacked_bond_ids: Dictionary[int, UnpackedBondId]
 
-var _is_being_edited: bool = false
 var _last_sequence: String = ""
 var _last_bases_cout: int = 0
 var _signal_queue_path_changed: bool = false
 var _signal_queue_parameters_changed: bool = false
-var _signal_queue_atoms_color_changed: PackedInt32Array = []
 var _baked_path: PackedVector3Array = []
 
-static func create(out_parameters: DnaStructureParameters, in_sequence: String = "") -> DnaStructure:
+@export var _motor_links: Dictionary[int, int] = {
+	# atom_id<int> : motor_id<int>
+}
+
+
+static func create_dna(out_parameters: DnaStructureParameters, in_sequence: String = "") -> DnaStructure:
 	var instance := DnaStructure.new()
 	instance._parameters = out_parameters.duplicate(true)
 	instance._sequence = in_sequence
@@ -54,7 +65,9 @@ func _init() -> void:
 	if _curve == null:
 		# Newly created object
 		_curve = Curve3D.new()
+		_curve.set_block_signals(true)
 		_curve.bake_interval = 0.02
+		_curve.set_block_signals(false)
 
 
 func _set_curve(in_curve: Curve3D) -> void:
@@ -93,71 +106,96 @@ func get_baked_path(in_path_override: Curve3D = null) -> PackedVector3Array:
 
 
 #region: Edit tracking
+func set_edit_mode(in_mode: EditMode) -> void:
+	# This may be counter intuitive, but logic is you should not be able to change
+	# Path/Sequence + Atoms/Bonds in the same start/end edit process
+	assert(!_is_being_edited, "Edit Mode can only be changed while edition is not happening")
+	if _edit_mode == in_mode: return
+	if in_mode == EditMode.SequenceAndPath:
+		# Atoms and bonds has been removed
+		var atoms_to_signal: PackedInt32Array = get_valid_atoms()
+		var bonds_to_signal: PackedInt32Array = get_valid_bonds()
+		_edit_mode = in_mode
+		_atoms_cache = {}
+		atoms_removed.emit(atoms_to_signal)
+		bonds_removed.emit(bonds_to_signal)
+		# TODO: Track springs? locked atoms? color overrides?
+		# changes on bases can easily invalidate springs,
+		# but maybe the property can be cleared when edit mode changes
+	elif in_mode == EditMode.AtomsAndBonds:
+		# Atoms and bonds added back
+		_edit_mode = in_mode
+		var atoms_to_signal: PackedInt32Array = get_valid_atoms()
+		var bonds_to_signal: PackedInt32Array = get_valid_bonds()
+		atoms_added.emit(atoms_to_signal)
+		bonds_created.emit(bonds_to_signal)
+	edit_mode_changed.emit(in_mode)
+
+
+func get_edit_mode() -> EditMode:
+	return _edit_mode
+
+
 func start_edit() -> void:
 	assert(not _is_being_edited, "I'm already being edited, make sure to call end_edit() when you are done with edits")
-	_is_being_edited = true
+	super.start_edit()
 	_last_bases_cout = _sequence.length()
 	_last_sequence = _sequence
-	_atoms_count_cache = -1
-	_atoms_ids_cache = {}
-	_atoms_cache = {}
-	_bonds_count_cache = -1
-	_bonds_ids_cache = {}
-	_bonds_cache = {}
 	return
-
-
-func is_being_edited() -> bool:
-	return _is_being_edited
 
 
 func end_edit() -> void:
 	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
-	_is_being_edited = false
-	_atoms_count_cache = -1
-	_atoms_ids_cache = {}
-	_atoms_cache = {}
-	_bonds_count_cache = -1
-	_bonds_ids_cache = {}
-	_bonds_cache = {}
-	
-	var has_changed: bool = (
-		_last_bases_cout != _sequence.length()
-		or _last_sequence != _sequence
-		or _signal_queue_path_changed
-		or _signal_queue_parameters_changed
-		or not _signal_queue_atoms_color_changed.is_empty()
-		)
-	if has_changed:
-		if _signal_queue_path_changed:
-			path_changed.emit()
-			_baked_path.clear()
-			_signal_queue_path_changed = false
-		# Emmit count changed signal before actual sequence
-		if _last_bases_cout != _sequence.length():
-			var count: = _sequence.length()
-			bases_count_changed.emit(count)
-			_last_bases_cout = _sequence.length()
-		if _last_sequence != _sequence:
-			_last_sequence = _sequence
-			_baked_path.clear()
-			sequence_changed.emit(_sequence)
-		if _signal_queue_parameters_changed:
-			_baked_path.clear()
-			_parameters.set_read_only(true)
-			parameters_changed.emit(_parameters)
-			_parameters.set_read_only(false)
-			_signal_queue_parameters_changed = false
-		if not _signal_queue_atoms_color_changed.is_empty():
-			atoms_color_override_changed.emit(_signal_queue_atoms_color_changed)
-			_signal_queue_atoms_color_changed = []
-		emit_changed()
+	if _edit_mode == EditMode.SequenceAndPath:
+		_is_being_edited = false
+		var has_changed: bool = (
+			_last_bases_cout != _sequence.length()
+			or _last_sequence != _sequence
+			or _signal_queue_path_changed
+			or _signal_queue_parameters_changed
+			)
+		if has_changed:
+			if _signal_queue_path_changed:
+				path_changed.emit()
+				_baked_path.clear()
+				_signal_queue_path_changed = false
+			# Emmit count changed signal before actual sequence
+			if _last_bases_cout != _sequence.length():
+				var count: = _sequence.length()
+				bases_count_changed.emit(count)
+				_last_bases_cout = _sequence.length()
+			if _last_sequence != _sequence:
+				_last_sequence = _sequence
+				_atoms_count_cache = -1
+				_atoms_ids_cache = {}
+				_atoms_cache = {}
+				_bonds_count_cache = -1
+				_bonds_ids_cache = {}
+				_bonds_cache = {}
+				_baked_path.clear()
+				sequence_changed.emit(_sequence)
+			if _signal_queue_parameters_changed:
+				_baked_path.clear()
+				_parameters.set_read_only(true)
+				parameters_changed.emit(_parameters)
+				_parameters.set_read_only(false)
+				_signal_queue_parameters_changed = false
+			emit_changed()
+	else:
+		super.end_edit()
+
+
+## UNUSED [s]Removes every atom, bond, and spring from this structure[/s]
+func clear() -> void:
+	assert(false, "Cannot delete atoms and bonds in this structure")
+	return
 #endregion: Edit tracking
 
 
 #region: Parameters
 func set_bases_per_turn(in_bases_per_turn: float) -> void:
 	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_signal_queue_parameters_changed = true
 	_parameters.bases_per_turn = in_bases_per_turn
 
@@ -168,6 +206,7 @@ func get_bases_per_turn() -> float:
 
 func set_rise_nanometers(in_rise_nanometers: float) -> void:
 	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_signal_queue_parameters_changed = true
 	_parameters.rise_nanometers = in_rise_nanometers
 	_adjust_sequence_to_path_length()
@@ -179,6 +218,7 @@ func get_rise_nanometers() -> float:
 
 func set_dna_radius_nanometers(in_radius_nanometers: float) -> void:
 	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_signal_queue_parameters_changed = true
 	_parameters.dna_radius_nanometers = in_radius_nanometers
 
@@ -189,6 +229,7 @@ func get_dna_radius_nanometers() -> float:
 
 func set_initial_twist_rad(in_initial_twist_rad: float) -> void:
 	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_signal_queue_parameters_changed = true
 	_parameters.initial_twist_rad = in_initial_twist_rad
 
@@ -199,6 +240,7 @@ func get_initial_twist_rad() -> float:
 
 func set_strand_policy(in_strand_policy: StrandPolicy) -> void:
 	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_signal_queue_parameters_changed = true
 	_parameters.strand_policy = in_strand_policy
 
@@ -222,6 +264,7 @@ func get_strands() -> Array[Strand]:
 
 func set_include_hydrogens(in_include_hydrogens: bool) -> void:
 	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_signal_queue_parameters_changed = true
 	_parameters.include_hydrogens = in_include_hydrogens
 
@@ -240,6 +283,7 @@ func _on_curve_changed() -> void:
 
 func insert_control_point(position: Vector3, in_index: int = -1) -> void:
 	assert(_is_being_edited)
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_curve.add_point(position, Vector3.ZERO, Vector3.ZERO, in_index)
 	var index: int = in_index if in_index > -1 else _curve.point_count - 1
 	recalculate_curve_in_out(_curve, index - 1)
@@ -249,6 +293,7 @@ func insert_control_point(position: Vector3, in_index: int = -1) -> void:
 
 func remove_control_point(in_index: int) -> void:
 	assert(_is_being_edited)
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_curve.remove_point(in_index)
 	if in_index > 0:
 		recalculate_curve_in_out(_curve, in_index - 1)
@@ -262,6 +307,7 @@ func is_control_point_valid(in_index: int) -> bool:
 
 func set_control_point_position(in_index: int, int_position: Vector3) -> void:
 	assert(_is_being_edited)
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	_curve.set_point_position(in_index, int_position)
 	recalculate_curve_in_out(_curve, in_index - 1)
 	recalculate_curve_in_out(_curve, in_index)
@@ -279,13 +325,6 @@ func get_control_point_position(in_index: int) -> Vector3:
 func get_path_length() -> float:
 	# This is obtained from the Path3D
 	return _curve.get_baked_length()
-
-
-func create_path3d() -> Path3D:
-	var path := Path3D.new()
-	path.curve = _curve
-	return path
-
 
 
 func get_base_transform(in_strand: Strand, in_base_index: int) -> Transform3D:
@@ -377,6 +416,7 @@ static func recalculate_curve_in_out(out_curve: Curve3D, in_index: int) -> void:
 #region: Sequence
 func set_sequence(in_sequence: String) -> void:
 	assert(_is_being_edited)
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	if _sequence != in_sequence:
 		_sequence = in_sequence
 		_adjust_sequence_to_path_length()
@@ -387,6 +427,8 @@ func get_sequence() -> String:
 
 
 func _adjust_sequence_to_path_length() -> void:
+	assert(_is_being_edited)
+	assert(_edit_mode == EditMode.SequenceAndPath, "Cannot change helix proeprties in this state")
 	var expected_sequence_length: int = floori(get_path_length() / _parameters.rise_nanometers)
 	if expected_sequence_length == _sequence.length():
 		return
@@ -404,6 +446,8 @@ func _adjust_sequence_to_path_length() -> void:
 ## Returns number of atoms that has been created in this NanoStructure
 func get_valid_atoms_count() -> int:
 	assert(not _is_being_edited, "I'm being edited, performing operations on atoms in this state is unrecommended")
+	if _edit_mode == EditMode.SequenceAndPath:
+		return 0
 	if _atoms_count_cache == -1:
 		var base_count: Dictionary[String, int] = {
 			"A" : DnaBuilder.get_template_atom_count("A", _parameters.include_hydrogens),
@@ -428,6 +472,10 @@ func get_valid_atoms_count() -> int:
 func get_atom_ids_for_strand(in_strand: Strand) -> PackedInt32Array:
 	assert(not _is_being_edited, "I'm being edited, performing operations on atoms in this state is unrecommended")
 	assert(in_strand != Strand.BOTH, "Invalid usage of get_atoms_for_strand, use get_valid_atoms() instead")
+	
+	if _edit_mode == EditMode.SequenceAndPath:
+		return []
+	
 	if not in_strand in _atoms_ids_cache.keys():
 		# Update cache
 		_atoms_ids_cache[in_strand] = PackedInt32Array()
@@ -459,6 +507,14 @@ func get_atom_ids_for_strand(in_strand: Strand) -> PackedInt32Array:
 ## Returns the list of atom_ids
 func get_valid_atoms() -> PackedInt32Array:
 	assert(not _is_being_edited, "I'm being edited, performing operations on atoms in this state is unrecommended")
+	
+	if _edit_mode == EditMode.SequenceAndPath:
+		return []
+	
+	if get_strand_policy() != StrandPolicy.DOUBLE:
+		return get_atom_ids_for_strand(get_strands()[0])
+	
+	
 	if not _atoms_ids_cache.get(Strand.BOTH, []).is_empty():
 		return _atoms_ids_cache[Strand.BOTH]
 	
@@ -468,32 +524,49 @@ func get_valid_atoms() -> PackedInt32Array:
 	return _atoms_ids_cache[Strand.BOTH]
 
 
-## Returns wether the atom should be rendered and/or mouse picked
-func is_atom_visible(in_atom_id: int) -> bool:
-	if is_atom_hidden_by_user(in_atom_id):
+## UNUSED
+func add_atom(_in_args: Variant = null) -> int:
+	assert(false, "Dna Structure cannot modify atoms")
+	return INVALID_ATOM_ID
+
+
+## UNUSED
+func revalidate_atom(_in_atom_idx: int) -> bool:
+	assert(false, "Dna Structure cannot modify atoms")
+	return false
+
+
+## UNUSED
+func remove_atom(_in_atom_id: int) -> bool:
+	assert(false, "Dna Structure cannot modify atoms")
+	return false
+
+
+func is_atom_valid(in_atom_id: int) -> bool:
+	if _edit_mode == EditMode.SequenceAndPath:
 		return false
-	if not are_hydrogens_visible() and atom_get_atomic_number(in_atom_id) == PeriodicTable.ATOMIC_NUMBER_HYDROGEN:
+	
+	var id_data: UnpackedAtomId = _unpack_atom_id(in_atom_id)
+	if id_data.base_idx < 0 or id_data.base_idx >= _sequence.length():
 		return false
-	return true
-
-
-## Returns true if the atom is explicitely hidden with the "Hide Selected" action.
-## Unlike is_atom_visible(), this method does not consider the hydrogen rendering state.
-func is_atom_hidden_by_user(_in_atom_id: int) -> bool:
-	# TODO: Support hide and show atoms
-	return false #hidden_atoms.get(in_atom_id, false)
-
-
-## Returns the list of valid atom_ids that are not hidden
-func get_visible_atoms() -> PackedInt32Array:
-	# TODO: Support hide and show atoms
-	return get_valid_atoms()
+	if not id_data.strand in get_strands():
+		return false
+	var template: PackedMolecule = _get_base_template_for_unpacked_atom(id_data)
+	return id_data.sub_atom_id >= 0 and id_data.sub_atom_id < template.atoms.size()
 
 
 ## Returns the numbers of protons in atom's nucleous. This reffers to the id of an
 ## element in the Periodic Table
 func atom_get_atomic_number(in_atom_id: int) -> int:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return INVALID_ATOMIC_NUMBER
 	return _get_atom_data(in_atom_id).atomic_number
+
+
+## UNUSED
+func atom_set_atomic_number(_in_atom_id: int, _in_atomic_number: int) -> void:
+	assert(false, "Dna Structure cannot modify atoms")
+	return
 
 
 ## Calculate the [url=https://en.wikipedia.org/wiki/Formal_charge]formal charge[/url] of a given atom
@@ -504,6 +577,8 @@ func atom_get_formal_charge(_in_atom_id: int) -> int:
 
 ## Returns the position of the atom, relative to structure's transform
 func atom_get_position(in_atom_id: int) -> Vector3:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return Vector3.ONE * NAN
 	return _get_atom_data(in_atom_id).position
 
 
@@ -511,34 +586,26 @@ func atom_get_position(in_atom_id: int) -> Vector3:
 ## Returs true if succeeds or false if something prevents the change
 ## This is uniquely supported to update atoms positions during simulation
 func atom_set_position(in_atom_id: int, in_pos: Vector3) -> bool:
+	assert(_is_being_edited)
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Atoms and Bonds cannot be edited in this mode")
 	const TO_UPDATE_POSITION = true
 	_get_atom_data(in_atom_id, TO_UPDATE_POSITION).position = in_pos
+	_signal_queue_atoms_moved.push_back(in_atom_id)
 	return true
 
 
 ## Should be used instead of [code]atom_set_position()[/code] in cases where there is many atoms to move,
 ## for performance reasons - this way [code]changed[/code] signal is emitted only once
-func atoms_set_positions(_in_atoms: PackedInt32Array, _in_positions: PackedVector3Array) -> void:
-	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
-	return
+func atoms_set_positions(in_atoms: PackedInt32Array, in_positions: PackedVector3Array) -> void:
+	assert(in_atoms.size() == in_positions.size())
+	for i in in_atoms.size():
+		atom_set_position(in_atoms[i], in_positions[i])
 
 
 
 ## Returns true if the atom is locked
 func atom_is_locked(_in_atom_id: int) -> bool:
-	# TBD: could all atoms in a base be locked?
-	return false
-
-
-func atom_is_hydrogen(in_atom_id: int) -> bool:
-	var atomic_number: int = atom_get_atomic_number(in_atom_id)
-	return atomic_number == PeriodicTable.ATOMIC_NUMBER_HYDROGEN
-
-
-func atom_is_any_hydrogen(in_atom_ids: PackedInt32Array) -> bool:
-	for atom_id in in_atom_ids:
-		if atom_is_hydrogen(atom_id):
-			return true
+	# TBD: can this feature be supported?
 	return false
 
 
@@ -548,33 +615,112 @@ func get_locked_atoms() -> PackedInt32Array:
 
 
 ## returns IDs of the bonds that given atom is participating in
-func atom_get_bonds(_in_atom_id: int) -> PackedInt32Array:
-	# TODO
-	return PackedInt32Array()
+func atom_get_bonds(in_atom_id: int) -> PackedInt32Array:
+	var result := PackedInt32Array()
+	var id_data: UnpackedAtomId = _unpack_atom_id(in_atom_id)
+	var template: PackedMolecule = _get_base_template_for_unpacked_atom(id_data)
+	for sub_bond_id: int in template.bonds.size():
+		var bond: Vector3i = template.bonds[sub_bond_id]
+		if id_data.sub_atom_id in [bond.x, bond.y]:
+			var bond_id: int = _get_bond_id(id_data.base_idx, id_data.strand, id_data.is_backbone, sub_bond_id)
+			result.append(bond_id)
+	# Check glue bonds
+	var bases_to_scan: Dictionary[int, bool] = {}
+	bases_to_scan[id_data.base_idx - 1] = true
+	bases_to_scan[id_data.base_idx] = true
+	bases_to_scan[id_data.base_idx + 1] = true
+	for base_idx: int in bases_to_scan.keys():
+		for is_backbone: bool in [true, false]:
+			var glue_bond_id: int = _get_glue_bond_id(base_idx, id_data.strand, is_backbone)
+			if not is_bond_valid(glue_bond_id):
+				continue
+			# Check if this bond actually connects both atoms
+			var bond: Vector3i = get_bond(glue_bond_id)
+			if in_atom_id in [bond.x, bond.y]:
+				result.append(glue_bond_id)
+	return result
 
 
 ## Returns the ID of the another atom that's participating in in_bond_id
-func atom_get_bond_target(_in_atom_id: int, _in_bond_id: int) -> int:
-	# TODO
-	return AtomicStructure.INVALID_ATOM_ID
+func atom_get_bond_target(in_atom_id: int, in_bond_id: int) -> int:
+	var bond_data: Vector3i = get_bond(in_bond_id)
+	if bond_data.x == in_atom_id:
+		return bond_data.y
+	elif bond_data.y == in_atom_id:
+		return bond_data.x
+	else:
+		push_error("Bond ", in_bond_id, " is not involved with atom ", in_atom_id)
+		return AtomicStructure.INVALID_ATOM_ID
 
 
 ## Returns bond id between first atom and second atom or -1 if bond do not exists
-func atom_find_bond_between(_in_atom_id_a: int, _in_atom_id_b: int) -> int:
-	# TODO
-	return -1
+func atom_find_bond_between(in_atom_id_a: int, in_atom_id_b: int) -> int:
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return INVALID_BOND_ID
+	
+	var a_id_data: UnpackedAtomId = _unpack_atom_id(in_atom_id_a)
+	var b_id_data: UnpackedAtomId = _unpack_atom_id(in_atom_id_b)
+	if a_id_data.strand != b_id_data.strand:
+		# Not in the same strand, hence not bonded
+		return INVALID_BOND_ID
+	# from now on they are in the same strand
+	elif a_id_data.base_idx != b_id_data.base_idx:
+		# Assume is glue bond between backbones
+		if not a_id_data.is_backbone or not b_id_data.is_backbone:
+			# Atoms not bonded
+			return INVALID_BOND_ID
+		var bases_to_scan: Dictionary[int, bool] = {}
+		bases_to_scan[a_id_data.base_idx - 1] = true
+		bases_to_scan[a_id_data.base_idx] = true
+		bases_to_scan[a_id_data.base_idx + 1] = true
+		bases_to_scan[b_id_data.base_idx - 1] = true
+		bases_to_scan[b_id_data.base_idx] = true
+		bases_to_scan[b_id_data.base_idx + 1] = true
+		for base_idx: int in bases_to_scan.keys():
+			var backbone_bond_id: int = _get_glue_bond_id(base_idx, a_id_data.strand, true)
+			# Check if this bond actually connects both atoms
+			var bond: Vector3i = get_bond(backbone_bond_id)
+			var bond_atoms: PackedInt32Array = [bond.x, bond.y]
+			if in_atom_id_a in bond_atoms and in_atom_id_b in bond_atoms:
+				return backbone_bond_id
+		# None of the proposed glue bonds happened to be 
+		return INVALID_BOND_ID
+	# from now on they are in the same base index
+	elif a_id_data.is_backbone != b_id_data.is_backbone:
+		# Assume is glue between base and backbone
+		var glue_bond: int = _get_glue_bond_id(a_id_data.base_idx, a_id_data.strand, false)
+		var bond: Vector3i = get_bond(glue_bond)
+		var bond_atoms: PackedInt32Array = [bond.x, bond.y]
+		if in_atom_id_a in bond_atoms and in_atom_id_b in bond_atoms:
+			return glue_bond
+		return INVALID_BOND_ID
+	# from now on they are in the same template, backbone or base
+	else:
+		var template: PackedMolecule = _get_base_template_for_unpacked_atom(a_id_data)
+		for sub_bond_id: int in template.bonds.size():
+			var bond: Vector3i = template.bonds[sub_bond_id]
+			var bond_atom_sub_ids: PackedInt32Array = [bond.x, bond.y]
+			if a_id_data.sub_atom_id in bond_atom_sub_ids and b_id_data.sub_atom_id in bond_atom_sub_ids:
+				return _get_bond_id(a_id_data.base_idx, a_id_data.strand, a_id_data.is_backbone, sub_bond_id)
+	return INVALID_BOND_ID
 
 
-func has_color_override(in_atom_id: int) -> bool:
-	return _color_overrides.has(in_atom_id)
-
-
-func get_color_override(in_atom_id: int) -> Color:
-	return _color_overrides.get(in_atom_id, null)
+func atoms_count_visible_by_type(types_to_count: PackedInt32Array) -> int:
+	assert(not _is_being_edited, "I'm being edited, performing operations on atoms in this state is unrecommended")
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return 0
+	var count: int = 0
+	const FOR_UPDATING_DATA: bool = false
+	for atom_id: int in get_valid_atoms():
+		var atom: AtomData = _get_atom_data(atom_id, FOR_UPDATING_DATA)
+		if atom.atomic_number in types_to_count and is_atom_visible(atom_id):
+			count += 1
+	return count
 
 
 func set_color_override(in_atoms: PackedInt32Array, color: Color) -> void:
 	assert(_is_being_edited, "Color override can only be changed while structure is being edited")
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Atoms and Bonds cannot be edited in this mode")
 	for atom_id: int in in_atoms:
 		_color_overrides[atom_id] = color
 	_signal_queue_atoms_color_changed.append_array(in_atoms)
@@ -586,18 +732,50 @@ func get_color_overrides() -> Dictionary:
 
 func remove_color_override(in_atoms: PackedInt32Array) -> void:
 	assert(_is_being_edited, "Color override can only be changed while structure is being edited")
-	for atom_id: int in in_atoms:
-		_color_overrides.erase(atom_id)
-	_signal_queue_atoms_color_changed.append_array(in_atoms)
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Atoms and Bonds cannot be edited in this mode")
+	super.remove_color_override(in_atoms)
 
 
-func are_hydrogens_visible() -> bool:
-	return _representation_settings.get_ref().get_hydrogens_visible()
+## UNUSED
+func add_bond(_in_atom_id_a: int, _in_atom_id_b: int, _in_bond_order: int) -> int:
+	assert(false, "Dna Structure cannot modify bonds")
+	return INVALID_ATOM_ID
+
+
+## UNUSED
+func remove_bond(_in_bond_id: int) -> void:
+	assert(false, "Dna Structure cannot modify bonds")
+	return
+
+
+## UNUSED
+func revalidate_bond(_in_bond_id: int) -> bool:
+	assert(false, "Dna Structure cannot modify bonds")
+	return false
+
+
+## Returns wether or not a bond has been removed from the structure
+func is_bond_valid(in_bond_id: int) -> bool:
+	var id_data: UnpackedBondId = _unpack_bond_id(in_bond_id)
+	if id_data.is_glue_bond:
+		if id_data.is_backbone:
+			# check if base is on range
+			return id_data.base_idx > 0 and id_data.base_idx < _sequence.length()
+		else:
+			# glue to the base, is always valid
+			return id_data.base_idx >= 0 and id_data.base_idx < _sequence.length()
+	else:
+		var template: PackedMolecule = _get_base_template_for_unpacked_bond(id_data)
+		return id_data.sub_bond_id >= 0 and id_data.sub_bond_id < template.bonds.size()
 
 
 func get_bond_ids_for_strand(in_strand: Strand) -> PackedInt32Array:
 	assert(not _is_being_edited, "I'm being edited, performing operations on bonds in this state is unrecommended")
 	assert(in_strand != Strand.BOTH, "Invalid usage of get_bonds_for_strand, use get_valid_bonds() instead")
+	
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return []
+	
 	if not in_strand in _bonds_ids_cache.keys():
 		# Update cache
 		_bonds_ids_cache[in_strand] = PackedInt32Array()
@@ -638,6 +816,10 @@ func get_bond_ids_for_strand(in_strand: Strand) -> PackedInt32Array:
 ## Returns the list of bond_ids
 func get_valid_bonds() -> PackedInt32Array:
 	assert(not _is_being_edited, "I'm being edited, performing operations on atoms in this state is unrecommended")
+	
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return []
+	
 	if not _bonds_ids_cache.get(Strand.BOTH, []).is_empty():
 		return _bonds_ids_cache[Strand.BOTH]
 	
@@ -647,38 +829,41 @@ func get_valid_bonds() -> PackedInt32Array:
 	return _bonds_ids_cache[Strand.BOTH]
 
 
+## Returns the list with all existing bonds ids
+func get_bonds_ids() -> PackedInt32Array:
+	return get_valid_bonds()
+
+
 ## Returns wether the bond should be rendered and/or mouse picked
 func is_bond_visible(in_bond_id: int) -> bool:
-	if is_bond_hidden_by_user(in_bond_id):
+	if _edit_mode != EditMode.AtomsAndBonds:
 		return false
-	if not are_hydrogens_visible():
-		var bond: Vector3i = get_bond(in_bond_id)
-		return atom_get_atomic_number(bond.x) != PeriodicTable.ATOMIC_NUMBER_HYDROGEN and \
-				atom_get_atomic_number(bond.y) != PeriodicTable.ATOMIC_NUMBER_HYDROGEN
-	return true
+	return super.is_bond_visible(in_bond_id)
 
 
 ## Returns true if the bond is explicitely hidden with the "Hide Selected" action.
 ## Unlike is_bond_visible(), this method does not consider the hydrogen rendering state.
 func is_bond_hidden_by_user(in_bond_id: int) -> bool:
-	# TODO: Support hiding bonds
-	return false # hidden_bonds.get(in_bond_id, false)
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return false
+	return super.is_bond_hidden_by_user(in_bond_id)
 
 
 ## Returns the list of bond_ids that are not hidden in the structure
 func get_visible_bonds() -> PackedInt32Array:
-	var visible_bonds: PackedInt32Array = PackedInt32Array()
-	var valid_bonds: PackedInt32Array = get_valid_bonds()
-	for bond_id in valid_bonds:
-		if is_bond_visible(bond_id):
-			visible_bonds.append(bond_id)
-	return visible_bonds
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return []
+	return super.get_visible_bonds()
 
 
 ## Returns number of bonds that has been created in this NanoStructure
 ## and have not been removed.
 func get_valid_bonds_count() -> int:
 	assert(not _is_being_edited, "I'm being edited, performing operations on atoms in this state is unrecommended")
+	
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return 0
+	
 	if _bonds_count_cache == -1:
 		var base_count: Dictionary[String, int] = {
 			"A" : DnaBuilder.get_template_bond_count("A", _parameters.include_hydrogens),
@@ -706,12 +891,16 @@ func get_valid_bonds_count() -> int:
 ## z component: bond order
 func get_bond(in_bond_id: int) -> Vector3i:
 	assert(not _is_being_edited, "I'm being edited, performing operations on bonds in this state is unrecommended")
+	
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return Vector3i(INVALID_ATOM_ID, INVALID_ATOM_ID, -1)
+	
 	if not _bonds_cache.has(in_bond_id):
 		var bond_data := Vector3i(-1, -1, -1)
 		var id_info: UnpackedBondId = _unpack_bond_id(in_bond_id)
 		if id_info.is_backbone:
 			var base: String = "backbone1" if id_info.strand == Strand.B else "backbone0"
-			var template: DnaBuilder.PackedMolecule = DnaBuilder.get_template(base, get_include_hydrogens())
+			var template: PackedMolecule = DnaBuilder.get_template(base, get_include_hydrogens())
 			if id_info.is_glue_bond:
 				bond_data.x = _get_atom_id(id_info.base_idx - 1, id_info.strand, true, template.next_backbone_atom_id)
 				bond_data.y = _get_atom_id(id_info.base_idx, id_info.strand, true, template.previous_backbone_atom_id)
@@ -725,10 +914,10 @@ func get_bond(in_bond_id: int) -> Vector3i:
 			var base: String = _sequence[id_info.base_idx]
 			if id_info.strand == Strand.B:
 				base = DnaBuilder.DNA_COMPLEMENT.get(base, "X")
-			var template: DnaBuilder.PackedMolecule = DnaBuilder.get_template(base, get_include_hydrogens())
+			var template: PackedMolecule = DnaBuilder.get_template(base, get_include_hydrogens())
 			if id_info.is_glue_bond:
 				var backbone: String = "backbone1" if id_info.strand == Strand.B else "backbone0"
-				var backbone_template: DnaBuilder.PackedMolecule = DnaBuilder.get_template(backbone, get_include_hydrogens())
+				var backbone_template: PackedMolecule = DnaBuilder.get_template(backbone, get_include_hydrogens())
 				bond_data.x = _get_atom_id(id_info.base_idx, id_info.strand, false, template.base_to_backbone_atom_id)
 				bond_data.y = _get_atom_id(id_info.base_idx, id_info.strand, true, backbone_template.base_to_backbone_atom_id)
 				bond_data.z = 1
@@ -743,21 +932,14 @@ func get_bond(in_bond_id: int) -> Vector3i:
 
 ## Sets the bond order
 func bond_set_order(_in_bond_id: int, _in_bond_order: int) -> void:
-	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
+	assert(false, "Dna Structure cannot modify bonds")
 	return
 
 
-func bond_is_hydrogen_involved(in_bond_id: int) -> bool:
-	var bond_data: Vector3i = get_bond(in_bond_id)
-	var is_hydrogen_involved: bool = atom_is_hydrogen(bond_data.x)
-	is_hydrogen_involved = is_hydrogen_involved or atom_is_hydrogen(bond_data.y)
-	return is_hydrogen_involved
-
-
 func _get_atom_data(in_atom_id: int, in_to_update_data: bool = false) -> AtomData:
-	if not in_to_update_data:
-		assert(!_is_being_edited, "Cannot query atom data while structure is being edited, is not safe")
-		pass
+	assert(in_to_update_data == _is_being_edited, "Invalid operation at this moment, information can only be "
+			+ ("UPDATED" if _is_being_edited else "READ"))
+	assert(is_atom_valid(in_atom_id), "This atom does not belong to the structure")
 	if not _atoms_cache.has(in_atom_id):
 		_atoms_cache[in_atom_id] = AtomData.new(_unpack_atom_id(in_atom_id), self)
 	return _atoms_cache[in_atom_id]
@@ -779,11 +961,22 @@ static func _get_atom_id(in_base_idx: int, in_strand: Strand, in_is_backbone: bo
 	return atom_id
 
 
-func _get_bond_data(in_bond_id: int) -> Vector3i:
-	if not _bonds_cache.has(in_bond_id):
-		var bond_data := UnpackedBondId.new(in_bond_id)
-		_bonds_cache[in_bond_id]
-	return _bonds_cache[in_bond_id]
+func _get_base_template_for_unpacked_atom(in_packed: UnpackedAtomId) -> PackedMolecule:
+	assert(in_packed.base_idx >= 0 and in_packed.base_idx < _sequence.length(), "Base index out of range")
+	assert(in_packed.strand in get_strands(), "This structure doesn't have %s strand" % Strand.find_key(in_packed.strand))
+	var base: String = "backbone0" if in_packed.is_backbone else _sequence[in_packed.base_idx]
+	if in_packed.strand == Strand.B:
+		base = "backbone1" if in_packed.is_backbone else DnaBuilder.DNA_COMPLEMENT.get(base, "X")
+	return DnaBuilder.get_template(base, get_include_hydrogens())
+
+
+func _get_base_template_for_unpacked_bond(in_packed: UnpackedBondId) -> PackedMolecule:
+	assert(in_packed.base_idx >= 0 and in_packed.base_idx < _sequence.length(), "Base index out of range")
+	assert(in_packed.strand in get_strands(), "This structure doesn't have %s strand" % Strand.find_key(in_packed.strand))
+	var base: String = "backbone0" if in_packed.is_backbone else _sequence[in_packed.base_idx]
+	if in_packed.strand == Strand.B:
+		base = "backbone1" if in_packed.is_backbone else DnaBuilder.DNA_COMPLEMENT.get(base, "X")
+	return DnaBuilder.get_template(base, get_include_hydrogens())
 
 
 static func _unpack_bond_id(in_bond_id: int) -> UnpackedBondId:
@@ -817,6 +1010,224 @@ static func _is_glue_bond_id(in_bond_id: int) -> bool:
 
 #endregion: Atoms and Bonds
 
+
+#region: Anchors and Springs
+func spring_create(_in_anchor_id: int, _in_atom_id: int, _in_spring_constant_force: float,
+			_is_equilibrium_length_automatic: bool, _in_equilibrium_manual_length: float) -> int:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return INVALID_SPRING_ID
+	# TDB: Support springs?
+	return INVALID_SPRING_ID
+
+
+func spring_has(_in_spring_id: int) -> bool:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return true
+	# TDB: Support springs?
+	return false
+
+
+func spring_invalidate(_in_spring_id: int) -> void:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return
+	# TDB: Support springs?
+	return
+
+
+func spring_revalidate(_in_spring_id: int) -> void:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return
+	# TDB: Support springs?
+	return
+
+
+func spring_get_atom_id(_in_spring_id: int) -> int:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return INVALID_ATOM_ID
+	# TDB: Support springs?
+	return INVALID_ATOM_ID
+
+
+func spring_get_atom_position(_in_spring_id: int) -> Vector3:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return Vector3()
+	# TDB: Support springs?
+	return Vector3()
+
+
+func spring_get_anchor_id(_in_spring_id: int) -> int:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return -1
+	# TDB: Support springs?
+	return -1
+
+
+func spring_get_anchor_position(_in_spring_id: int, _in_parent_context: StructureContext) -> Vector3:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return Vector3()
+	# TDB: Support springs?
+	return Vector3()
+
+
+func spring_get_equilibrium_length_is_auto(_in_spring_id: int) -> bool:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return false
+	# TDB: Support springs?
+	return false
+
+
+func spring_set_equilibrium_lenght_is_auto(_in_spring_id: int, _in_is_auto: bool) -> void:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return
+	# TDB: Support springs?
+	return
+
+
+func spring_set_equilibrium_manual_length(_in_spring_id: int, _new_equilibrium_manual_length: float) -> void:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return
+	# TDB: Support springs?
+	return
+
+
+func spring_get_equilibrium_manual_length(_in_spring_id: int) -> float:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return 0
+	# TDB: Support springs?
+	return -1.0
+
+
+func spring_calculate_equilibrium_auto_length(_in_spring_id: int, _in_parent_context: StructureContext) -> float:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return 0
+	# TDB: Support springs?
+	return -1.0
+
+
+func spring_get_current_equilibrium_length(_in_spring_id: int, _in_parent_context: StructureContext) -> float:
+	# TDB: Support springs?
+	return 1.0
+
+
+func spring_get_constant_force(_in_spring_id: int) -> float:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return 0
+	# TDB: Support springs?
+	return -1.0
+
+
+func spring_set_constant_force(_in_spring_id: int, _new_force: float) -> void:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return
+	# TDB: Support springs?
+	return
+
+
+func springs_get_all() -> PackedInt32Array:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return PackedInt32Array()
+	# TDB: Support springs?
+	return PackedInt32Array()
+
+
+func springs_get_valid() -> PackedInt32Array:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return PackedInt32Array()
+	# TDB: Support springs?
+	return PackedInt32Array()
+
+
+func springs_count() -> int:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return 0
+	# TDB: Support springs?
+	return -1
+
+
+
+func atom_get_springs(_in_atom_id: int) -> PackedInt32Array:
+	if _edit_mode == EditMode.SequenceAndPath:
+		return PackedInt32Array()
+	# TDB: Support springs?
+	return PackedInt32Array()
+#endregion: Anchors and Strings
+
+
+#region: Virtual Motors
+func _set_connected_motor(in_motor_id: int) -> void:
+	if !_initialized:
+		#during initialization do not emit signals
+		connected_motor = in_motor_id
+		return
+	# disabled since we are now working on snapshots, this probably should not have any setter anymore
+	#assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
+	connected_motor = in_motor_id
+	_motor_links.clear()
+	_signal_queue_motor_links_changed = get_valid_atoms() ## all atoms where changed
+
+
+func motor_link_get_motor_id(in_atom_id: int) -> int:
+	if connected_motor != 0:
+		return connected_motor
+	else:
+		return _motor_links.get(in_atom_id, 0)
+
+
+func motor_link_get_motor_position(in_atom_id: int, in_parent_context: StructureContext) -> Vector3:
+	var motor_id: int = motor_link_get_motor_id(in_atom_id)
+	var motor: NanoVirtualMotor = in_parent_context.workspace_context.workspace.get_structure_by_int_guid(motor_id) as NanoVirtualMotor
+	assert(is_instance_valid(motor), "Atom is not linked to a motor")
+	return motor.get_transform().origin
+
+
+func motor_links_count() -> int:
+	if connected_motor != 0:
+		return get_valid_atoms_count()
+	return _motor_links.size()
+
+
+func motor_links_get_all() -> Dictionary: # { atom_id<int> = motor_id<int> }
+	if connected_motor != 0:
+		var motor_links: Dictionary = {}
+		for atom_id: int in get_valid_atoms():
+			motor_links[atom_id] = connected_motor
+		return motor_links
+	return _motor_links.duplicate()
+
+
+func atom_set_motor_link(in_atom_id: int, out_motor_context: StructureContext) -> void:
+	assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Atoms and Bonds cannot be edited in this mode")
+	assert(is_instance_valid(out_motor_context) and out_motor_context.nano_structure is NanoVirtualMotor,
+			"Invalid motor target for creating a link")
+	assert(connected_motor == 0, "Linking a particual atom when the entire structure is connected is not possible")
+	assert(is_atom_valid(in_atom_id), "Invalid atom ID")
+	var motor_id: int = out_motor_context.nano_structure.int_guid
+	if _motor_links.get(in_atom_id, 0) == motor_id:
+		# Nothin to do here
+		return
+	_signal_queue_motor_links_changed.push_back(in_atom_id)
+	_motor_links[in_atom_id] = motor_id
+
+
+func atom_clear_motor_link(in_atom_id: int) -> void:
+	assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Atoms and Bonds cannot be edited in this mode")
+	assert(connected_motor == 0, "Disconnecting a particular atom when the entire structure is connected is not possible")
+	assert(is_atom_valid(in_atom_id), "Invalid atom ID")
+	if _motor_links.has(in_atom_id):
+		_motor_links.erase(in_atom_id)
+		_signal_queue_motor_links_changed.push_back(in_atom_id)
+
+
+func atom_has_motor_link(in_atom_id: int) -> bool:
+	if connected_motor != 0:
+		return true
+	return _motor_links.has(in_atom_id)
+
+
+#endregion
+
 func get_type() -> StringName:
 	return &"DnaStructure"
 
@@ -844,14 +1255,44 @@ func get_icon() -> Texture2D:
 	return null
 
 
-func get_aabb() -> AABB:
-	if _curve.point_count == 0:
-		return AABB()
-	var aabb := AABB(_curve.get_point_position(0), Vector3.ZERO)
-	for p in range(1, _curve.point_count):
-		aabb = aabb.expand(_curve.get_point_position(p))
-	aabb = aabb.grow(_parameters.dna_radius_nanometers)
-	return aabb
+func get_aabb(in_bounds_type := AABB_BoundsType.AtomsPositions) -> AABB:
+	if _edit_mode == EditMode.AtomsAndBonds:
+		var aabb: AABB = AABB()
+		if get_valid_atoms_count() == 0:
+			return aabb
+		var elements_radius: Dictionary[int, float]
+		var is_first: bool = true
+		for atom_id: int in get_valid_atoms():
+			var atom: AtomData = _get_atom_data(atom_id)
+			var atom_aabb := AABB(atom.position, Vector3.ZERO)
+			if in_bounds_type != AABB_BoundsType.AtomsPositions and not atom.atomic_number in elements_radius:
+				var element_data: ElementData = PeriodicTable.get_by_atomic_number(atom.atomic_number)
+				match in_bounds_type:
+					AABB_BoundsType.VisualRadius:
+						elements_radius[atom.atomic_number] = (
+							Representation.get_atom_radius(element_data, get_representation_settings()) \
+							* Representation.get_atom_scale_factor(get_representation_settings())
+						)
+					AABB_BoundsType.CovalentRadius:
+						elements_radius[atom.atomic_number] = element_data.covalent_radius[1]
+					AABB_BoundsType.ContactRadius:
+						elements_radius[atom.atomic_number] = element_data.contact_radius
+			atom_aabb = atom_aabb.grow(elements_radius.get(atom.atomic_number, 0.0)).abs()
+			if is_first:
+				aabb = atom_aabb
+				is_first = false
+			else:
+				aabb = aabb.expand(atom_aabb.position)
+				aabb = aabb.expand(atom_aabb.end)
+		return aabb.abs()
+	else:
+		if _curve.point_count == 0:
+			return AABB()
+		var aabb := AABB(_curve.get_point_position(0), Vector3.ZERO)
+		for p in range(1, _curve.point_count):
+			aabb = aabb.expand(_curve.get_point_position(p))
+		aabb = aabb.grow(_parameters.dna_radius_nanometers)
+		return aabb
 
 
 func is_spline_within_screen_rect(in_camera: Camera3D, screen_rect: Rect2i) -> bool:
@@ -1012,7 +1453,7 @@ class AtomData:
 		if base == "X":
 			assert(false, "Invalid atom ID %d" % id_data.original_id)
 			return
-		var base_template: DnaBuilder.PackedMolecule = DnaBuilder.get_template(base, owner.get_include_hydrogens())
+		var base_template: PackedMolecule = DnaBuilder.get_template(base, owner.get_include_hydrogens())
 		assert(id_data.sub_atom_id < base_template.atoms.size(),
 			"Invalid atom ID %d (sub_atom_id = %d)" % [id_data.original_id, id_data.sub_atom_id])
 		var atom_info: Vector4 = base_template.atoms[id_data.sub_atom_id]

--- a/godot_project/project_workspace/structs/nano_molecular_structure.gd
+++ b/godot_project/project_workspace/structs/nano_molecular_structure.gd
@@ -81,6 +81,11 @@ func get_icon() -> Texture2D:
 	return preload("res://editor/icons/MolecularStructure_x28.svg")
 
 
+## Does this object work as a group?
+func can_contain_child_structure() -> bool:
+	return true
+
+
 ## Unlike Resource.duplicate(subresources=true) this method will make sure internal Dictionaries
 ## and Arrays are also duplicated and unique, so they are not shared to the original NanoStructure
 func safe_duplicate() -> NanoStructure:

--- a/godot_project/project_workspace/structs/nano_structure.gd
+++ b/godot_project/project_workspace/structs/nano_structure.gd
@@ -99,6 +99,11 @@ func get_visible() -> bool:
 	return _visible
 
 
+## Does this object work as a group?
+func can_contain_child_structure() -> bool:
+	return false
+
+
 ## Returns true if the object is not a group of particles. Ex: Shapes, Motors, Springs
 func is_virtual_object() -> bool:
 	return self is NanoShape or self.get_type() in \

--- a/godot_project/project_workspace/workspace.gd
+++ b/godot_project/project_workspace/workspace.gd
@@ -371,6 +371,7 @@ func _internal_add_structure(in_structure: NanoStructure, in_parent: NanoStructu
 	_structures[in_structure.int_guid] = in_structure
 	if in_parent != null:
 		assert(_structures.has(in_parent.int_guid), "Parent structure is not part of the workspace")
+		assert(in_parent.can_contain_child_structure(), "Object of type %s cannot contain children" % in_parent.get_type())
 		in_structure.int_parent_guid = in_parent.int_guid
 	in_structure.set_representation_settings(representation_settings)
 	if not in_structure.renamed.is_connected(_on_nano_structure_renamed):

--- a/godot_project/project_workspace/workspace_context/multi_structure_hit_result.gd
+++ b/godot_project/project_workspace/workspace_context/multi_structure_hit_result.gd
@@ -195,7 +195,7 @@ func _calculate_dna_path_sqrd_distance_to_camera(in_camera: Camera3D, in_screen_
 		# path cannot be querried during simulation
 		return result
 	var dna_structure: DnaStructure = in_context.nano_structure as DnaStructure
-	if dna_structure == null:
+	if dna_structure == null or dna_structure.get_edit_mode() != DnaStructure.EditMode.SequenceAndPath:
 		# not a dna structure
 		return result
 	var path: PackedVector3Array = dna_structure.get_baked_path()

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
@@ -293,7 +293,7 @@ func invert_selection() -> void:
 		set_spring_selection(springs_to_select)
 	
 	# ---- DNA Structures ----
-	if nano_structure is DnaStructure:
+	if nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 		if _structure_context.workspace_context.get_edited_dna_spline_id() == nano_structure.int_guid:
 			var dna_structure := nano_structure as DnaStructure
 			var all_points := PackedInt32Array(range(dna_structure.get_control_point_count()))
@@ -314,7 +314,7 @@ func select_all() -> void:
 	var nano_structure: NanoStructure = _structure_context.nano_structure
 	if nano_structure.is_virtual_object():
 		set_virtual_object_selected(true)
-	elif  nano_structure is DnaStructure:
+	elif  nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 		set_dna_spline_selected(true)
 		if _structure_context.workspace_context.get_edited_dna_spline_id() == _structure_context.get_int_guid():
 			set_dna_control_point_selection(range(nano_structure.get_control_point_count()))
@@ -377,6 +377,7 @@ func set_dna_spline_selected(in_selected: bool) -> void:
 
 func set_dna_control_point_selection(in_control_points_to_select: PackedInt32Array) -> void:
 	var dna_structure: DnaStructure = _structure_context.nano_structure as DnaStructure
+	assert(dna_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath, "Invalid edit mdoe for this operation")
 	assert(!dna_structure.is_being_edited(), "Setting the selection while structure is changing is insecure and should be avoided")
 	_validate_dna_control_point_selection(in_control_points_to_select)
 	
@@ -404,7 +405,6 @@ func set_dna_control_point_selection(in_control_points_to_select: PackedInt32Arr
 
 func select_dna_control_points(in_control_points: PackedInt32Array) -> void:
 	var dna_structure: DnaStructure = _structure_context.nano_structure as DnaStructure
-	assert(!dna_structure.is_being_edited(), "Setting the selection while structure is changing is insecure and should be avoided")
 	_validate_dna_control_point_selection(in_control_points)
 	var changed: bool = false
 	for p: int in in_control_points:

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -215,9 +215,8 @@ func is_spring_selected(in_spring_id: int) -> bool:
 func dna_structure_has_selection() -> bool:
 	if not nano_structure is DnaStructure:
 		return false
-	if workspace_context.is_simulating():
-		# TODO: Check if any atoms are selected
-		return false
+	if nano_structure.get_edit_mode() == DnaStructure.EditMode.AtomsAndBonds:
+		return is_any_atom_selected() or is_any_bond_selected()
 	if _selection_db.is_dna_spline_selected():
 		return true
 	if workspace_context.get_edited_dna_spline_id() == get_int_guid() and _selection_db.get_selected_dna_spline_countrol_points().size() > 0:
@@ -229,12 +228,13 @@ func is_dna_structure_fully_selected() -> bool:
 	if not nano_structure is DnaStructure:
 		return false
 	var dna_structure := nano_structure as DnaStructure
-	if workspace_context.is_simulating():
-		# TODO: Check if all atoms are fully selected
-		return false
-	if workspace_context.get_edited_dna_spline_id() == dna_structure.int_guid:
-		return _selection_db.get_selected_dna_spline_countrol_points().size() == dna_structure.get_control_point_count()
-	return _selection_db.is_dna_spline_selected()
+	if dna_structure.get_edit_mode() == DnaStructure.EditMode.AtomsAndBonds:
+		return get_selected_atoms().size() == dna_structure.get_valid_atoms_count() \
+			and get_selected_bonds().size() == dna_structure.get_valid_bonds_count()
+	else:
+		if workspace_context.get_edited_dna_spline_id() == dna_structure.int_guid:
+			return _selection_db.get_selected_dna_spline_countrol_points().size() == dna_structure.get_control_point_count()
+		return _selection_db.is_dna_spline_selected()
 
 
 func is_virtual_object_selected() -> bool:
@@ -298,6 +298,8 @@ func has_atom_selection(include_children: bool = true) -> bool:
 
 
 func is_empty() -> bool:
+	if nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
+		return false
 	if nano_structure is AtomicStructure:
 		return nano_structure.get_valid_atoms_count() == 0
 	return false

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -19,8 +19,6 @@ signal aborted_creating_object()
 signal object_tree_visibility_changed()
 signal atoms_relaxation_started()
 signal atoms_relaxation_finished(error_description_or_empty: String)
-signal dna_spline_edit_started(spline_context: StructureContext)
-signal dna_spline_edit_ended()
 # When simulaiton starts
 signal simulation_started()
 # When last frame of simulation is received, or user stops simulation without aborting it
@@ -90,7 +88,6 @@ var _current_structure_context_id: int
 #TODO: this is redundant
 var _modified_structure_contexts: Dictionary #[int, true]
 var _selection_modified_structure_contexts: Dictionary #[int, true]
-var _edited_dna_spline_id: int
 var _simulation: SimulationData = null
 var _is_simulation_playback_running: bool = false
 var _is_applying_simulation_state: bool = false
@@ -416,7 +413,6 @@ func set_current_structure_context(in_structure_context: StructureContext) -> vo
 		return
 	# Activating an object cancels create mode
 	abort_creating_object()
-	stop_editing_dna_spline()
 	workspace.active_structure_int_guid = in_structure_context.get_int_guid()
 	_current_structure_context_id = in_structure_context.get_int_guid()
 	current_structure_context_changed.emit(in_structure_context)
@@ -571,42 +567,25 @@ func peek_context_of_object_being_created(in_callback: Callable) -> bool:
 # # # # # #
 # # Edited DNA Spline
 func get_edited_dna_spline_id() -> int:
-	return _edited_dna_spline_id
+	var dna := get_current_structure_context().nano_structure as DnaStructure
+	if dna == null or dna.get_edit_mode() != DnaStructure.EditMode.SequenceAndPath:
+		return Workspace.INVALID_STRUCTURE_ID
+	return dna.int_guid
 
 
 func get_edited_dna_spline_context() -> StructureContext:
-	if _edited_dna_spline_id == Workspace.INVALID_STRUCTURE_ID:
+	var dna := get_current_structure_context().nano_structure as DnaStructure
+	if dna == null or dna.get_edit_mode() != DnaStructure.EditMode.SequenceAndPath:
 		return null
-	var structure_context: StructureContext = get_nano_structure_context_from_id(_edited_dna_spline_id)
-	assert(structure_context != null)
-	return structure_context
+	return get_current_structure_context()
 
 
 func start_editing_dna_spline(in_dna_id: int) -> void:
-	if in_dna_id == _edited_dna_spline_id:
+	if in_dna_id == get_edited_dna_spline_id():
 		return
 	assert(workspace.get_structure_by_int_guid(in_dna_id) is DnaStructure, "Invalid dna_id")
-	if _edited_dna_spline_id != Workspace.INVALID_STRUCTURE_ID:
-		_edited_dna_spline_id = Workspace.INVALID_STRUCTURE_ID
-		dna_spline_edit_ended.emit()
 	var structure_context: StructureContext = get_nano_structure_context_from_id(in_dna_id)
-	assert(structure_context != null)
-	_edited_dna_spline_id = in_dna_id
-	structure_context.set_dna_spline_selected(false)
-	get_rendering().notify_dna_path_being_edited(in_dna_id)
-	dna_spline_edit_started.emit(structure_context)
-	_emit_new_editable_structures()
-
-
-func stop_editing_dna_spline() -> void:
-	if _edited_dna_spline_id != Workspace.INVALID_STRUCTURE_ID:
-		var structure_context: StructureContext = get_edited_dna_spline_context()
-		_edited_dna_spline_id = Workspace.INVALID_STRUCTURE_ID
-		get_rendering().notify_dna_path_being_edited(Workspace.INVALID_STRUCTURE_ID)
-		_emit_new_editable_structures()
-		structure_context.set_dna_control_point_selection([])
-		structure_context.set_dna_spline_selected(true)
-		dna_spline_edit_ended.emit()
+	set_current_structure_context(structure_context)
 # # /Edited DNA Spline
 # # # # # #
 
@@ -934,7 +913,7 @@ func get_all_structure_contexts(in_include_empty_structures: bool = false) -> Ar
 	var result: Array[StructureContext] = []
 	for context: StructureContext in _structure_contexts.values():
 		var structure_has_data: bool = context.nano_structure.is_virtual_object() \
-				or context.nano_structure is DnaStructure \
+				or (context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath) \
 				or context.nano_structure.get_valid_atoms_count() > 0
 		if structure_has_data or in_include_empty_structures:
 			result.push_back(context)
@@ -947,7 +926,7 @@ func get_visible_structure_contexts(in_include_empty_structures: bool = false) -
 	for context: StructureContext in _structure_contexts.values():
 		if context.nano_structure.get_visible():
 			var structure_has_data: bool = context.nano_structure.is_virtual_object() \
-					or context.nano_structure is DnaStructure \
+					or (context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath) \
 					or context.nano_structure.get_valid_atoms_count() > 0
 			if structure_has_data or in_include_empty_structures:
 				result.push_back(context)
@@ -1146,9 +1125,6 @@ func get_atomic_structure_contexts_with_selection(in_include_empty_groups_with_s
 	var editable := get_editable_structure_contexts()
 	for structure_context: StructureContext in editable:
 		if structure_context.nano_structure.is_virtual_object():
-			continue
-		if structure_context.nano_structure is DnaStructure:
-			# TODO: add DNA structures during simulation?
 			continue
 		if structure_context.nano_structure.get_visible() and structure_context.has_selection(in_include_empty_groups_with_selected_subgroups):
 			result.push_back(structure_context)
@@ -1460,7 +1436,6 @@ func create_state_snapshot() -> Dictionary:
 	
 	snapshot["structure_contexts"] = structure_contexts
 	snapshot["_current_structure_context_id"] = _current_structure_context_id
-	snapshot["_edited_dna_spline_id"] = _edited_dna_spline_id
 	snapshot["_editable_structure_contexts_ids"] = _editable_structure_contexts_ids.duplicate()
 	snapshot["rendering_snapshot"] = get_rendering().create_state_snapshot()
 	
@@ -1494,7 +1469,6 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 		_selection_modified_structure_contexts.erase(structure_context_id)
 	
 	_current_structure_context_id = in_snapshot["_current_structure_context_id"]
-	_edited_dna_spline_id = in_snapshot["_edited_dna_spline_id"]
 	
 	get_rendering().apply_state_snapshot(in_snapshot["rendering_snapshot"])
 	_is_applying_snapshot = false

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -456,7 +456,6 @@ static func hide_selected_objects(out_workspace_context: WorkspaceContext) -> vo
 	if edited_dna_context != null:
 		if edited_dna_context.is_dna_structure_fully_selected():
 			structures_with_selection = [edited_dna_context]
-			out_workspace_context.stop_editing_dna_spline()
 		else:
 			out_workspace_context.workspace_main_view.editor_viewport_container.show_warning_in_message_bar(
 				out_workspace_context.tr(&"Cannot hide DNA spline control points"))
@@ -476,9 +475,9 @@ static func hide_selected_objects(out_workspace_context: WorkspaceContext) -> vo
 				atomic_structure.set_springs_visibility(springs_to_hide, false)
 			structure_context.set_anchor_selected(false)
 			structure_context.nano_structure.set_visible(false)
-		elif structure_context.nano_structure is DnaStructure and structure_context.is_dna_structure_fully_selected():
-			if out_workspace_context.get_edited_dna_spline_id() == structure_context.get_int_guid():
-				out_workspace_context.stop_editing_dna_spline()
+		elif structure_context.nano_structure is DnaStructure \
+				and structure_context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath \
+				and structure_context.is_dna_structure_fully_selected():
 			structure_context.set_dna_spline_selected(false)
 			structure_context.nano_structure.set_visible(false)
 		elif structure_context.nano_structure.is_virtual_object() and structure_context.is_virtual_object_selected():


### PR DESCRIPTION
DISCLAIMER: At the moment, attempting to create/delete atoms or other objects inside DNA group will crash with asserts, next PR will prevent all this stuff from happening

Task: Creating and Editing DNA

https://github.com/user-attachments/assets/882f81f3-717b-45ba-baeb-e55120e08ece

