### PR TITLE
Remove the need of modality for editing DNA chain path, and hide the Atoms&Bonds edit stage under feature flags

### DIFF
--- a/godot_project/autoloads/feature_flag_manager/FeatureFlagManager.gd
+++ b/godot_project/autoloads/feature_flag_manager/FeatureFlagManager.gd
@@ -36,6 +36,7 @@ const FEATURE_FLAGS_ALLOW_CREATE_SMALL_MOLECULES_IN_NEW_GROUP = &"feature_flags/
 const FEATURE_FLAGS_MSEP_ONLINE = &"feature_flags/msep_online"
 const FEATURE_FLAGS_DNA_BUILDER = &"feature_flags/dna_builder"
 const FEATURE_FLAGS_DNA_BUILDER_DEV_TOOL = &"feature_flags/dna_builder_dev_tool"
+const FEATURE_FLAGS_DNA_CHAIN_AS_GROUP_OF_ATOMS = &"feature_flags/dna_chain_as_group_of_atoms"
 const FEATURE_FLAGS_DNA_CHAIN_CAN_HAVE_CHILDREN = &"feature_flags/dna_chain_can_have_children"
 
 var irritating_bg: Texture = preload("res://autoloads/feature_flag_manager/assets/seamless_floral_background.png")

--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -16,8 +16,10 @@ enum ClipboardContentType {
 
 
 func copy(in_workspace_context: WorkspaceContext) -> void:
-	if in_workspace_context.get_edited_dna_spline_id():
-		if not in_workspace_context.get_edited_dna_spline_context().is_dna_structure_fully_selected():
+	for context: StructureContext in in_workspace_context.get_structure_contexts_with_selection():
+		if context.nano_structure is DnaStructure \
+				and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath \
+				and not context.is_dna_structure_fully_selected():
 			in_workspace_context.workspace_main_view.editor_viewport_container.show_warning_in_message_bar(
 				tr(&"Cannot copy DNA spline control points"))
 			return
@@ -277,8 +279,10 @@ func _copy_dna_structure(in_structure_context: StructureContext,
 
 
 func cut(out_workspace_context: WorkspaceContext) -> void:
-	if out_workspace_context.get_edited_dna_spline_id():
-		if not out_workspace_context.get_edited_dna_spline_context().is_dna_structure_fully_selected():
+	for context: StructureContext in out_workspace_context.get_structure_contexts_with_selection():
+		if context.nano_structure is DnaStructure \
+				and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath \
+				and not context.is_dna_structure_fully_selected():
 			out_workspace_context.workspace_main_view.editor_viewport_container.show_warning_in_message_bar(
 				tr(&"Cannot cut DNA spline control points"))
 			return

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
@@ -85,7 +85,7 @@ func _on_create_button_pressed() -> void:
 	dna.end_edit()
 	_workspace_context.workspace.add_structure(dna, parent_context.nano_structure)
 	_workspace_context.clear_all_selection()
-	_workspace_context.get_structure_context(dna.int_guid).set_dna_spline_selected(true)
+	_workspace_context.get_structure_context(dna.int_guid).select_all()
 	WorkspaceUtils.focus_camera_on_aabb(_workspace_context, dna.get_aabb())
 	_workspace_context.snapshot_moment("Create DNA Chain")
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/uneditable_atoms_warning.gd
@@ -24,9 +24,13 @@ func should_show(in_workspace_context: WorkspaceContext) -> bool:
 				return true
 	return false
 
-func _on_feature_flag_toggled(in_path: String, in_new_value: bool) -> void:
-	if in_path == FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_CAN_HAVE_CHILDREN:
-		if in_new_value:
+func _on_feature_flag_toggled(in_path: String, _in_new_value: bool) -> void:
+	if in_path in [FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_AS_GROUP_OF_ATOMS, FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_CAN_HAVE_CHILDREN]:
+		var can_have_children: bool = (
+			FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_AS_GROUP_OF_ATOMS)
+			and FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_CAN_HAVE_CHILDREN)
+		)
+		if can_have_children:
 			_info_label.message = tr(&"Immutable structures cannot add, remove, or modify atoms or bonds")
 		else:
 			_info_label.message = tr(&"Immutable structures cannot add, remove, or modify atoms, bonds, or child objects")

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/connect_motors_to_groups_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/connect_motors_to_groups_panel.gd
@@ -54,7 +54,7 @@ func _initialize_structures_list(in_workspace_context: WorkspaceContext) -> void
 	_structures_tree.hide_root = true
 	var root: TreeItem = _structures_tree.create_item()
 	for child: NanoStructure in childs_of_root:
-		if child.is_virtual_object():
+		if not _can_appear_in_tree(child):
 			# Dont show virtual objects, DNA structure is left on purpose
 			continue
 		_add_structures_recursively(workspace, child, root, _get_tracked_motor())
@@ -82,7 +82,7 @@ func _add_structures_recursively(
 			in_parent_tree_item: TreeItem, in_tracked_motor: NanoVirtualMotor) -> void:
 	var structure_item: TreeItem = _add_structure_to_tree(in_structure, in_parent_tree_item, in_tracked_motor)
 	for child: NanoStructure in in_workspace.get_child_structures(in_structure):
-		if child.is_virtual_object():
+		if not _can_appear_in_tree(child):
 			# Dont show virtual objects, DNA structure is left on purpose
 			continue
 		_add_structures_recursively(in_workspace, child, structure_item, in_tracked_motor)
@@ -96,7 +96,7 @@ func _rebuild() -> void:
 
 
 func _on_workspace_context_structure_added(in_structure: NanoStructure) -> void:
-	if in_structure.is_virtual_object():
+	if not _can_appear_in_tree(in_structure):
 		# Dont show virtual objects, DNA structure is left on purpose
 		return
 	var parent_tree_item: TreeItem = null
@@ -105,6 +105,14 @@ func _on_workspace_context_structure_added(in_structure: NanoStructure) -> void:
 		parent_tree_item = _tree_items[in_structure.int_parent_guid] as TreeItem
 		assert(parent_tree_item != null)
 	_add_structure_to_tree(in_structure, parent_tree_item, _get_tracked_motor())
+
+
+func _can_appear_in_tree(in_structure: NanoStructure) -> bool:
+	if in_structure.is_virtual_object():
+		return false
+	if in_structure is DnaStructure:
+		return FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_AS_GROUP_OF_ATOMS)
+	return true
 
 
 func _on_workspace_context_structure_about_to_remove(in_structure: NanoStructure) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
@@ -7,6 +7,7 @@ const EditMode = DnaStructure.EditMode
 
 var _select_one_info_label: InfoLabel
 var _main_container: Container
+var _edit_mode_container: VBoxContainer
 var _edit_path_button: Button
 var _edit_atoms_button: Button
 var _override_colors_check_button: CheckButton
