### PR TITLE
By default, 'Convert DNA template to atoms' will not override atom colors

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
@@ -282,7 +282,6 @@ layout_mode = 2
 [node name="OverrideColorsCheckButton" type="CheckButton" parent="VBoxContainer/PanelContainer2/VBoxContainer" index="0"]
 unique_name_in_owner = true
 layout_mode = 2
-button_pressed = true
 text = "Override Colors per Strand"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PanelContainer2/VBoxContainer" index="1"]


### PR DESCRIPTION
Task: In converting DNA to Atoms and Bonds, Override Colors Per Strand should default to Off