### PR TITLE
Fix crash when changing DNA mode from Path&Sequence to Atoms&Bonds, but sequence has an X on it

### DIFF
--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -480,7 +480,7 @@ func get_valid_atoms_count() -> int:
 			if get_strand_policy() in [StrandPolicy.A, StrandPolicy.DOUBLE]:
 				_atoms_count_cache += base_count[base]
 			if get_strand_policy() in [StrandPolicy.B, StrandPolicy.DOUBLE]:
-				_atoms_count_cache += base_count[DnaBuilder.DNA_COMPLEMENT[base]]
+				_atoms_count_cache += base_count[DnaBuilder.DNA_COMPLEMENT.get(base, "X")]
 	return _atoms_count_cache
 
 
@@ -867,7 +867,7 @@ func get_valid_bonds_count() -> int:
 			if get_strand_policy() in [StrandPolicy.A, StrandPolicy.DOUBLE]:
 				_bonds_count_cache += base_count[base]
 			if get_strand_policy() in [StrandPolicy.B, StrandPolicy.DOUBLE]:
-				_bonds_count_cache += base_count[DnaBuilder.DNA_COMPLEMENT[base]]
+				_bonds_count_cache += base_count[DnaBuilder.DNA_COMPLEMENT.get(base, "X")]
 	return _bonds_count_cache
 
 


### PR DESCRIPTION
- A common way to have an X is you edit the path and make it longer than the configured sequence

Task CRASH - Switching back to DNA atomic mode after editing DNA curve