@@ -24,6 +25,7 @@ func _notification(what: int) -> void:
 		_initialized = true
 		_select_one_info_label = %SelectOneInfoLabel as InfoLabel
 		_main_container = $VBoxContainer as Container
+		_edit_mode_container = %EditModeContainer as VBoxContainer
 		_edit_path_button = %EditPathButton as Button
 		_edit_atoms_button = %EditAtomsButton as Button
 		_override_colors_check_button = %OverrideColorsCheckButton as CheckButton
@@ -37,6 +39,19 @@ func _notification(what: int) -> void:
 		_strand_a_button.button_group.pressed.connect(_on_strand_policy_button_group_button_pressed)
 		_include_hydrogens_check_button.toggled.connect(_on_include_hydrogens_check_button_toggled)
 		_create_atoms_button.pressed.connect(_on_create_atoms_button_pressed)
+
+
+func _ready() -> void:
+	FeatureFlagManager.on_feature_flag_toggled.connect(_on_feature_flag_toggled)
+	_on_feature_flag_toggled(
+		FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_AS_GROUP_OF_ATOMS,
+		FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_AS_GROUP_OF_ATOMS)
+	)
+
+
+func _on_feature_flag_toggled(in_path: String, in_value: bool) -> void:
+	if in_path == FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_AS_GROUP_OF_ATOMS:
+		_edit_mode_container.visible = in_value
 
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:
@@ -146,7 +161,7 @@ func _on_edit_mode_button_group_pressed(in_button: Button) -> void:
 				_edit_path_button.set_pressed_no_signal(false)
 				_edit_atoms_button.set_pressed_no_signal(true)
 				return
