### PR TITLE
Prevent creating/deleting/modifying atoms of DNA chains, while allowing locking/color-override/springs

### DIFF
--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -55,7 +55,16 @@ func copy(in_workspace_context: WorkspaceContext) -> void:
 			&"ParticleEmitter":
 				_copy_particle_emitter(structure_context, nano_structure, new_content)
 			&"DnaStructure":
-				_copy_dna_structure(structure_context, nano_structure, new_content)
+				var is_current: bool = in_workspace_context.get_current_structure_context().nano_structure == nano_structure
+				if nano_structure.get_edit_mode() == DnaStructure.EditMode.AtomsAndBonds and is_current:
+					_copy_selected_atoms(
+						structure_context, nano_structure, atom_selection, new_content
+					)
+					_copy_selected_springs(
+						structure_context, nano_structure, spring_selection, atom_selection, new_content
+					)
+				else:
+					_copy_dna_structure(structure_context, nano_structure, new_content)
 			_:
 				push_warning("Nano structure type not implemented for copy")
 	var root_group_id: int = -1
@@ -287,6 +296,11 @@ func paste(out_workspace_context: WorkspaceContext, in_auto_bond_order: int) -> 
 	var did_create_undo_action: bool = false
 	if out_workspace_context.get_current_structure_context() != null:
 		target_structure = out_workspace_context.get_current_structure_context().nano_structure
+	if target_structure is DnaStructure:
+		out_workspace_context.get_editor_viewport_container().show_warning_in_message_bar(
+			tr("Cannot paste atoms and objects inside a DNA structure.")
+		)
+		return
 	var original_to_new_structure_id: Dictionary = {
 	#	old_id<int> = new_id<int>
 	}

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_bonds_panel.gd
@@ -20,6 +20,8 @@ func _ready() -> void:
 
 func should_show(in_workspace_context: WorkspaceContext) -> bool:
 	_ensure_initialized(in_workspace_context)
+	if not in_workspace_context.get_current_structure_context().nano_structure.can_create_and_delete_atoms():
+		return false
 	return in_workspace_context.create_object_parameters.get_create_mode_type() \
 			== CreateObjectParameters.CreateModeType.CREATE_ATOMS_AND_BONDS
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_atoms_and_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_atoms_and_bonds_panel.gd
@@ -12,6 +12,8 @@ func should_show(in_workspace_context: WorkspaceContext) -> bool:
 	if !is_instance_valid(structure_context) || !is_instance_valid(structure_context.nano_structure):
 		return false
 	_workspace_context = in_workspace_context
+	if not in_workspace_context.get_current_structure_context().nano_structure.can_create_and_delete_atoms():
+		return false
 	if in_workspace_context.create_object_parameters.get_create_mode_type() \
 			!= CreateObjectParameters.CreateModeType.CREATE_ATOMS_AND_BONDS:
 		return false

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_docker.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_docker.gd
@@ -13,6 +13,17 @@ const _CREATE_OBJECT_CONTROLS: Dictionary = {
 				"res://editor/controls/dockers/workspace_docker/a_create_docker/controls/create_mode_picker.tscn"
 			]
 		},
