### PR TITLE
Prevent processing hover on renderers that have been destroyed

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
@@ -159,6 +159,8 @@ func _on_workspace_context_hovered_structure_context_changed(
 			in_toplevel_hovered_structure_context: StructureContext, in_hovered_structure_context: StructureContext,
 			in_atom_id: int, in_bond_id: int, in_spring_id: int,
 			_in_dna_control_point_idx: int) -> void:
+	if is_queued_for_deletion():
+		return
 	_current_representation.handle_hover_structure_changed(in_toplevel_hovered_structure_context,
 			in_hovered_structure_context, in_atom_id, in_bond_id, in_spring_id)
 	_springs_representation.handle_hover_structure_changed(in_toplevel_hovered_structure_context,


### PR DESCRIPTION
Task: CRASH: When undoing "Import file" while hovering a group which belongs to the imported file