-			_workspace_context.get_structure_context(_tracked_structure.get_int_guid()).set_dna_spline_selected(false)
+			_workspace_context.get_structure_context(_tracked_structure.get_int_guid()).clear_selection()
 			_tracked_structure.set_edit_mode(EditMode.SequenceAndPath)
 			_setup_animation_player.play(&"setup_edit_path")
 			ctx.select_all()

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
@@ -61,7 +61,7 @@ tracks/3/keys = {
 tracks/4/type = "value"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("VBoxContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
+tracks/4/path = NodePath("VBoxContainer/EditModeContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
@@ -124,7 +124,7 @@ tracks/3/keys = {
 tracks/4/type = "value"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("VBoxContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
+tracks/4/path = NodePath("VBoxContainer/EditModeContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
@@ -187,7 +187,7 @@ tracks/3/keys = {
 tracks/4/type = "value"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("VBoxContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
+tracks/4/path = NodePath("VBoxContainer/EditModeContainer/PanelContainer3/VBoxContainer/EditModeInfoLabel:visible")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
@@ -216,22 +216,26 @@ text = "[center][wave start=4 length=14 freq=0.5 sat=0.8 val=0.8 connected=1]ℹ
 message = &"Select only one DNA Chain at a time to edit it"
 effect = "wave"
 
-[node name="Label4" type="Label" parent="VBoxContainer" index="0"]
+[node name="EditModeContainer" type="VBoxContainer" parent="VBoxContainer" index="0"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Label4" type="Label" parent="VBoxContainer/EditModeContainer" index="0"]
 layout_mode = 2
 text = "Edit Stage"
 
-[node name="PanelContainer3" type="PanelContainer" parent="VBoxContainer" index="1"]
+[node name="PanelContainer3" type="PanelContainer" parent="VBoxContainer/EditModeContainer" index="1"]
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/PanelContainer3" index="0"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/EditModeContainer/PanelContainer3" index="0"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PanelContainer3/VBoxContainer" index="0"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/EditModeContainer/PanelContainer3/VBoxContainer" index="0"]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="EditPathButton" type="Button" parent="VBoxContainer/PanelContainer3/VBoxContainer/HBoxContainer" index="0"]
+[node name="EditPathButton" type="Button" parent="VBoxContainer/EditModeContainer/PanelContainer3/VBoxContainer/HBoxContainer" index="0"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -241,7 +245,7 @@ button_pressed = true
 button_group = SubResource("ButtonGroup_673q0")
 text = "1. Path And Sequence"
 
-[node name="EditAtomsButton" type="Button" parent="VBoxContainer/PanelContainer3/VBoxContainer/HBoxContainer" index="1"]
+[node name="EditAtomsButton" type="Button" parent="VBoxContainer/EditModeContainer/PanelContainer3/VBoxContainer/HBoxContainer" index="1"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -250,7 +254,7 @@ toggle_mode = true
 button_group = SubResource("ButtonGroup_673q0")
 text = "2. Atoms and Bonds"
 
-[node name="EditModeInfoLabel" parent="VBoxContainer/PanelContainer3/VBoxContainer" index="1" instance=ExtResource("3_673q0")]
+[node name="EditModeInfoLabel" parent="VBoxContainer/EditModeContainer/PanelContainer3/VBoxContainer" index="1" instance=ExtResource("3_673q0")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -268,11 +272,11 @@ button_group = SubResource("ButtonGroup_q7pc7")
 [node name="StrandDoubleButton" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer/HBoxContainer" index="2"]
 button_group = SubResource("ButtonGroup_q7pc7")
 
-[node name="Label3" type="Label" parent="VBoxContainer" index="6"]
+[node name="Label3" type="Label" parent="VBoxContainer" index="5"]
 layout_mode = 2
 text = "Convert to Group"
 
-[node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer" index="7"]
+[node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer" index="6"]
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
 

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
@@ -416,7 +416,7 @@ func _update_structure_selection(in_groups_to_update: PackedInt32Array) -> void:
 ## NanoShape and Motors, etc can't be displayed here but shapes also extends NanoMolecularStructure
 ## so we have to be explicit on the check here.
 func _can_appear_in_tree(nano_structure: NanoStructure) -> bool:
-	return nano_structure.can_contain_child_structure() or nano_structure is DnaStructure
+	return nano_structure.can_contain_child_structure()
 
 
 func _get_structure_tree_item_or_null(in_structure_id: int) -> TreeItem:

--- a/godot_project/editor/controls/workspace_view/box_selection/box_selection.gd
+++ b/godot_project/editor/controls/workspace_view/box_selection/box_selection.gd
@@ -82,12 +82,8 @@ func apply_selection() -> void:
 				context.select_bonds(selected_bonds)
 				context.select_springs(selected_springs)
 		if context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
-			if _workspace_context.get_edited_dna_spline_context() == context:
-				var control_points_in_box: PackedInt32Array = _get_dna_control_points_within_screen_rect(context, camera)
-				context.set_dna_control_point_selection(control_points_in_box)
-			else:
-				if _is_dna_structure_within_screen_rect(context, camera):
-					context.set_dna_spline_selected(true)
+			var control_points_in_box: PackedInt32Array = _get_dna_control_points_within_screen_rect(context, camera)
+			context.set_dna_control_point_selection(control_points_in_box)
 		if context.nano_structure.is_virtual_object() and _is_virtual_object_within_screen_rect(context, camera):
 			context.set_virtual_object_selected(true)
 
@@ -150,11 +146,9 @@ func apply_deselection() -> void:
 				context.deselect_atoms(deselected_atoms)
 				context.deselect_bonds(deselected_bonds)
 				context.deselect_springs(deselected_springs)
-		if _workspace_context.get_edited_dna_spline_context() == context:
+		if context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 			var control_points_in_box: PackedInt32Array = _get_dna_control_points_within_screen_rect(context, camera)
 			context.deselect_dna_control_points(control_points_in_box)
-		elif _is_dna_structure_within_screen_rect(context, camera):
-				context.set_dna_spline_selected(true)
 		if context.nano_structure.is_virtual_object() and _is_virtual_object_within_screen_rect(context, camera):
 			context.set_virtual_object_selected(false)
 	
@@ -163,7 +157,8 @@ func apply_deselection() -> void:
 
 
 func _is_dna_structure_within_screen_rect(in_context: StructureContext, in_camera: Camera3D) -> bool:
-	assert(in_context.nano_structure is DnaStructure)
+	if not in_context.nano_structure is DnaStructure:
+		return false
 	var is_simulating: bool = in_context.workspace_context.is_simulating()
 	if is_simulating:
 		# individual atoms and bonds not considered in this API

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -6,6 +6,7 @@ const MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED = 20 * 20
 
 var _select_connected_queued_at: int = 0
 var _press_down_position: Vector2 = Vector2(-100, -100)
+var _queue_abort_release: bool = false
 
 func _init(in_context: WorkspaceContext) -> void:
 	super._init(in_context)
@@ -43,6 +44,8 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 	if is_double_click:
 		var editable_structures: Array[StructureContext] = _workspace_context.get_editable_structure_contexts()
 		if _activate_selection_logic(in_camera, in_input_event.position, editable_structures):
+			# Dont parse mouse release if activation logic executes
+			_queue_abort_release = true
 			return true
 		# Selection logic needs to happen on mouse release
 		# because of that we give a window of 200 msec for releasing the mouse after double click
@@ -98,6 +101,9 @@ func forward_input(in_input_event: InputEvent, in_camera: Camera3D, in_context: 
 		return input_consumed
 	
 	if in_input_event.is_action_released(&"select", true) and _is_near_press_down_pos(in_input_event):
+		if _queue_abort_release:
+			_queue_abort_release = false
+			return false
 		var rendering: Rendering = get_workspace_context().get_rendering()
 		if rendering.is_atom_preview_visible():
 			# Atom is being added, avoid changing selection
@@ -317,42 +323,51 @@ func _activate_selection_logic(
 		var hit_context: StructureContext = multi_structure_hit_result.closest_hit_structure_context
 		if hit_context != get_workspace_context().get_current_structure_context():
 			var affected_context: = get_workspace_context().get_toplevel_editable_context(hit_context)
-			if affected_context.nano_structure.is_virtual_object():
+			if not affected_context.nano_structure.can_contain_child_structure():
 				# Shapes, Motors, Emitters, Springs, etc; cannot be activated, this is on purpose to have a more compact group hierarchy
+				if affected_context == hit_context and hit_context.nano_structure is DnaStructure \
+						and hit_context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
+					_activate_dna_structure(multi_structure_hit_result)
+					return true
 				return false
 			get_workspace_context().change_current_structure_context(affected_context)
 			_workspace_context.snapshot_moment("Change Selection")
 			return true
 		elif hit_context.nano_structure is DnaStructure \
-				and multi_structure_hit_result.hit_type in [
-					MultiStructureHitResult.HitType.HIT_DNA_PATH,
-					MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT
-				]:
-			var dna_structure: DnaStructure = hit_context.nano_structure as DnaStructure
-			if get_workspace_context().get_edited_dna_spline_id() == hit_context.get_int_guid():
-				if multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
-					hit_context.select_all()
-					_workspace_context.snapshot_moment("Change Selection")
-				else:
-					assert(multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_PATH)
-					# insert control point
-					var pos: Vector3 = multi_structure_hit_result.closest_hit_dna_pos
-					var closest_segment: int = -1
-					var closest_distance_sqrd: float = INF
-					for i in (dna_structure.get_control_point_count() - 1):
-						var p0: Vector3 = dna_structure.get_control_point_position(i)
-						var p1: Vector3 = dna_structure.get_control_point_position(i+1)
-						var closest_point: Vector3 = Geometry3D.get_closest_point_to_segment(pos, p0, p1)
-						var dist_sqrd: float = pos.distance_squared_to(closest_point)
-						if dist_sqrd < closest_distance_sqrd:
-							closest_distance_sqrd = dist_sqrd
-							closest_segment = i
-					dna_structure.start_edit()
-					dna_structure.insert_control_point(pos, closest_segment + 1)
-					dna_structure.end_edit()
-					_workspace_context.snapshot_moment("Insert DNA control cpoint")
+				and hit_context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
+			_activate_dna_structure(multi_structure_hit_result)
 			return true
 	return false
+
+
+func _activate_dna_structure(multi_structure_hit_result: MultiStructureHitResult) -> void:
+	assert(multi_structure_hit_result.hit_type in [
+		MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT,
+		MultiStructureHitResult.HitType.HIT_DNA_PATH
+	])
+	var hit_context: StructureContext = multi_structure_hit_result.closest_hit_structure_context
+	var dna_structure: DnaStructure = hit_context.nano_structure as DnaStructure
+	if multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
+		hit_context.select_all()
+	elif multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_PATH:
+		# insert control point
+		var pos: Vector3 = multi_structure_hit_result.closest_hit_dna_pos
+		var closest_segment: int = -1
+		var closest_distance_sqrd: float = INF
+		for i in (dna_structure.get_control_point_count() - 1):
+			var p0: Vector3 = dna_structure.get_control_point_position(i)
+			var p1: Vector3 = dna_structure.get_control_point_position(i+1)
+			var closest_point: Vector3 = Geometry3D.get_closest_point_to_segment(pos, p0, p1)
+			var dist_sqrd: float = pos.distance_squared_to(closest_point)
+			if dist_sqrd < closest_distance_sqrd:
+				closest_distance_sqrd = dist_sqrd
+				closest_segment = i
+		dna_structure.start_edit()
+		dna_structure.insert_control_point(pos, closest_segment + 1)
+		dna_structure.end_edit()
+		hit_context.clear_selection()
+		hit_context.select_dna_control_points([closest_segment + 1])
+		_workspace_context.snapshot_moment("Insert DNA control cpoint")
 
 
 func _select_connected_selection_logic(
@@ -446,8 +461,12 @@ func _screen_selection_logic(
 	if multi_structure_hit_result.did_hit():
 		# perform selection
 		var hit_context: StructureContext = multi_structure_hit_result.closest_hit_structure_context
+		var current: StructureContext = get_workspace_context().get_current_structure_context()
+		var is_toplevel_dna: bool = hit_context.nano_structure is DnaStructure and (hit_context == current or _workspace_context.get_toplevel_editable_context(hit_context) == hit_context)
 		const GROUP_SELECTION_BLACKLIST = [&"AnchorPoint", &"Spring"]
-		if hit_context != get_workspace_context().get_current_structure_context() and not hit_context.nano_structure.get_type() in GROUP_SELECTION_BLACKLIST:
+		if hit_context != get_workspace_context().get_current_structure_context() \
+				and not is_toplevel_dna \
+				and not hit_context.nano_structure.get_type() in GROUP_SELECTION_BLACKLIST:
 			# Clicked an object that is a child of current edited structure, select the entire group
 			if not need_to_create_snapshot:
 				snapshot_name = "Select Group"
@@ -537,39 +556,23 @@ func _screen_selection_logic(
 							snapshot_name = "Select Anchor"
 							need_to_create_snapshot = true
 						hit_context.set_anchor_selected(true)
-				MultiStructureHitResult.HitType.HIT_DNA_PATH, MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
-					var is_editing_this: bool = _workspace_context.get_edited_dna_spline_id() == hit_context.int_guid
-					var hit_on_path: bool = multi_structure_hit_result.hit_type == MultiStructureHitResult.HitType.HIT_DNA_PATH
-					if is_editing_this:
-						if hit_on_path:
-							# Deselect what is selected
-							hit_context.deselect_dna_control_points(hit_context.get_selected_dna_spline_countrol_points())
-							if not need_to_create_snapshot:
-								snapshot_name = "Clear DNA control point selection"
-								need_to_create_snapshot = true
-						else:
-							var hit_control_point: int = multi_structure_hit_result.closest_hit_dna_control_point_id
-							if hit_control_point in hit_context.get_selected_dna_spline_countrol_points():
-								hit_context.deselect_dna_control_points([hit_control_point])
-								if not need_to_create_snapshot:
-									snapshot_name = "Unselect DNA control point"
-									need_to_create_snapshot = true
-							else:
-								hit_context.select_dna_control_points([hit_control_point])
-								if not need_to_create_snapshot:
-									snapshot_name = "Select DNA control point"
-									need_to_create_snapshot = true
+				MultiStructureHitResult.HitType.HIT_DNA_PATH:
+					hit_context.select_all()
+					if not need_to_create_snapshot:
+						snapshot_name = "Select DNA Chain"
+						need_to_create_snapshot = true
+				MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
+					var hit_control_point: int = multi_structure_hit_result.closest_hit_dna_control_point_id
+					if hit_control_point in hit_context.get_selected_dna_spline_countrol_points():
+						hit_context.deselect_dna_control_points([hit_control_point])
+						if not need_to_create_snapshot:
+							snapshot_name = "Unselect DNA control point"
+							need_to_create_snapshot = true
 					else:
-						if hit_context.is_dna_structure_fully_selected():
-							hit_context.set_dna_spline_selected(false)
-							if not need_to_create_snapshot:
-								snapshot_name = "Deselect DNA spline"
-								need_to_create_snapshot = true
-						else:
-							hit_context.set_dna_spline_selected(true)
-							if not need_to_create_snapshot:
-								snapshot_name = "Select DNA spline"
-								need_to_create_snapshot = true
+						hit_context.select_dna_control_points([hit_control_point])
+						if not need_to_create_snapshot:
+							snapshot_name = "Select DNA control point"
+							need_to_create_snapshot = true
 				_:
 					assert(false, "Invalid hit result")
 	if need_to_create_snapshot:
@@ -593,7 +596,8 @@ func _screen_deselection_logic(
 	# If got a hit perform deselection
 	if multi_structure_hit_result.did_hit():
 		var hit_context: StructureContext = multi_structure_hit_result.closest_hit_structure_context
-		if hit_context != get_workspace_context().get_current_structure_context():
+		var is_toplevel_dna: bool = hit_context.nano_structure is DnaStructure and _workspace_context.get_toplevel_editable_context(hit_context) == hit_context
+		if hit_context != get_workspace_context().get_current_structure_context() and not is_toplevel_dna:
 			if not did_create_undo_action:
 				snapshot_name = "Deselect Group"
 				did_create_undo_action = true
@@ -631,6 +635,14 @@ func _screen_deselection_logic(
 					var deselected_spring_id: int = multi_structure_hit_result.closest_hit_spring_id
 					var deselected_spring: PackedInt32Array = [deselected_spring_id]
 					hit_context.deselect_springs(deselected_spring)
+				MultiStructureHitResult.HitType.HIT_DNA_PATH:
+					snapshot_name = "Deselect DNA Chain"
+					did_create_undo_action = true
+					hit_context.clear_selection()
+				MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
+					snapshot_name = "Unselect DNA control point"
+					var hit_control_point: int = multi_structure_hit_result.closest_hit_dna_control_point_id
+					hit_context.deselect_dna_control_points([hit_control_point])
 				_:
 					assert(false, "Invalid hit result")
 		if did_create_undo_action:

--- a/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
@@ -122,9 +122,7 @@ func _init_initial_positions_and_determine_center() -> Vector3:
 			_structure_context_2_initial_object_transforms[context.get_int_guid()] = Transform3D(Basis(), context.nano_structure.get_position())
 		elif context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 			if context.has_selection():
-				var control_points: Array = range(context.nano_structure.get_control_point_count())
-				if _workspace_context.get_edited_dna_spline_id() == context.get_int_guid():
-					control_points = context.get_selected_dna_spline_countrol_points()
+				var control_points: Array = context.get_selected_dna_spline_countrol_points()
 				selection_size += control_points.size()
 				for p: int in control_points:
 					center_pos += context.nano_structure.get_control_point_position(p)
@@ -257,9 +255,7 @@ func _apply_selection_transform() -> void:
 			object_old_transform = nano_structure.get_transform()
 		elif nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 			var dna := nano_structure as DnaStructure
-			var points_to_transform: PackedInt32Array = range(dna.get_control_point_count())
-			if _workspace_context.get_edited_dna_spline_id() == context.get_int_guid():
-				points_to_transform = context.get_selected_dna_spline_countrol_points()
+			var points_to_transform: PackedInt32Array = context.get_selected_dna_spline_countrol_points()
 			dna.start_edit()
 			for p: int in points_to_transform:
 				action_created = true
@@ -297,7 +293,7 @@ func _apply_selection_transform() -> void:
 		var atoms_changed: bool = nmb_of_moved_atoms > 0
 		var object_moved: bool = context.is_shape_selected() or context.is_motor_selected() or context.is_particle_emitter_selected()
 		var anchor_moved: bool = context.is_anchor_selected()
-		var dna_changed: bool = context.is_dna_structure_fully_selected() # or _workspace_context.get_edited_dna_spline_context() == context.nano_structure
+		var dna_changed: bool = context.is_dna_structure_fully_selected()
 		if atoms_changed or object_moved or anchor_moved or dna_changed:
 			if atoms_changed:
 				nano_structure.start_edit()
@@ -446,7 +442,7 @@ func _force_gizmo_update() -> void:
 			elif context.is_anchor_selected():
 				selection_size += 1
 				# Anchors does not trigger `has_transformable_objects_selected = true` because they dont rotate
-			elif _workspace_context.get_edited_dna_spline_id() == context.get_int_guid():
+			elif context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 				selection_size += context.get_selected_dna_spline_countrol_points().size()
 			elif context.is_dna_structure_fully_selected():
 				selection_size += (context.nano_structure as DnaStructure).get_control_point_count()

--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -45,9 +45,9 @@ var _updating_parameters: bool = false
 # hovering API
 var _hover_enabled: bool = true
 var _is_selectable: bool = true
+var _is_top_level: bool = true
 var _path_hovered: bool = false
 var _path_highlighted: bool = false
-var _path_being_edited: bool = false
 var _edit_mode: DnaStructure.EditMode
 var _hovered_control_point: int = -1
 var _highlighted_control_points: Dictionary[int, bool] = {}
@@ -111,10 +111,8 @@ func _enter_tree() -> void:
 		return
 	var workspace_context: WorkspaceContext = editor_viewport.get_workspace_context()
 	if not workspace_context.editable_structure_context_list_changed.is_connected(_on_editable_structure_context_list_changed):
-		workspace_context.current_structure_context_changed.connect(_on_current_structure_context_changed)
 		workspace_context.editable_structure_context_list_changed.connect(_on_editable_structure_context_list_changed)
 		workspace_context.hovered_structure_context_changed.connect(_on_hovered_structure_context_changed)
-		workspace_context.selection_in_structures_changed.connect(_on_workspace_context_selection_in_structures_changed)
 
 
 func _ensure_structure_signal_connections(in_structure: DnaStructure) -> void:
@@ -178,11 +176,8 @@ func set_selection_position_delta(in_selection_delta: Vector3) -> void:
 		_reset_temp_curve()
 		return
 	_setup_temp_curve()
-	var points_to_transform: PackedInt32Array = range(curve.point_count)
-	var needs_recalculate_in_out: bool = false
-	if _path_being_edited:
-		needs_recalculate_in_out = _highlighted_control_points.size() != curve.point_count
-		points_to_transform = _highlighted_control_points.keys()
+	var needs_recalculate_in_out: bool = _highlighted_control_points.size() != curve.point_count
+	var points_to_transform: PackedInt32Array = _highlighted_control_points.keys()
 	var inout_positions_to_update: Dictionary[int, bool]
 	for p: int in points_to_transform:
 		var original_pos: Vector3 = _original_curve.get_point_position(p)
@@ -204,9 +199,7 @@ func rotate_selection_around_point(in_point: Vector3, in_rotation_to_apply: Basi
 		_reset_temp_curve()
 		return
 	_setup_temp_curve()
-	var points_to_transform: PackedInt32Array = range(curve.point_count)
-	if _path_being_edited:
-		points_to_transform = _highlighted_control_points.keys()
+	var points_to_transform: PackedInt32Array = _highlighted_control_points.keys()
 	var inout_positions_to_update: Dictionary[int, bool]
 	for p: int in points_to_transform:
 		var original_pos: Vector3 = _original_curve.get_point_position(p)
@@ -343,16 +336,14 @@ func queue_redraw() -> void:
 	_path_representation.queue_redraw()
 
 
-func _on_current_structure_context_changed(structure_context: StructureContext) -> void:
-	_path_being_edited = structure_context.get_int_guid() == _structure_id
-	_update_visibility()
-
-
 func _on_editable_structure_context_list_changed(in_new_editable_structure_contexts: Array[StructureContext]) -> void:
 	_is_selectable = false
+	_is_top_level = false
+	var current: StructureContext = _workspace_context.get_current_structure_context()
 	for context: StructureContext in in_new_editable_structure_contexts:
 		if context.get_int_guid() == _structure_id:
 			_is_selectable = true
+			_is_top_level = context == current or _workspace_context.get_toplevel_editable_context(context) == context
 			break
 	const SELECTABLE_VALUE: float = 1.0
 	const UNSELECTABLE_VALUE: float = 0.0
@@ -394,14 +385,16 @@ func _on_path_representation_drawn() -> void:
 	const MIN_SEGMENT_DISTANCE_SQRD_IN_PIXELS: float = 3 * 3
 	var last_idx: int = path.size() - 1
 	var path_width: int = 2
-	if _path_highlighted or _path_being_edited:
+	if _highlighted_control_points.size() > 0:
 		path_width = 4
 	for i in range(1, path.size()):
 		var pos2d: Vector2 = camera.unproject_position(path[i])
 		if last_pos2d.distance_squared_to(pos2d) >= MIN_SEGMENT_DISTANCE_SQRD_IN_PIXELS or i == last_idx:
 			_path_representation.draw_line(last_pos2d, pos2d, _get_outline_color(), path_width)
 			last_pos2d = pos2d
-	if not _path_being_edited:
+	if _is_top_level == false:
+		return
+	if _highlighted_control_points.size() == 0 and _hovered_control_point == -1 and _path_hovered == false:
 		return
 	var drawn_curve: Curve3D = curve if _temp_curve == null else _temp_curve
 	for cp_idx: int in drawn_curve.point_count:
@@ -425,20 +418,11 @@ func _get_outline_color() -> Color:
 	if representation_settings.get_custom_selection_outline_color_enabled():
 		color = representation_settings.get_custom_selection_outline_color()
 	var is_hovered: bool = _path_hovered and _hover_enabled
-	if is_hovered or _path_highlighted or _path_being_edited:
+	var has_selection: bool = _highlighted_control_points.size() > 0
+	if is_hovered or has_selection:
 		return color
 	color.a = 0.5
 	return color
-
-
-func _on_workspace_context_selection_in_structures_changed(out_structure_contexts: Array[StructureContext]) -> void:
-	for context: StructureContext in out_structure_contexts:
-		var is_this_strucutre: bool = context.nano_structure.int_guid == _structure_id
-		if is_this_strucutre:
-			var is_selected: bool = context.is_dna_structure_fully_selected()
-			if is_selected != _path_highlighted:
-				_path_highlighted = is_selected
-				queue_redraw()
 
 
 func _set_shader_uniform(in_uniform: StringName, in_value: Variant) -> void:
@@ -457,10 +441,10 @@ func create_state_snapshot() -> Dictionary:
 	snapshot["_bases_per_turn"] = _bases_per_turn
 	snapshot["_initial_twist"] = _initial_twist
 	snapshot["_path_highlighted"] = _path_highlighted
-	snapshot["_path_being_edited"] = _path_being_edited
 	snapshot["_edit_mode"] = _edit_mode
 	snapshot["_highlighted_control_points"] = _highlighted_control_points.duplicate()
 	snapshot["_is_selectable"] = _is_selectable
+	snapshot["_is_top_level"] = _is_top_level
 	snapshot["_object_visible"] = _object_visible
 	snapshot["_selectable_uniform"] = base_pivot_material.get_shader_parameter(&"is_selectable")
 	var bases_snapshots: Array[Dictionary] = []
@@ -479,21 +463,21 @@ func apply_state_snapshot(in_state_snapshot: Dictionary) -> void:
 	_bases_per_turn = in_state_snapshot["_bases_per_turn"]
 	_initial_twist = in_state_snapshot["_initial_twist"]
 	_path_highlighted = in_state_snapshot["_path_highlighted"]
-	_path_being_edited = in_state_snapshot["_path_being_edited"]
 	_edit_mode = in_state_snapshot["_edit_mode"]
 	_highlighted_control_points = in_state_snapshot["_highlighted_control_points"].duplicate()
 	_is_selectable = in_state_snapshot["_is_selectable"]
+	_is_top_level = in_state_snapshot["_is_top_level"]
 	_object_visible = in_state_snapshot["_object_visible"]
 	_set_shader_uniform(&"is_selectable", in_state_snapshot["_selectable_uniform"])
 	var bases_snapshots: Array[Dictionary] = in_state_snapshot["bases_snapshots"]
 	var dna_structure: DnaStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id) as DnaStructure
-	dna_structure.grab_curve(self)
 	while _bases.size() > bases_snapshots.size():
 		_bases.pop_back().queue_free()
 	while _bases.size() < bases_snapshots.size():
 		var base := DnaBaseRepresentation.create()
 		add_child(base)
 		_bases.append(base)
+	dna_structure.grab_curve(self)
 	for i in bases_snapshots.size():
 		_bases[i].apply_state_snapshot(bases_snapshots[i])
 	_applying_snapshot = false

--- a/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
+++ b/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
@@ -163,12 +163,13 @@ func _can_delete_atoms_bonds_or_springs(in_context: StructureContext) -> bool:
 
 
 func _can_delete_dna_control_points(out_context: StructureContext) -> bool:
-	return _workspace_context.get_edited_dna_spline_id() == out_context.get_int_guid() \
+	return  out_context.nano_structure is DnaStructure \
+			and out_context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath \
 			and out_context.get_selected_dna_spline_countrol_points().size() > 0
 
 
 func _action_delete_dna_control_points(out_context: StructureContext) -> void:
-	assert(_workspace_context.get_edited_dna_spline_id() == out_context.get_int_guid())
+	assert(out_context.nano_structure is DnaStructure and out_context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath)
 	var selected_points: PackedInt32Array = out_context.get_selected_dna_spline_countrol_points()
 	out_context.clear_selection()
 	assert(selected_points.size() > 0)
@@ -255,9 +256,10 @@ func _can_delete_objects(in_context: StructureContext) -> bool:
 			if not in_context.nano_structure is DnaStructure else in_context.is_dna_structure_fully_selected()
 	
 	# EXCEPTION: DnaStructure gets deleted if all but 1 control point are selected
-	if _workspace_context.get_edited_dna_spline_id() == in_context.int_guid:
-		if in_context.get_selected_dna_spline_countrol_points().size() >= in_context.nano_structure.get_control_point_count() - 1:
-			dna_spline_selected = true
+	if in_context.nano_structure is DnaStructure \
+			and in_context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath \
+			and in_context.get_selected_dna_spline_countrol_points().size() >= in_context.nano_structure.get_control_point_count() - 1:
+		dna_spline_selected = true
 	
 	var child_structures: Array[NanoStructure] = \
 			in_context.workspace_context.workspace.get_child_structures(in_context.nano_structure)

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -97,6 +97,7 @@ particle_emitters_with_emit_count=false
 msep_online=false
 dna_builder=false
 dna_builder_dev_tool=false
+dna_chain_as_group_of_atoms=false
 dna_chain_can_have_children=false
 
 [file_customization]

--- a/godot_project/project_workspace/structs/nano_structure.gd
+++ b/godot_project/project_workspace/structs/nano_structure.gd
@@ -101,7 +101,8 @@ func get_visible() -> bool:
 
 ## Does this object work as a group?
 func can_contain_child_structure() -> bool:
-	return FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_CAN_HAVE_CHILDREN)
+	return FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_AS_GROUP_OF_ATOMS) \
+		and FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_DNA_CHAIN_CAN_HAVE_CHILDREN)
 
 
 ## Returns true if the object is not a group of particles. Ex: Shapes, Motors, Springs

--- a/godot_project/project_workspace/workspace_context/history/history.gd
+++ b/godot_project/project_workspace/workspace_context/history/history.gd
@@ -20,6 +20,7 @@ const ACTION_WHITELIST_DURING_SIMULATION: Dictionary = {
 	"Select Bond" : true,
 	"Select Shape" : true,
 	"Select Motor" : true,
+	"Select DNA Chain" : true,
 	"Select Particle Emitter" : true,
 	"Select Anchor" : true,
 	"Select Spring" : true,

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
@@ -8,7 +8,6 @@ signal selection_changed
 signal atoms_deselected(in_deselected_atoms: PackedInt32Array)
 signal dna_control_points_deselected(in_deselected_control_points: PackedInt32Array)
 signal virtual_object_selection_changed(is_selected: bool)
-signal dna_spline_selection_changed(is_selected: bool)
 signal springs_deselected(in_deselected_springs: PackedInt32Array)
 
 
@@ -19,7 +18,6 @@ var _spring_selection: SpringSelection
 
 var _application_is_editor_build: bool = OS.has_feature("editor")
 var _is_virtual_object_selected: bool = false
-var _is_dna_spline_selected: bool = false
 var _is_initialized: bool = false
 
 
@@ -50,7 +48,6 @@ func has_selection() -> bool:
 	
 	return _atom_selection.has_selection() \
 			or _is_virtual_object_selected \
-			or _is_dna_spline_selected \
 			or _spring_selection.has_selection() \
 			or _dna_control_point_selection.size() > 0
 
@@ -89,10 +86,6 @@ func is_spring_selected(in_spring_id: int) -> bool:
 
 func is_virtual_object_selected() -> bool:
 	return _is_virtual_object_selected
-
-
-func is_dna_spline_selected() -> bool:
-	return _is_dna_spline_selected
 
 
 func get_selected_atoms() -> PackedInt32Array:
@@ -294,16 +287,12 @@ func invert_selection() -> void:
 	
 	# ---- DNA Structures ----
 	if nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
-		if _structure_context.workspace_context.get_edited_dna_spline_id() == nano_structure.int_guid:
-			var dna_structure := nano_structure as DnaStructure
-			var all_points := PackedInt32Array(range(dna_structure.get_control_point_count()))
-			var selected_points: PackedInt32Array = _structure_context.get_selected_dna_spline_countrol_points()
-			var new_selection: Array = all_points.duplicate()
-			for p in selected_points:
-				new_selection.erase(p)
-			set_dna_control_point_selection(PackedInt32Array(new_selection))
-		else:
-			set_dna_spline_selected(!is_dna_spline_selected())
+		var dna_structure := nano_structure as DnaStructure
+		var selected_points: PackedInt32Array = _structure_context.get_selected_dna_spline_countrol_points()
+		var new_selection: Array = PackedInt32Array(range(dna_structure.get_control_point_count()))
+		for p in selected_points:
+			new_selection.erase(p)
+		set_dna_control_point_selection(PackedInt32Array(new_selection))
 	
 	# ---- Virtual Objects ----
 	if nano_structure.is_virtual_object():
@@ -315,9 +304,7 @@ func select_all() -> void:
 	if nano_structure.is_virtual_object():
 		set_virtual_object_selected(true)
 	elif  nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
-		set_dna_spline_selected(true)
-		if _structure_context.workspace_context.get_edited_dna_spline_id() == _structure_context.get_int_guid():
-			set_dna_control_point_selection(range(nano_structure.get_control_point_count()))
+		set_dna_control_point_selection(range(nano_structure.get_control_point_count()))
 	else:
 		assert(!nano_structure.is_being_edited(), "Setting the selection while structure is changing is insecure and should be avoided")
 		set_atom_selection(nano_structure.get_visible_atoms())
@@ -364,15 +351,6 @@ func set_virtual_object_selected(in_selected: bool) -> void:
 	assert(nano_structure.get_visible(), "Cannot change selection of a hidden object")
 	_is_virtual_object_selected = in_selected
 	virtual_object_selection_changed.emit(in_selected)
-
-
-func set_dna_spline_selected(in_selected: bool) -> void:
-	var nano_structure: NanoStructure = _structure_context.nano_structure
-	if in_selected == _is_dna_spline_selected || not nano_structure is DnaStructure:
-		return
-	assert(nano_structure.get_visible(), "Cannot change selection of a hidden object")
-	_is_dna_spline_selected = in_selected
-	dna_spline_selection_changed.emit(in_selected)
 
 
 func set_dna_control_point_selection(in_control_points_to_select: PackedInt32Array) -> void:
@@ -477,7 +455,6 @@ func clear_selection() -> void:
 	
 	var rendering: Rendering = _structure_context.get_rendering()
 	set_virtual_object_selected(false)
-	set_dna_spline_selected(false)
 	
 	if nano_structure is AtomicStructure:
 		rendering.lowlight_atoms(deselected_atoms, nano_structure, bonds_released_from_partial_influence,
@@ -502,7 +479,7 @@ func get_selection_aabb() -> AABB:
 		var object_aabb: AABB = nano_structure.get_aabb()
 		selections_aabbs.push_back(object_aabb)
 	
-	if _structure_context.workspace_context.get_edited_dna_spline_id() == nano_structure.int_guid:
+	if nano_structure is DnaStructure and nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 		if not _dna_control_point_selection.is_empty():
 			var dna_structure := _structure_context.nano_structure as DnaStructure
 			var points: PackedInt32Array = _dna_control_point_selection.keys()
@@ -510,12 +487,6 @@ func get_selection_aabb() -> AABB:
 			for i in range(1, points.size()):
 				aabb = aabb.expand(dna_structure.get_control_point_position(points[i]))
 			selections_aabbs.push_back(aabb)
-		else:
-			assert(is_dna_spline_selected())
-			selections_aabbs.push_back(nano_structure.get_aabb())
-	elif is_dna_spline_selected():
-		selections_aabbs.push_back(nano_structure.get_aabb())
-		
 	
 	if _atom_selection.has_selection():
 		selections_aabbs.push_back(_atom_selection.get_aabb())
@@ -582,7 +553,6 @@ func get_selection_snapshot() -> Dictionary:
 		atom_snapshot = _atom_selection.get_snapshot(),
 		spring_snapshot = _spring_selection.get_snapshot(),
 		is_virtual_object_selected = _is_virtual_object_selected,
-		is_dna_spline_selected = _is_dna_spline_selected,
 		dna_control_points_snapshot = _dna_control_point_selection.duplicate()
 	}
 	return result_data
@@ -590,7 +560,6 @@ func get_selection_snapshot() -> Dictionary:
 
 func apply_selection_snapshot(in_snapshot: Dictionary) -> void:
 	_is_virtual_object_selected = in_snapshot.is_virtual_object_selected
-	_is_dna_spline_selected = in_snapshot.is_dna_spline_selected
 	_dna_control_point_selection = in_snapshot.dna_control_points_snapshot.duplicate()
 	var atom_snapshot: Array = in_snapshot.atom_snapshot
 	var spring_snapshot: Array = in_snapshot.spring_snapshot

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -6,7 +6,6 @@ signal selection_changed()
 signal atom_selection_changed()
 signal atoms_deselected(in_deselected_atoms: PackedInt32Array)
 signal virtual_object_selection_changed(is_selected: bool)
-signal dna_spline_selection_changed(is_selected: bool)
 signal dna_control_points_selection_changed()
 signal dna_control_points_deselected(in_deselected_control_points: PackedInt32Array)
 
@@ -43,7 +42,6 @@ func _notification(what: int) -> void:
 		_selection_db.atom_selection_changed.connect(_on_selection_db_atom_selection_changed)
 		_selection_db.atoms_deselected.connect(_on_selection_db_atoms_deselected)
 		_selection_db.virtual_object_selection_changed.connect(_on_virtual_object_selection_changed)
-		_selection_db.dna_spline_selection_changed.connect(_on_dna_spline_selection_changed)
 		_selection_db.dna_control_points_selection_changed.connect(_on_dna_control_points_selection_changed)
 		_selection_db.dna_control_points_deselected.connect(_on_dna_control_points_deselected)
 	if what == NOTIFICATION_READY:
@@ -172,7 +170,6 @@ func has_selection(in_recursive: bool = false) -> bool:
 func has_transformable_selection() -> bool:
 	return is_any_atom_selected() \
 		or _selection_db.is_virtual_object_selected() \
-		or _selection_db.is_dna_spline_selected() \
 		or _selection_db.get_selected_dna_spline_countrol_points().size() > 0
 
 
@@ -213,9 +210,7 @@ func dna_structure_has_selection() -> bool:
 		return false
 	if nano_structure.get_edit_mode() == DnaStructure.EditMode.AtomsAndBonds:
 		return is_any_atom_selected() or is_any_bond_selected()
-	if _selection_db.is_dna_spline_selected():
-		return true
-	if workspace_context.get_edited_dna_spline_id() == get_int_guid() and _selection_db.get_selected_dna_spline_countrol_points().size() > 0:
+	if _selection_db.get_selected_dna_spline_countrol_points().size() > 0:
 		return true
 	return false
 
@@ -228,9 +223,7 @@ func is_dna_structure_fully_selected() -> bool:
 		return get_selected_atoms().size() == dna_structure.get_valid_atoms_count() \
 			and get_selected_bonds().size() == dna_structure.get_valid_bonds_count()
 	else:
-		if workspace_context.get_edited_dna_spline_id() == dna_structure.int_guid:
-			return _selection_db.get_selected_dna_spline_countrol_points().size() == dna_structure.get_control_point_count()
-		return _selection_db.is_dna_spline_selected()
+		return _selection_db.get_selected_dna_spline_countrol_points().size() == dna_structure.get_control_point_count()
 
 
 func is_virtual_object_selected() -> bool:
@@ -420,11 +413,6 @@ func set_spring_selection(in_springs_to_select: PackedInt32Array) -> void:
 	return _selection_db.set_spring_selection(in_springs_to_select)
 
 
-func set_dna_spline_selected(in_selected: bool) -> void:
-	assert(nano_structure is DnaStructure)
-	_selection_db.set_dna_spline_selected(in_selected)
-
-
 func set_dna_control_point_selection(in_control_points_to_select: PackedInt32Array) -> void:
 	return _selection_db.set_dna_control_point_selection(in_control_points_to_select)
 
@@ -574,10 +562,6 @@ func _on_selection_db_atoms_deselected(in_deselected_atoms: PackedInt32Array) ->
 
 func _on_virtual_object_selection_changed(is_selected: bool) -> void:
 	virtual_object_selection_changed.emit(is_selected)
-
-
-func _on_dna_spline_selection_changed(is_selected: bool) -> void:
-	dna_spline_selection_changed.emit(is_selected)
 
 
 func _on_dna_control_points_selection_changed() -> void:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -565,32 +565,6 @@ func peek_context_of_object_being_created(in_callback: Callable) -> bool:
 
 
 # # # # # #
-# # Edited DNA Spline
-func get_edited_dna_spline_id() -> int:
-	var dna := get_current_structure_context().nano_structure as DnaStructure
-	if dna == null or dna.get_edit_mode() != DnaStructure.EditMode.SequenceAndPath:
-		return Workspace.INVALID_STRUCTURE_ID
-	return dna.int_guid
-
-
-func get_edited_dna_spline_context() -> StructureContext:
-	var dna := get_current_structure_context().nano_structure as DnaStructure
-	if dna == null or dna.get_edit_mode() != DnaStructure.EditMode.SequenceAndPath:
-		return null
-	return get_current_structure_context()
-
-
-func start_editing_dna_spline(in_dna_id: int) -> void:
-	if in_dna_id == get_edited_dna_spline_id():
-		return
-	assert(workspace.get_structure_by_int_guid(in_dna_id) is DnaStructure, "Invalid dna_id")
-	var structure_context: StructureContext = get_nano_structure_context_from_id(in_dna_id)
-	set_current_structure_context(structure_context)
-# # /Edited DNA Spline
-# # # # # #
-
-
-# # # # # #
 # # Simulation
 func start_simulating(in_simulation_data: SimulationData) -> void:
 	assert(not is_simulating(), "I'm already being simulated, make sure to call " +
@@ -743,8 +717,7 @@ func get_nano_structure_context(in_nano_structure: NanoStructure) -> StructureCo
 		_structure_contexts_holder.add_child_with_name(structure_context, in_nano_structure.get_structure_name().to_snake_case())
 		structure_context.selection_changed.connect(_on_structure_context_selection_changed.bind(structure_context.get_int_guid()))
 		structure_context.virtual_object_selection_changed.connect(_on_structure_context_virtual_object_selection_changed.bind(structure_context.get_int_guid()))
-		structure_context.dna_spline_selection_changed.connect(_on_structure_context_dna_spline_selection_changed.bind(structure_context.get_int_guid()))
-		structure_context.dna_control_points_selection_changed.connect(_on_structure_context_dna_spline_selection_changed.bind(true, structure_context.get_int_guid()))
+		structure_context.dna_control_points_selection_changed.connect(_on_structure_context_dna_control_points_selection_changed.bind(structure_context.get_int_guid()))
 		if structure_context.nano_structure is AtomicStructure \
 				and not structure_context.nano_structure.atoms_moved.is_connected(_on_structure_context_atoms_moved):
 			structure_context.nano_structure.atoms_moved.connect(_on_structure_context_atoms_moved.bind(structure_context.get_int_guid()))
@@ -862,7 +835,7 @@ func _on_structure_context_virtual_object_selection_changed(_in_selected: bool, 
 		_selection_modified_structure_contexts[in_structure_context_id] = true
 
 
-func _on_structure_context_dna_spline_selection_changed(_is_selected: bool, in_structure_context_id: int) -> void:
+func _on_structure_context_dna_control_points_selection_changed(in_structure_context_id: int) -> void:
 	if not workspace.has_structure_with_int_guid(in_structure_context_id):
 		return
 	var structure_context: StructureContext = get_structure_context(in_structure_context_id)

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -452,14 +452,11 @@ static func forward_event(out_workspace_context: WorkspaceContext, event: InputE
 static func hide_selected_objects(out_workspace_context: WorkspaceContext) -> void:
 	var structures_with_selection: Array[StructureContext] = out_workspace_context.get_structure_contexts_with_selection()
 	
-	var edited_dna_context: StructureContext = out_workspace_context.get_edited_dna_spline_context()
-	if edited_dna_context != null:
-		if edited_dna_context.is_dna_structure_fully_selected():
-			structures_with_selection = [edited_dna_context]
-		else:
+	for context: StructureContext in structures_with_selection:
+		if context.nano_structure is DnaStructure and context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
 			out_workspace_context.workspace_main_view.editor_viewport_container.show_warning_in_message_bar(
 				out_workspace_context.tr(&"Cannot hide DNA spline control points"))
-			structures_with_selection = []
+			return
 	
 	if structures_with_selection.is_empty():
 		return
@@ -478,7 +475,7 @@ static func hide_selected_objects(out_workspace_context: WorkspaceContext) -> vo
 		elif structure_context.nano_structure is DnaStructure \
 				and structure_context.nano_structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath \
 				and structure_context.is_dna_structure_fully_selected():
-			structure_context.set_dna_spline_selected(false)
+			structure_context.clear_selection()
 			structure_context.nano_structure.set_visible(false)
 		elif structure_context.nano_structure.is_virtual_object() and structure_context.is_virtual_object_selected():
 			structure_context.set_virtual_object_selected(false)


### PR DESCRIPTION
- Now hovering a path will show the control points
- At least one control point selected means chain has selection
- Click on the path selects all control points
- Several DNA paths can be edited at once by selecting their control points
- Control points can be selected along other objects
- When feature flag to treat DNA chain as a group is disabled (default) is not possible to set the dna chain as current structure and add subgroups to it

Task: Creating and Editing DNA