### PR TITLE
Fix crash when undoing changes to DNA control points

### DIFF
--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -153,6 +153,8 @@ func _on_edit_mode_changed(in_mode: DnaStructure.EditMode) -> void:
 
 
 func _on_curve_changed() -> void:
+	if _applying_snapshot:
+		return
 	assert(curve.point_count > 1, "Invalid curve, dna chain should be deleted in this case")
 	_path_representation.queue_redraw()
 	_update_base_transforms()


### PR DESCRIPTION
Tasks:
- CRASH - making and moving 2 DNA control points
- CRASH - Doing undo after converting a DNA object to atoms and bonds