### PR TITLE
Prevent a crash when aborting a video recording

### DIFF
--- a/godot_project/utils/video_recorder/video_recorder_ffmpeg.gd
+++ b/godot_project/utils/video_recorder/video_recorder_ffmpeg.gd
@@ -56,6 +56,8 @@ func abort() -> void:
 		return
 	OS.kill(_pid)
 	_dispose_video_file(_pid, _filename)
+	_pid = 0
+
 
 static func _dispose_video_file(child_pid: int, filename: String) -> void:
 	while OS.is_process_running(child_pid):
@@ -87,6 +89,8 @@ func _flush_pipes() -> void:
 
 
 func add_frame(in_image: Image) -> void:
+	if not is_running():
+		return
 	_flush_pipes()
 	_write_frame(in_image)
 


### PR DESCRIPTION
Card: CRASH: Pressing "Abort" when recording a simulation crashes MSEP

Something is causing a frame write after the recording was aborted and the video file was deleted.
This PR makes sure the critical method can't be called after the process has been killed.