+	&"Uneditable DNA Chain":
+		{
+			icon = "",
+			header = false,
+			scroll = false,
+			collapse = false,
+			start_collapsed = false,
+			controls = [
+				"res://editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.tscn"
+			]
+		},
 	&"Atoms and Bonds Parameters":
 		{
 			icon = "uid://df8has67xkedj",

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.gd
@@ -30,6 +30,7 @@ func should_show(in_workspace_context: WorkspaceContext) -> bool:
 		return false
 	_ensure_initialized(in_workspace_context)
 	
+	
 	var check_object_being_created: Callable = func(in_struct: NanoStructure) -> bool:
 		return in_struct is NanoParticleEmitter
 	
@@ -38,6 +39,9 @@ func should_show(in_workspace_context: WorkspaceContext) -> bool:
 		if in_workspace_context.is_creating_object() and \
 				in_workspace_context.peek_object_being_created(check_object_being_created):
 			in_workspace_context.abort_creating_object()
+		return false
+	
+	if not structure_context.nano_structure.can_create_and_delete_atoms():
 		return false
 	
 	if in_workspace_context.is_creating_object() and \
@@ -174,6 +178,20 @@ func _on_create_from_small_molecules_pressed() -> void:
 
 func _on_small_molecules_picker_molecule_selected(in_path: String, _in_preview: Texture2D) -> void:
 	assert(is_instance_valid(_workspace_context))
+	var parent_context: StructureContext = _workspace_context.get_current_structure_context()
+	if parent_context.nano_structure is DnaStructure:
+		var promise: Promise = _workspace_context.show_warning_dialog(
+			tr("Creating a Particle Emitter as child of a DNA Chain is not allowed.\n"+
+				"This is because particle emitters creates atoms in their parent group, and DNA Chains dont support this."),
+			tr("Create as sibling"), tr("Abort")
+		)
+		await promise.wait_for_fulfill()
+		if promise.get_result() == false:
+			# Aborted
+			return
+		parent_context = _workspace_context.get_nano_structure_context_from_id(parent_context.nano_structure.int_parent_guid)
+		_workspace_context.set_current_structure_context(parent_context)
+	
 	var unpacked_mol_path: String = WorkspaceUtils.unpack_mol_file_and_get_path(in_path)
 	var absolute_path: String = ProjectSettings.globalize_path(unpacked_mol_path)
 	var template: NanoStructure = await WorkspaceUtils.get_nano_structure_from_file(_workspace_context, absolute_path, false, false, false)

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_particle_emitter_panel.tscn
@@ -17,10 +17,10 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 bbcode_enabled = true
-text = "[center]ℹ Selection must be part of the active group, and have fully selected molecules[/center]"
+text = "[center]ℹ Selection must be part of the active group, and fully selected molecules, and not belong to a DNA Chain[/center]"
 fit_content = true
 script = ExtResource("3_vh652")
-message = &"Selection must be part of the active group, and have fully selected molecules"
+message = &"Selection must be part of the active group, and fully selected molecules, and not belong to a DNA Chain"
 effect = "none"
 metadata/_custom_type_script = "uid://3hjuxktmfb16"
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.gd
@@ -1,0 +1,12 @@
+extends DynamicContextControl
+
+
+func should_show(in_workspace_context: WorkspaceContext) -> bool:
+	if not in_workspace_context.create_object_parameters.get_create_mode_type() in [
+			CreateObjectParameters.CreateModeType.CREATE_ATOMS_AND_BONDS,
+			CreateObjectParameters.CreateModeType.CREATE_PARTICLE_EMITTERS,
+		]:
+		return false
+	if not in_workspace_context.get_current_structure_context().nano_structure.can_create_and_delete_atoms():
+		return true
+	return false

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.gd.uid
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.gd.uid
@@ -1,0 +1,1 @@
+uid://bjmqv00gts6mu

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://b8vqayn2i3ske"]
+
+[ext_resource type="Script" uid="uid://bjmqv00gts6mu" path="res://editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.gd" id="1_qbfyo"]
+[ext_resource type="PackedScene" uid="uid://b2b25o2443x3b" path="res://editor/controls/general/info_label.tscn" id="2_4oxem"]
+
+[node name="UneditableAtomsWarning" type="MarginContainer"]
+offset_right = 276.0
+offset_bottom = 30.0
+script = ExtResource("1_qbfyo")
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+layout_mode = 2
+theme_type_variation = &"PanelContainerCrystal"
+
+[node name="InfoLabel" parent="PanelContainer" instance=ExtResource("2_4oxem")]
+layout_mode = 2
+text = "[center]ℹ Dna Chains cannot add, remove, or modify atoms and bonds[/center]"
+message = &"Dna Chains cannot add, remove, or modify atoms and bonds"
+effect = "none"

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.gd
@@ -6,6 +6,7 @@ const _METADATA_ID_ELEMENT: int = 1
 
 
 @onready var _tree: Tree = %Tree
+@onready var _immutable_atoms_info_label: InfoLabel = %ImmutableAtomsInfoLabel
 @onready var _selection_description: Label = %SelectionDescription
 @onready var _button_change_to: Button = %ButtonChangeTo
 @onready var _element_picker_popup: CompactElementPickerPopup = %CompactElementPickerPopup
@@ -65,6 +66,8 @@ func _on_element_picker_atom_type_change_requested(in_to_element: int) -> void:
 	var selected_contexts: Array[StructureContext] =  \
 			_workspace_context.get_structure_contexts_with_selection()
 	for context in selected_contexts:
+		if context.nano_structure.can_create_and_delete_atoms() == false:
+			continue
 		var should_change_callback: Callable = func(atom_id: int) -> bool:
 			var element: int = context.nano_structure.atom_get_atomic_number(atom_id)
 			return element in elements_to_change
@@ -153,12 +156,19 @@ func _refresh_target_list() -> void:
 	
 	var selected_contexts: Array[StructureContext] =  \
 			_workspace_context.get_structure_contexts_with_selection()
+	var has_immutable_objects: bool = false
 	for context in selected_contexts:
+		if context.nano_structure is AtomicStructure and context.nano_structure.can_create_and_delete_atoms() == false:
+			if context.get_selected_atoms().size():
+				has_immutable_objects = true
+			continue
 		var atoms: PackedInt32Array = context.get_selected_atoms()
 		total += atoms.size()
 		for atom_id in atoms:
 			var element: int = context.nano_structure.atom_get_atomic_number(atom_id)
 			per_element_count[element] = per_element_count.get(element, 0) + 1
+	
+	_immutable_atoms_info_label.visible = has_immutable_objects
 	
 	_tree.clear()
 	var item_all: TreeItem = _tree.create_item()

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://df1wehgky7mt5"]
+[gd_scene load_steps=4 format=3 uid="uid://df1wehgky7mt5"]
 
 [ext_resource type="Script" uid="uid://dxgv6t3xlxtfv" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.gd" id="1_538ej"]
+[ext_resource type="PackedScene" uid="uid://b2b25o2443x3b" path="res://editor/controls/general/info_label.tscn" id="2_gt1e4"]
 [ext_resource type="PackedScene" uid="uid://dyadiqebvvyti" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/compact_element_picker_popup.tscn" id="2_pru4w"]
 
 [node name="ChangeAtomType" type="VBoxContainer"]
@@ -18,6 +19,12 @@ layout_mode = 2
 hide_folding = true
 select_mode = 1
 scroll_horizontal_enabled = false
+
+[node name="ImmutableAtomsInfoLabel" parent="." instance=ExtResource("2_gt1e4")]
+unique_name_in_owner = true
+layout_mode = 2
+text = "[center][shake start=4 length=14 freq=0.5 sat=0.8 val=0.8 connected=1]ℹ[/shake] Some selected atoms belong to an immutable structure and won't be affected[/center]"
+message = &"Some selected atoms belong to an immutable structure and won\'t be affected"
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
@@ -37,6 +44,7 @@ text = "No Atoms selected"
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
+theme_type_variation = &"CrystalButton"
 text = "Change To ..."
 
 [node name="CompactElementPickerPopup" parent="." instance=ExtResource("2_pru4w")]

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_bond_type.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_bond_type.gd
@@ -1,6 +1,7 @@
 extends DynamicContextControl
 
 
+var _immutable_atoms_info_label: InfoLabel
 var _label_describe_change: Label = null
 var _button_single: Button = null
 var _button_double: Button = null
@@ -12,6 +13,7 @@ var _workspace_context: WorkspaceContext
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_SCENE_INSTANTIATED:
+		_immutable_atoms_info_label = %ImmutableAtomsInfoLabel as InfoLabel
 		_label_describe_change = %LabelDescribeChange
 		_button_single = %ButtonSingle as Button
 		_button_double = %ButtonDouble as Button
@@ -60,11 +62,21 @@ func _on_rendering_representation_changed() -> void:
 func _update_availability() -> void:
 	var representation: Rendering.Representation = _workspace_context.workspace.representation_settings.get_rendering_representation()
 	var representation_allows_editing: bool = representation != Rendering.Representation.STICKS
-	var selected_count: int = _get_count_selected()
+	var selected_count: int = 0
+	var has_immutable_objects: bool = false
+	if _workspace_context != null:
+		var selected_contexts: Array[StructureContext] = _workspace_context.get_structure_contexts_with_selection()
+		for context in selected_contexts:
+			if context.nano_structure is AtomicStructure and context.nano_structure.can_create_and_delete_atoms() == false:
+				if context.get_selected_bonds().size():
+					has_immutable_objects = true
+				continue
+			selected_count += context.get_selected_bonds().size()
 	var can_be_edited_by_user: bool = selected_count > 0 and representation_allows_editing
 	_button_single.disabled = not can_be_edited_by_user
 	_button_double.disabled = not can_be_edited_by_user
 	_button_triple.disabled = not can_be_edited_by_user
+	_immutable_atoms_info_label.visible = has_immutable_objects
 	
 	if not representation_allows_editing:
 		_label_describe_change.text = tr(&"Cannot change bond order in Sticks representation")
@@ -74,20 +86,12 @@ func _update_availability() -> void:
 		_label_describe_change.text = tr(&"Change {0} selected Bonds to...").format([selected_count])
 
 
-func _get_count_selected() -> int:
-	var selected_count: int = 0
-	if _workspace_context == null:
-		return selected_count
-	var selected_contexts: Array[StructureContext] = _workspace_context.get_structure_contexts_with_selection()
-	for context in selected_contexts:
-		selected_count += context.get_selected_bonds().size()
-	return selected_count
-
-
 func _change_order_of_selected_atoms(in_selected_bond_order: int) -> void:
 	EditorSfx.mouse_down()
 	var selected_contexts: Array[StructureContext] = _workspace_context.get_structure_contexts_with_selection()
 	for context in selected_contexts:
+		if context.nano_structure is AtomicStructure and context.nano_structure.can_create_and_delete_atoms() == false:
+			continue
 		var selected_bonds: PackedInt32Array = context.get_selected_bonds()
 		if selected_bonds.size() == 0:
 			continue

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_bond_type.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_bond_type.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=12 format=3 uid="uid://bib8sjgo2kpy"]
+[gd_scene load_steps=13 format=3 uid="uid://bib8sjgo2kpy"]
 
 [ext_resource type="Script" uid="uid://vjen2iwyobnq" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_bond_type.gd" id="1_37twa"]
+[ext_resource type="PackedScene" uid="uid://b2b25o2443x3b" path="res://editor/controls/general/info_label.tscn" id="2_6fp1r"]
 [ext_resource type="Texture2D" uid="uid://qn5bgnygn1jt" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/icons/icon_BondSingle.svg" id="2_l3kpj"]
 [ext_resource type="Texture2D" uid="uid://bsqgf1craj03i" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/icons/icon_BondDouble.svg" id="3_qi1vk"]
 [ext_resource type="Texture2D" uid="uid://bmw5i4fv44r1s" path="res://editor/controls/dockers/workspace_docker/a_create_docker/controls/icons/icon_BondTriple.svg" id="4_j3y1c"]
@@ -39,12 +40,17 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_37twa")
 
+[node name="ImmutableAtomsInfoLabel" parent="." instance=ExtResource("2_6fp1r")]
+unique_name_in_owner = true
+layout_mode = 2
+text = "[center][shake start=4 length=14 freq=0.5 sat=0.8 val=0.8 connected=1]ℹ[/shake] Some selected bonds belong to an immutable structure and won't be affected[/center]"
+message = &"Some selected bonds belong to an immutable structure and won\'t be affected"
+
 [node name="LabelDescribeChange" type="Label" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-text = "Change All {0} Selected Bonds
-"
+text = "Change All {0} Selected Bonds"
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 layout_mode = 2

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
@@ -85,7 +85,7 @@ func _set_tracked_structure(in_structure_or_null: DnaStructure) -> void:
 	if _tracked_structure != null:
 		_tracked_structure.sequence_changed.disconnect(_on_tracked_structure_sequence_changed)
 	_tracked_structure = in_structure_or_null
-	if _tracked_structure != null:
+	if _tracked_structure != null and not _tracked_structure.sequence_changed.is_connected(_on_tracked_structure_sequence_changed):
 		_tracked_structure.sequence_changed.connect(_on_tracked_structure_sequence_changed)
 	_update_ui()
 
@@ -129,21 +129,36 @@ func _on_edit_mode_button_group_pressed(in_button: Button) -> void:
 	if mode == _tracked_structure.get_edit_mode():
 		# Re-selected the already selected mode, nothing to do here
 		return
+	var ctx: StructureContext = _workspace_context.get_structure_context(_tracked_structure.int_guid)
 	match mode:
 		DnaStructure.EditMode.SequenceAndPath:
+			var locked_atoms_count: int = _tracked_structure.get_locked_atoms().size()
+			var color_overrides_count: int = _tracked_structure.get_color_overrides().size()
+			var springs_count: int = _tracked_structure.springs_count()
+			var msg: String = (
+				tr("This is a destructive operation and any modification to the atoms will be discarded.\n") +
+				tr("  · Positions of atoms will reset\n") +
+				(tr("  · %d Springs will will be deleted.\n") % springs_count if springs_count > 0 else "") +
+				(tr("  · %d atoms will lose it's 'Locking' state.\n") % locked_atoms_count if locked_atoms_count > 0 else "") +
+				(tr("  · %d Atoms will lose it's color override.\n") % color_overrides_count if color_overrides_count > 0 else "") + 
+				tr("\nDo you want to proceed?")
+			)
 			var promise: Promise = _workspace_context.show_warning_dialog(
-				tr("Any modification in position of the atoms will be discarded with this operation.\n"+
-				"Do you want to proceed?"), tr("Continue"), tr("Cancel"))
+				msg, tr("Continue"), tr("Cancel"))
 			await promise.wait_for_fulfill()
 			if promise.get_result() == false:
+				_edit_path_button.set_pressed_no_signal(false)
+				_edit_atoms_button.set_pressed_no_signal(true)
 				return
 			_workspace_context.get_structure_context(_tracked_structure.get_int_guid()).set_dna_spline_selected(false)
 			_tracked_structure.set_edit_mode(DnaStructure.EditMode.SequenceAndPath)
 			_setup_animation_player.play(&"setup_edit_path")
+			ctx.select_all()
 			_workspace_context.snapshot_moment("DNA Structure: edit Path and Sequence")
 		DnaStructure.EditMode.AtomsAndBonds:
 			_tracked_structure.set_edit_mode(DnaStructure.EditMode.AtomsAndBonds)
 			_setup_animation_player.play(&"setup_edit_atoms")
+			ctx.select_all()
 			_workspace_context.snapshot_moment("DNA Structure: show Atoms and Bonds")
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/inspector_controls/inspector_control_bond_order/inspector_control_bond_order.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/inspector_controls/inspector_control_bond_order/inspector_control_bond_order.gd
@@ -50,7 +50,7 @@ func _on_rendering_representation_changed(in_representation: Rendering.Represent
 
 func _update_availability(in_representation: Rendering.Representation) -> void:
 	var can_be_edited_by_user: bool = in_representation != Rendering.Representation.STICKS
-	_option_button.disabled = not can_be_edited_by_user
+	_option_button.disabled = (not can_be_edited_by_user) or (not _is_editable)
 
 
 func is_editable() -> bool:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
@@ -118,7 +118,12 @@ func _update_selected_info() -> void:
 			item.set_text(1, str(total_anchors_selected))
 	# 2. Second pass for details
 	for context in selected_structures:
-		var selection_info: Dictionary = SelectionInfo.create_selection_info(context, SelectionInfo.Type.READ_WRITE_PROPERTIES)
+		var type: SelectionInfo.Type = (
+			SelectionInfo.Type.READ_WRITE_PROPERTIES
+			if not context.nano_structure is AtomicStructure or context.nano_structure.can_create_and_delete_atoms() else
+			SelectionInfo.Type.READ_ONLY_PROPERTIES
+		)
+		var selection_info: Dictionary = SelectionInfo.create_selection_info(context, type)
 		var structure_root: TreeItem = _tree_info.create_item(root)
 		structure_root.set_text(0, context.nano_structure.get_structure_name())
 		structure_root.set_icon(0, context.nano_structure.get_icon())

--- a/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
@@ -21,7 +21,7 @@ func handles_structure_context(in_structure_context: StructureContext) -> bool:
 	if in_structure_context.workspace_context.is_creating_object():
 		# Make sure we abort creating shapes, motors, small molecules, etc
 		in_structure_context.workspace_context.abort_creating_object()
-	return in_structure_context.nano_structure is AtomicStructure
+	return in_structure_context.nano_structure is AtomicStructure and in_structure_context.nano_structure.can_create_and_delete_atoms()
 
 
 func handle_inputs_end() -> void:
@@ -33,6 +33,7 @@ func handle_inputs_resume() -> void:
 	var structure_context: StructureContext = workspace_context.get_current_structure_context()
 	var parameters: CreateObjectParameters = workspace_context.create_object_parameters
 	if parameters.get_create_mode_type() != CreateObjectParameters.CreateModeType.CREATE_ATOMS_AND_BONDS \
+			or not get_workspace_context().get_current_structure_context().nano_structure.can_create_and_delete_atoms() \
 			or not parameters.get_create_mode_enabled():
 		return
 	update_preview_position()

--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -32,7 +32,7 @@ func handles_structure_context(in_structure_context: StructureContext) -> bool:
 	if in_structure_context.workspace_context.is_creating_object():
 		# Make sure we abort creating shapes, motors, small molecules, etc
 		in_structure_context.workspace_context.abort_creating_object()
-	return in_structure_context.nano_structure is AtomicStructure
+	return in_structure_context.nano_structure is AtomicStructure and in_structure_context.nano_structure.can_create_and_delete_atoms()
 
 
 func handle_inputs_end() -> void:
@@ -266,6 +266,12 @@ func _update_candidates() -> void:
 	_candidates = []
 	
 	var context: StructureContext = _workspace_context.get_current_structure_context()
+	
+	if not context.nano_structure.can_create_and_delete_atoms():
+		_get_rendering().atom_autopose_preview_set_candidates(_candidates)
+		_candidates_dirty = false
+		return
+	
 	var total_atoms_selected: int = context.get_selected_atoms().size()
 	var max_candidates: int = MolecularEditorContext.msep_editor_settings.editor_max_atom_candidates
 	if total_atoms_selected > max_candidates:

--- a/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
@@ -22,7 +22,7 @@ func handles_structure_context(in_structure_context: StructureContext) -> bool:
 	var workspace_context: WorkspaceContext = in_structure_context.workspace_context
 	if workspace_context.is_creating_object():
 		workspace_context.abort_creating_object()
-	return true
+	return in_structure_context.nano_structure.can_create_and_delete_atoms()
 
 
 func handle_inputs_end() -> void:
@@ -32,6 +32,7 @@ func handle_inputs_end() -> void:
 func handle_inputs_resume() -> void:
 	var parameters: CreateObjectParameters = get_workspace_context().create_object_parameters
 	if parameters.get_create_mode_type() != CreateObjectParameters.CreateModeType.CREATE_ANCHORS_AND_SPRINGS \
+			or not get_workspace_context().get_current_structure_context().nano_structure.can_create_and_delete_atoms() \
 			or not parameters.get_create_mode_enabled():
 		return
 	update_preview_position()

--- a/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
@@ -31,6 +31,8 @@ func handles_structure_context(in_structure_context: StructureContext) -> bool:
 	if parameters.get_create_mode_type() != CreateObjectParameters.CreateModeType.CREATE_FRAGMENT:
 		return false
 	
+	if not _workspace_context.get_current_structure_context().nano_structure.can_create_and_delete_atoms():
+		return false
 	var new_structure: NanoStructure = parameters.get_new_structure()
 	var is_creating_another_object: Callable = func(in_nano_structure: NanoStructure) -> bool:
 			return in_nano_structure != new_structure
@@ -114,6 +116,7 @@ func handle_inputs_end() -> void:
 func handle_inputs_resume() -> void:
 	var parameters: CreateObjectParameters = get_workspace_context().create_object_parameters
 	if parameters.get_create_mode_type() != CreateObjectParameters.CreateModeType.CREATE_FRAGMENT \
+			or not get_workspace_context().get_current_structure_context().nano_structure.can_create_and_delete_atoms() \
 			or not parameters.get_create_mode_enabled():
 		return
 	update_preview_position()

--- a/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
@@ -51,7 +51,7 @@ func handles_structure_context(in_structure_context: StructureContext) -> bool:
 	if workspace_context.is_creating_object():
 		workspace_context.abort_creating_object()
 		return false
-	return true
+	return workspace_context.get_current_structure_context().nano_structure.can_create_and_delete_atoms()
 
 
 func handle_inputs_end() -> void:
@@ -443,12 +443,6 @@ func _create_spring(in_atomic_struct: NanoStructure, in_anchor_id: int, in_atom_
 			in_params.get_spring_equilibrium_length_is_auto(), in_params.get_spring_equilibrium_manual_length())
 	in_atomic_struct.end_edit()
 	return spring_id
-
-
-func _revalidate_spring(in_atomic_struct: NanoStructure, in_spring_id_to_revalidate: int) -> void:
-	in_atomic_struct.start_edit()
-	in_atomic_struct.spring_revalidate(in_spring_id_to_revalidate)
-	in_atomic_struct.end_edit()
 
 
 func _select_spring(structure_context: StructureContext, in_spring_id_to_select: int) -> void:

--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -104,6 +104,7 @@ func build(in_workspace_context: WorkspaceContext, in_structure: DnaStructure) -
 	_updating_parameters = false
 	_update_bases()
 	_ensure_structure_signal_connections(in_structure)
+	_update_visibility()
 
 
 func _enter_tree() -> void:

--- a/godot_project/editor/ring_menu_levels/atoms/ring_action_add_hydrogens.gd
+++ b/godot_project/editor/ring_menu_levels/atoms/ring_action_add_hydrogens.gd
@@ -34,7 +34,9 @@ func _validate() -> bool:
 	if selected_contexts.is_empty():
 		# No Selection, try with all visible objects
 		for context in _workspace_context.get_visible_structure_contexts():
-			if context.nano_structure is AtomicStructure and context.nano_structure.get_valid_atoms_count() > 0:
+			if context.nano_structure is AtomicStructure \
+					and context.nano_structure.can_create_and_delete_atoms() \
+					and context.nano_structure.get_valid_atoms_count() > 0:
 				return true
 			# No visible objects, cannot execute
 		return false
@@ -60,6 +62,8 @@ func _execute_action() -> void:
 	for context in target_structures:
 		if not context.nano_structure is AtomicStructure:
 			continue
+		if context.nano_structure.can_create_and_delete_atoms() == false:
+			continue
 		var new_atoms_selection: PackedInt32Array = context.get_selected_atoms()
 		var new_bonds_selection: PackedInt32Array = context.get_selected_bonds()
 		var atoms_to_check: PackedInt32Array = []
@@ -78,9 +82,10 @@ func _execute_action() -> void:
 		
 		context.set_atom_selection(new_atoms_selection)
 		context.set_bond_selection(new_bonds_selection)
-		
-	hydrogen_atoms_count_changed.emit(delta_hydrogens.added, delta_hydrogens.removed)
-	_workspace_context.snapshot_moment(tr("Correct Hydrogens"))
+	
+	if delta_hydrogens.added > 0 or delta_hydrogens.removed > 0:
+		hydrogen_atoms_count_changed.emit(delta_hydrogens.added, delta_hydrogens.removed)
+		_workspace_context.snapshot_moment(tr("Correct Hydrogens"))
 
 
 func _complete_atom_valence(

--- a/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
+++ b/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
@@ -35,6 +35,17 @@ func _execute_action() -> void:
 	var selected_structures_contexts: Array[StructureContext] = \
 			_workspace_context.get_structure_contexts_with_selection()
 	_did_create_undo_action = false
+	for context in selected_structures_contexts:
+		if context.nano_structure is AtomicStructure and not context.nano_structure.can_create_and_delete_atoms():
+			if context.is_fully_selected():
+				# will delete the entire group
+				continue
+			var has_atom_bond_selection: bool = context.get_selected_atoms().size() + context.get_selected_bonds().size() > 0
+			if has_atom_bond_selection:
+				_workspace_context.get_editor_viewport_container().show_warning_in_message_bar(
+					tr("Cannot delete selected atoms and bonds, The structure containing them does not support being modified")
+				)
+				return
 	var deleted_structures_contexts: Array[StructureContext] = []
 	for context in selected_structures_contexts:
 		_delete_selection_of_structure(context, deleted_structures_contexts)

--- a/godot_project/project_workspace/structs/atomic_structure.gd
+++ b/godot_project/project_workspace/structs/atomic_structure.gd
@@ -178,6 +178,11 @@ func _update_springs_moved_queue() -> void:
 #endregion: Edit tracking
 
 
+## Some auto-generated structures, (like dna chains) wont allow to manually add and remove atoms
+func can_create_and_delete_atoms() -> bool:
+	return true
+
+
 ## Returns number of atoms that has been created in this NanoStructure
 ## and have not been removed.
 func get_valid_atoms_count() -> int:
@@ -508,11 +513,6 @@ func spring_has(_in_spring_id: int) -> bool:
 
 
 func spring_invalidate(_in_spring_id: int) -> void:
-	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
-	return
-
-
-func spring_revalidate(_in_spring_id: int) -> void:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
 	return
 

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -27,7 +27,6 @@ const INVALID_CONTROL_POINT_IDX: int = -1
 @export var _twists_offset_radians: float
 @export var _sequence: String
 @export var _parameters: DnaStructureParameters
-@export var _color_overrides: Dictionary[int, Color] = {}
 @export var _edit_mode := EditMode.SequenceAndPath
 
 # Atoms and Bases caches
@@ -38,6 +37,7 @@ var _atoms_cache: Dictionary[int, AtomData] = {}
 var _bonds_count_cache: int = -1
 var _bonds_ids_cache: Dictionary[Strand, PackedInt32Array] = {}
 var _bonds_cache: Dictionary[int, Vector3i]
+var _highest_spring_id: int = -1
 static var _unpacked_atom_ids: Dictionary[int, UnpackedAtomId]
 static var _unpacked_bond_ids: Dictionary[int, UnpackedBondId]
 
@@ -47,6 +47,9 @@ var _signal_queue_path_changed: bool = false
 var _signal_queue_parameters_changed: bool = false
 var _baked_path: PackedVector3Array = []
 
+@export var _springs: Dictionary = {
+	# id<int> : NanoSpring
+}
 @export var _motor_links: Dictionary[int, int] = {
 	# atom_id<int> : motor_id<int>
 }
@@ -115,8 +118,15 @@ func set_edit_mode(in_mode: EditMode) -> void:
 		# Atoms and bonds has been removed
 		var atoms_to_signal: PackedInt32Array = get_valid_atoms()
 		var bonds_to_signal: PackedInt32Array = get_valid_bonds()
+		var springs_to_remove: PackedInt32Array = _springs.keys()
 		_edit_mode = in_mode
 		_atoms_cache = {}
+		_atoms_count_cache = -1
+		_bonds_count_cache = -1
+		_springs.clear()
+		locked_atoms = {}
+		color_overrides = {}
+		springs_removed.emit(springs_to_remove)
 		atoms_removed.emit(atoms_to_signal)
 		bonds_removed.emit(bonds_to_signal)
 		# TODO: Track springs? locked atoms? color overrides?
@@ -125,6 +135,8 @@ func set_edit_mode(in_mode: EditMode) -> void:
 	elif in_mode == EditMode.AtomsAndBonds:
 		# Atoms and bonds added back
 		_edit_mode = in_mode
+		_atoms_count_cache = -1
+		_bonds_count_cache = -1
 		var atoms_to_signal: PackedInt32Array = get_valid_atoms()
 		var bonds_to_signal: PackedInt32Array = get_valid_bonds()
 		atoms_added.emit(atoms_to_signal)
@@ -443,6 +455,12 @@ func _adjust_sequence_to_path_length() -> void:
 
 
 #region: Atoms and Bonds
+## DNA Structure does not allow creating, removing, or modifying atoms and bonds
+## so this function always returns false
+func can_create_and_delete_atoms() -> bool:
+	return false
+
+
 ## Returns number of atoms that has been created in this NanoStructure
 func get_valid_atoms_count() -> int:
 	assert(not _is_being_edited, "I'm being edited, performing operations on atoms in this state is unrecommended")
@@ -602,18 +620,6 @@ func atoms_set_positions(in_atoms: PackedInt32Array, in_positions: PackedVector3
 		atom_set_position(in_atoms[i], in_positions[i])
 
 
-
-## Returns true if the atom is locked
-func atom_is_locked(_in_atom_id: int) -> bool:
-	# TBD: can this feature be supported?
-	return false
-
-
-## Returns an array with the IDs of all locked atoms
-func get_locked_atoms() -> PackedInt32Array:
-	return PackedInt32Array() # PackedInt32Array(locked_atoms.keys())
-
-
 ## returns IDs of the bonds that given atom is participating in
 func atom_get_bonds(in_atom_id: int) -> PackedInt32Array:
 	var result := PackedInt32Array()
@@ -716,24 +722,6 @@ func atoms_count_visible_by_type(types_to_count: PackedInt32Array) -> int:
 		if atom.atomic_number in types_to_count and is_atom_visible(atom_id):
 			count += 1
 	return count
-
-
-func set_color_override(in_atoms: PackedInt32Array, color: Color) -> void:
-	assert(_is_being_edited, "Color override can only be changed while structure is being edited")
-	assert(_edit_mode == EditMode.AtomsAndBonds, "Atoms and Bonds cannot be edited in this mode")
-	for atom_id: int in in_atoms:
-		_color_overrides[atom_id] = color
-	_signal_queue_atoms_color_changed.append_array(in_atoms)
-
-
-func get_color_overrides() -> Dictionary:
-	return _color_overrides.duplicate()
-
-
-func remove_color_override(in_atoms: PackedInt32Array) -> void:
-	assert(_is_being_edited, "Color override can only be changed while structure is being edited")
-	assert(_edit_mode == EditMode.AtomsAndBonds, "Atoms and Bonds cannot be edited in this mode")
-	super.remove_color_override(in_atoms)
 
 
 ## UNUSED
@@ -865,15 +853,16 @@ func get_valid_bonds_count() -> int:
 		return 0
 	
 	if _bonds_count_cache == -1:
+		const GLUE_BOND = 1
 		var base_count: Dictionary[String, int] = {
-			"A" : DnaBuilder.get_template_bond_count("A", _parameters.include_hydrogens),
-			"T" : DnaBuilder.get_template_bond_count("T", _parameters.include_hydrogens),
-			"G" : DnaBuilder.get_template_bond_count("G", _parameters.include_hydrogens),
-			"C" : DnaBuilder.get_template_bond_count("C", _parameters.include_hydrogens),
+			"A" : DnaBuilder.get_template_bond_count("A", _parameters.include_hydrogens) + GLUE_BOND,
+			"T" : DnaBuilder.get_template_bond_count("T", _parameters.include_hydrogens) + GLUE_BOND,
+			"G" : DnaBuilder.get_template_bond_count("G", _parameters.include_hydrogens) + GLUE_BOND,
+			"C" : DnaBuilder.get_template_bond_count("C", _parameters.include_hydrogens) + GLUE_BOND,
 			"X" : 0,
 			"B" : DnaBuilder.get_template_bond_count("backbone0", _parameters.include_hydrogens)
 		}
-		_bonds_count_cache = base_count["B"] * _sequence.length()
+		_bonds_count_cache = (base_count["B"] + GLUE_BOND) * _sequence.length() - GLUE_BOND
 		if get_strand_policy() == StrandPolicy.DOUBLE:
 			# account for both backbones
 			_bonds_count_cache *= 2
@@ -1012,143 +1001,193 @@ static func _is_glue_bond_id(in_bond_id: int) -> bool:
 
 
 #region: Anchors and Springs
-func spring_create(_in_anchor_id: int, _in_atom_id: int, _in_spring_constant_force: float,
-			_is_equilibrium_length_automatic: bool, _in_equilibrium_manual_length: float) -> int:
-	if _edit_mode == EditMode.SequenceAndPath:
-		return INVALID_SPRING_ID
-	# TDB: Support springs?
-	return INVALID_SPRING_ID
+func spring_create(in_anchor_id: int, in_atom_id: int, in_spring_constant_force: float,
+			is_equilibrium_length_automatic: bool, in_equilibrium_manual_length: float) -> int:
+	assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Cannot edit springs in this mode")
+	_highest_spring_id += 1
+	_springs[_highest_spring_id] = NanoSpring.create(in_anchor_id, in_atom_id, in_spring_constant_force,
+			is_equilibrium_length_automatic, in_equilibrium_manual_length)
+	_signal_queue_springs_added.append(_highest_spring_id)
+	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
+	var anchor: NanoVirtualAnchor = workspace.get_structure_by_int_guid(in_anchor_id)
+	_springs[_highest_spring_id].anchor_is_visible = anchor.get_visible()
+	anchor.handle_spring_added(self, _highest_spring_id)
+	if not anchor.position_changed.is_connected(_on_anchor_position_change):
+		anchor.position_changed.connect(_on_anchor_position_change.bind(anchor))
+	if not anchor.visibility_changed.is_connected(_on_anchor_visibility_changed.bind(anchor)):
+		anchor.visibility_changed.connect(_on_anchor_visibility_changed.bind(anchor))
+	if not _atoms_to_related_springs.has(in_atom_id):
+		_atoms_to_related_springs[in_atom_id] = Dictionary()
+	_atoms_to_related_springs[in_atom_id][_highest_spring_id] = true
+	return _highest_spring_id
 
 
-func spring_has(_in_spring_id: int) -> bool:
+func _on_anchor_position_change(_in_position: Vector3, in_anchor: NanoVirtualAnchor) -> void:
+	var moved_springs: PackedInt32Array = in_anchor.get_related_springs(int_guid)
+	for related_spring_id: int in moved_springs:
+		if spring_is_visible(related_spring_id):
+			_signal_queue_springs_moved[related_spring_id] = true
+	ScriptUtils.call_deferred_once(_ensure_edit_queue_flushed)
+
+
+func _on_anchor_visibility_changed(in_is_visible: bool, in_anchor: NanoVirtualAnchor) -> void:
+	var changed_springs: PackedInt32Array = in_anchor.get_related_springs(int_guid)
+	for related_spring_id: int in changed_springs:
+		_springs[related_spring_id].anchor_is_visible = in_is_visible
+	springs_visibility_changed.emit(changed_springs)
+
+
+func _ensure_edit_queue_flushed() -> void:
+	# Workaround, there are two scenarios:
+	# 1. User drags only anchors, in this scenario springs_moved signal will be emitted  once 
+	# (nothing unusuall, similar effect like having springs_moved.emit() inside _on_anchor_position_change
+	# 2. User drags both atoms and anchors, in this scenario thanks to this workaround springs_moved
+	# signal will be emitted only once, instead of twice (once because of atom movement, and other time 
+	# in a result of anchor movement). Thanks to this _springs will be processed only once per movement
+	start_edit()
+	end_edit()
+
+
+func spring_has(in_spring_id: int) -> bool:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return true
-	# TDB: Support springs?
-	return false
+	return _springs.has(in_spring_id)
 
 
-func spring_invalidate(_in_spring_id: int) -> void:
-	if _edit_mode == EditMode.SequenceAndPath:
-		return
-	# TDB: Support springs?
-	return
+func spring_invalidate(in_spring_id: int) -> void:
+	assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Cannot edit springs in this mode")
+	var atom_id: int = spring_get_atom_id(in_spring_id)
+	var anchor_id: int = spring_get_anchor_id(in_spring_id)
+	_atoms_to_related_springs[atom_id].erase(in_spring_id)
+	_springs.erase(in_spring_id)
+	_signal_queue_springs_moved.erase(in_spring_id)
+	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
+	var anchor: NanoVirtualAnchor = workspace.get_structure_by_int_guid(anchor_id)
+	anchor.handle_spring_removed(self, in_spring_id)
+	
+	var is_still_linked_to_anchor: bool = anchor.is_structure_related(int_guid)
+	if not is_still_linked_to_anchor:
+		if anchor.position_changed.is_connected(_on_anchor_position_change):
+			anchor.position_changed.disconnect(_on_anchor_position_change)
+		if anchor.visibility_changed.is_connected(_on_anchor_visibility_changed):
+			anchor.visibility_changed.disconnect(_on_anchor_visibility_changed)
+	_signal_queue_springs_removed.append(in_spring_id)
 
 
-func spring_revalidate(_in_spring_id: int) -> void:
-	if _edit_mode == EditMode.SequenceAndPath:
-		return
-	# TDB: Support springs?
-	return
+func spring_is_visible(in_spring_id: int) -> bool:
+	var spring: NanoSpring = _springs[in_spring_id]
+	if not spring.anchor_is_visible:
+		return false
+	return super.spring_is_visible(in_spring_id)
 
 
-func spring_get_atom_id(_in_spring_id: int) -> int:
+func spring_get_atom_id(in_spring_id: int) -> int:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return INVALID_ATOM_ID
-	# TDB: Support springs?
-	return INVALID_ATOM_ID
+	return _springs[in_spring_id].target_atom
 
 
-func spring_get_atom_position(_in_spring_id: int) -> Vector3:
+func spring_get_atom_position(in_spring_id: int) -> Vector3:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return Vector3()
-	# TDB: Support springs?
-	return Vector3()
+	var spring: NanoSpring = _springs[in_spring_id]
+	return atom_get_position(spring.target_atom)
 
 
-func spring_get_anchor_id(_in_spring_id: int) -> int:
+func spring_get_anchor_id(in_spring_id: int) -> int:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return -1
-	# TDB: Support springs?
-	return -1
+	var spring: NanoSpring = _springs[in_spring_id]
+	return spring.target_anchor
 
 
-func spring_get_anchor_position(_in_spring_id: int, _in_parent_context: StructureContext) -> Vector3:
+func spring_get_anchor_position(in_spring_id: int, in_parent_context: StructureContext) -> Vector3:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return Vector3()
-	# TDB: Support springs?
-	return Vector3()
+	assert(in_parent_context.nano_structure == self, "This method expects parent StructureContext")
+	var anchor_id: int = in_parent_context.nano_structure.spring_get_anchor_id(in_spring_id)
+	var workspace: Workspace = in_parent_context.workspace_context.workspace
+	var anchor: NanoVirtualAnchor = workspace.get_structure_by_int_guid(anchor_id) as NanoVirtualAnchor
+	return anchor.get_position()
 
 
-func spring_get_equilibrium_length_is_auto(_in_spring_id: int) -> bool:
+func spring_get_equilibrium_length_is_auto(in_spring_id: int) -> bool:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return false
-	# TDB: Support springs?
-	return false
+	var spring: NanoSpring = _springs[in_spring_id]
+	return spring.equilibrium_length_is_auto
 
 
-func spring_set_equilibrium_lenght_is_auto(_in_spring_id: int, _in_is_auto: bool) -> void:
-	if _edit_mode == EditMode.SequenceAndPath:
-		return
-	# TDB: Support springs?
-	return
+func spring_set_equilibrium_lenght_is_auto(in_spring_id: int, in_is_auto: bool) -> void:
+	assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Cannot edit springs in this mode")
+	var spring: NanoSpring = _springs[in_spring_id]
+	spring.equilibrium_length_is_auto = in_is_auto
 
 
-func spring_set_equilibrium_manual_length(_in_spring_id: int, _new_equilibrium_manual_length: float) -> void:
-	if _edit_mode == EditMode.SequenceAndPath:
-		return
-	# TDB: Support springs?
-	return
+func spring_set_equilibrium_manual_length(in_spring_id: int, new_equilibrium_manual_length: float) -> void:
+	assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Cannot edit springs in this mode")
+	var spring: NanoSpring = _springs[in_spring_id]
+	spring.equilibrium_manual_length = new_equilibrium_manual_length
 
 
-func spring_get_equilibrium_manual_length(_in_spring_id: int) -> float:
-	if _edit_mode == EditMode.SequenceAndPath:
-		return 0
-	# TDB: Support springs?
-	return -1.0
-
-
-func spring_calculate_equilibrium_auto_length(_in_spring_id: int, _in_parent_context: StructureContext) -> float:
+func spring_get_equilibrium_manual_length(in_spring_id: int) -> float:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return 0
-	# TDB: Support springs?
-	return -1.0
+	var spring: NanoSpring = _springs[in_spring_id]
+	return spring.equilibrium_manual_length
 
 
-func spring_get_current_equilibrium_length(_in_spring_id: int, _in_parent_context: StructureContext) -> float:
-	# TDB: Support springs?
-	return 1.0
-
-
-func spring_get_constant_force(_in_spring_id: int) -> float:
+func spring_calculate_equilibrium_auto_length(in_spring_id: int, _in_parent_context: StructureContext) -> float:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return 0
-	# TDB: Support springs?
-	return -1.0
+	var begin: Vector3 = spring_get_atom_position(in_spring_id)
+	var end: Vector3 = spring_get_anchor_position(in_spring_id, _in_parent_context)
+	var length: float = begin.distance_to(end)
+	return length
 
 
-func spring_set_constant_force(_in_spring_id: int, _new_force: float) -> void:
+func spring_get_constant_force(in_spring_id: int) -> float:
 	if _edit_mode == EditMode.SequenceAndPath:
-		return
-	# TDB: Support springs?
-	return
+		return 0
+	var spring: NanoSpring = _springs[in_spring_id]
+	return spring.constant_force
+
+
+func spring_set_constant_force(in_spring_id: int, new_force: float) -> void:
+	assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
+	assert(_edit_mode == EditMode.AtomsAndBonds, "Cannot edit springs in this mode")
+	var spring: NanoSpring = _springs[in_spring_id]
+	spring.constant_force = new_force
 
 
 func springs_get_all() -> PackedInt32Array:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return PackedInt32Array()
-	# TDB: Support springs?
-	return PackedInt32Array()
+	return PackedInt32Array(_springs.keys())
 
 
 func springs_get_valid() -> PackedInt32Array:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return PackedInt32Array()
-	# TDB: Support springs?
-	return PackedInt32Array()
+	return PackedInt32Array(_springs.keys())
 
 
 func springs_count() -> int:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return 0
-	# TDB: Support springs?
-	return -1
+	return _springs.size()
 
 
 
-func atom_get_springs(_in_atom_id: int) -> PackedInt32Array:
+func atom_get_springs(in_atom_id: int) -> PackedInt32Array:
 	if _edit_mode == EditMode.SequenceAndPath:
 		return PackedInt32Array()
-	# TDB: Support springs?
+	if _atoms_to_related_springs.has(in_atom_id):
+		return PackedInt32Array(_atoms_to_related_springs[in_atom_id].keys())
 	return PackedInt32Array()
 #endregion: Anchors and Strings
 
@@ -1233,7 +1272,7 @@ func get_type() -> StringName:
 
 
 func get_readable_type() -> String:
-	return "DNA Structure"
+	return "DNA Chain"
 
 
 func get_tooltip_text() -> String:
@@ -1308,7 +1347,14 @@ func is_spline_within_screen_rect(in_camera: Camera3D, screen_rect: Rect2i) -> b
 
 func create_state_snapshot() -> Dictionary:
 	var state_snapshot: Dictionary = super.create_state_snapshot()
+	
+	var springs_dump: Dictionary = {}
+	for spring_id: int in _springs:
+		var spring: NanoSpring = _springs[spring_id]
+		springs_dump[spring_id] = spring.duplicate()
+
 	state_snapshot["script.resource_path"] = get_script().resource_path
+	state_snapshot["_edit_mode"] = _edit_mode
 	state_snapshot["_curve"] = _create_curve_snapshot()
 	state_snapshot["_twists_offset_radians"] = _twists_offset_radians
 	state_snapshot["_sequence"] = _sequence
@@ -1316,7 +1362,12 @@ func create_state_snapshot() -> Dictionary:
 	state_snapshot["_base_transform_cache"] = _base_transform_cache.duplicate()
 	state_snapshot["_atoms_count_cache"] = _atoms_count_cache
 	state_snapshot["_atoms_ids_cache"] = _atoms_ids_cache.duplicate()
-	state_snapshot["_atoms_cache"] = _atoms_cache.duplicate(true)
+	state_snapshot["_springs"] = springs_dump
+	state_snapshot["_highest_spring_id"] = _highest_spring_id
+	var atom_cache_state: Dictionary = {}
+	for id: int in _atoms_cache.keys():
+		atom_cache_state[id] = AtomData.to_state(_atoms_cache[id])
+	state_snapshot["_atoms_cache"] = atom_cache_state
 	state_snapshot["_bonds_count_cache"] = _bonds_count_cache
 	state_snapshot["_bonds_ids_cache"] = _bonds_ids_cache.duplicate()
 	state_snapshot["_bonds_cache"] = _bonds_cache.duplicate()
@@ -1325,6 +1376,7 @@ func create_state_snapshot() -> Dictionary:
 
 
 func apply_state_snapshot(in_state_snapshot: Dictionary) -> void:
+	_edit_mode = in_state_snapshot["_edit_mode"]
 	_set_curve_snapshot(in_state_snapshot["_curve"])
 	_twists_offset_radians = in_state_snapshot["_twists_offset_radians"]
 	_sequence = in_state_snapshot["_sequence"]
@@ -1332,11 +1384,21 @@ func apply_state_snapshot(in_state_snapshot: Dictionary) -> void:
 	_base_transform_cache = in_state_snapshot["_base_transform_cache"].duplicate()
 	_atoms_count_cache = in_state_snapshot["_atoms_count_cache"]
 	_atoms_ids_cache = in_state_snapshot["_atoms_ids_cache"].duplicate()
-	_atoms_cache = in_state_snapshot["_atoms_cache"].duplicate(true)
+	_atoms_cache = {}
+	for id: int in in_state_snapshot["_atoms_cache"].keys():
+		_atoms_cache[id] = AtomData.from_state(in_state_snapshot["_atoms_cache"][id])
 	_bonds_count_cache = in_state_snapshot["_bonds_count_cache"]
 	_bonds_ids_cache = in_state_snapshot["_bonds_ids_cache"].duplicate()
 	_bonds_cache = in_state_snapshot["_bonds_cache"].duplicate()
 	_baked_path = in_state_snapshot["_baked_path"].duplicate()
+	
+	_springs.clear()
+	var springs_to_apply: Dictionary = in_state_snapshot["_springs"]
+	for spring_id: int in springs_to_apply:
+		var spring: NanoSpring = springs_to_apply[spring_id].duplicate()
+		_springs[spring_id] = spring
+	_highest_spring_id = in_state_snapshot["_highest_spring_id"]
+	
 	super.apply_state_snapshot(in_state_snapshot)
 
 
@@ -1347,6 +1409,7 @@ func _create_curve_snapshot() -> PackedVector3Array:
 		snapshot.append(_curve.get_point_in(p))
 		snapshot.append(_curve.get_point_out(p))
 	return snapshot
+
 
 func _set_curve_snapshot(in_curve_snapshot: PackedVector3Array) -> void:
 	_curve.set_block_signals(true)
@@ -1443,6 +1506,9 @@ class AtomData:
 	var position: Vector3
 	
 	func _init(id_data: UnpackedAtomId, owner: DnaStructure) -> void:
+		if id_data == null and owner == null:
+			# Assume reconstructing cache
+			return
 		var base: String
 		if id_data.is_backbone:
 			base = "backbone0" if id_data.strand == Strand.A else "backbone1"
@@ -1465,4 +1531,17 @@ class AtomData:
 			owner.get_base_transform(id_data.strand, id_data.base_idx)
 		)
 		position = xform * position
+	
+	
+	static func to_state(atom: AtomData) -> Dictionary:
+		return {
+			atomic_number =  atom.atomic_number,
+			position = atom.position
+		}
+	
+	static func from_state(data: Dictionary) -> AtomData:
+		var atom := AtomData.new(null, null)
+		atom.atomic_number = data.atomic_number
+		atom.position = data.position
+		return atom
 

--- a/godot_project/project_workspace/structs/lmdb_nano_struct.gd
+++ b/godot_project/project_workspace/structs/lmdb_nano_struct.gd
@@ -208,10 +208,6 @@ func spring_invalidate(_in_spring_id: int) -> void:
 	return
 
 
-func spring_revalidate(_in_spring_id: int) -> void:
-	return
-
-
 func spring_get_atom_id(_in_spring_id: int) -> int:
 	return INVALID_ATOM_ID
 

--- a/godot_project/project_workspace/structs/nano_molecular_structure.gd
+++ b/godot_project/project_workspace/structs/nano_molecular_structure.gd
@@ -31,11 +31,6 @@ var _valid_atoms: Dictionary = {
 
 var _highest_spring_id: int = -1
 
-#TODO: should not be needed
-var _invalid_springs: Dictionary = {
-	# id<int> : NanoSpring
-}
-
 
 func _init() -> void:
 	super._init()
@@ -518,7 +513,6 @@ func spring_invalidate(in_spring_id: int) -> void:
 	var atom_id: int = spring_get_atom_id(in_spring_id)
 	var anchor_id: int = spring_get_anchor_id(in_spring_id)
 	_atoms_to_related_springs[atom_id].erase(in_spring_id)
-	_invalid_springs[in_spring_id] = _springs[in_spring_id]
 	_springs.erase(in_spring_id)
 	_signal_queue_springs_moved.erase(in_spring_id)
 	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
@@ -532,26 +526,6 @@ func spring_invalidate(in_spring_id: int) -> void:
 		if anchor.visibility_changed.is_connected(_on_anchor_visibility_changed):
 			anchor.visibility_changed.disconnect(_on_anchor_visibility_changed)
 	_signal_queue_springs_removed.append(in_spring_id)
-
-
-func spring_revalidate(in_spring_id: int) -> void:
-	assert(_is_being_edited, "To perform any changes to AtomicStructure you need to put it in edit mode by calling start_edit()")
-	_springs[in_spring_id] = _invalid_springs[in_spring_id]
-	_invalid_springs.erase(in_spring_id)
-	_signal_queue_springs_added.append(in_spring_id)
-	
-	var revalidated_spring: NanoSpring = _springs[in_spring_id]
-	var related_anchor_id: int = revalidated_spring.target_anchor
-	var workspace: Workspace = MolecularEditorContext.find_workspace_possessing_structure(self)
-	var anchor: NanoVirtualAnchor = workspace.get_structure_by_int_guid(related_anchor_id)
-	anchor.handle_spring_added(self, in_spring_id)
-	if not anchor.position_changed.is_connected(_on_anchor_position_change):
-		anchor.position_changed.connect(_on_anchor_position_change.bind(anchor))
-	
-	var related_atom_id: int = revalidated_spring.target_atom
-	if not _atoms_to_related_springs.has(related_atom_id):
-		_atoms_to_related_springs[related_atom_id] = Dictionary()
-	_atoms_to_related_springs[related_atom_id][in_spring_id] = true
 
 
 func spring_is_visible(in_spring_id: int) -> bool:
@@ -724,7 +698,6 @@ func clear() -> void:
 	_valid_atoms.clear()
 	hidden_atoms.clear()
 	hidden_bonds.clear()
-	_invalid_springs.clear()
 	_springs.clear()
 	_invalid_atoms_count = 0
 	_highest_spring_id = -1
@@ -793,7 +766,6 @@ func create_state_snapshot() -> Dictionary:
 	state_snapshot["_motor_links"] = _motor_links.duplicate()
 	state_snapshot["_valid_atoms"] = _valid_atoms.duplicate()
 	state_snapshot["_highest_spring_id"] = _highest_spring_id
-	state_snapshot["_invalid_springs"] = _invalid_springs.duplicate()
 	state_snapshot["signals"] = History.create_signal_snapshot_for_object(self)
 	return state_snapshot
 
@@ -819,7 +791,6 @@ func apply_state_snapshot(in_state_snapshot: Dictionary) -> void:
 	_motor_links = in_state_snapshot["_motor_links"].duplicate()
 	_valid_atoms = in_state_snapshot["_valid_atoms"].duplicate()
 	_highest_spring_id = in_state_snapshot["_highest_spring_id"]
-	_invalid_springs = in_state_snapshot["_invalid_springs"].duplicate()
 	
 	# This call defferent should not be needed when Renderer will implement snapshoting
 	History.apply_signal_snapshot_to_object.call_deferred(self, in_state_snapshot["signals"])

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -759,7 +759,8 @@ func get_nano_structure_context(in_nano_structure: NanoStructure) -> StructureCo
 			structure_context.nano_structure.atoms_locking_changed.connect(_on_nano_structure_atoms_locking_changed.bind(structure_context.get_int_guid()))
 		if not structure_context.nano_structure.visibility_changed.is_connected(_on_nano_structure_visibility_changed):
 			structure_context.nano_structure.visibility_changed.connect(_on_nano_structure_visibility_changed.bind(structure_context.get_int_guid()))
-		if structure_context.nano_structure is DnaStructure:
+		if structure_context.nano_structure is DnaStructure \
+				and not structure_context.nano_structure.bases_count_changed.is_connected(_on_structure_contents_modified_arg1):
 			structure_context.nano_structure.bases_count_changed.connect(_on_structure_contents_modified_arg1.bind(structure_context.get_int_guid()))
 			structure_context.nano_structure.sequence_changed.connect(_on_structure_contents_modified_arg1.bind(structure_context.get_int_guid()))
 			structure_context.nano_structure.path_changed.connect(_on_structure_contents_modified_arg0.bind(structure_context.get_int_guid()))

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -1367,6 +1367,8 @@ static func _can_create_particle_emitter_from_selection(in_workspace_context: Wo
 	if context != in_workspace_context.get_current_structure_context():
 		# Selection is not coming from active group
 		return false
+	if context.nano_structure is DnaStructure:
+		return false
 	var structure: NanoStructure = context.nano_structure
 	var selected_atoms: PackedInt32Array = context.get_selected_atoms()
 	var selected_bonds: PackedInt32Array = context.get_selected_bonds()


### PR DESCRIPTION
- Fixed clipboard copy/paste when structure is in edit mode
- Also some fixes to counting of atoms
- Removed dead code related to revalidating invalid atoms
- Make clear with information labels in the dynamic context panel when a structure is unmutable

Task: Creating and Editing DNA

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b007d2ea-acbf-4e65-9376-b896b56ed924" />
