### PR TITLE
Expose 'Initial Twist' parameter to the DNA Editor Panel

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
@@ -58,6 +58,7 @@ func _on_create_button_pressed() -> void:
 	params.dna_radius_nanometers = _dna_radius_spin_box_slider.value
 	params.bases_per_turn = _bases_per_turn_spin_box_slider.value
 	params.rise_nanometers = _rise_nanometers_spin_box_slider.value
+	params.initial_twist_rad = deg_to_rad(_initial_twist_spin_box_slider.value)
 	var strand_button: Button = _strand_a_button.button_group.get_pressed_button()
 	match strand_button:
 		_strand_a_button:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
@@ -36,6 +36,7 @@ func _notification(what: int) -> void:
 		_dna_radius_spin_box_slider.value_confirmed.connect(_on_dna_radius_spin_box_slider_value_confirmed)
 		_bases_per_turn_spin_box_slider.value_confirmed.connect(_on_bases_per_turn_spin_box_slider_value_confirmed)
 		_rise_nanometers_spin_box_slider.value_confirmed.connect(_on_rise_nanometers_spin_box_slider_value_confirmed)
+		_initial_twist_spin_box_slider.value_confirmed.connect(_on_initial_twist_spin_box_slider_value_confirmed)
 		_strand_a_button.button_group.pressed.connect(_on_strand_policy_button_group_button_pressed)
 		_include_hydrogens_check_button.toggled.connect(_on_include_hydrogens_check_button_toggled)
 		_create_atoms_button.pressed.connect(_on_create_atoms_button_pressed)
@@ -93,7 +94,7 @@ func _on_history_changed() -> void:
 func _set_tracked_structure(in_structure_or_null: DnaStructure) -> void:
 	if in_structure_or_null == _tracked_structure:
 		return
-	if _tracked_structure != null:
+	if _tracked_structure != null and _tracked_structure.sequence_changed.is_connected(_on_tracked_structure_sequence_changed):
 		_tracked_structure.sequence_changed.disconnect(_on_tracked_structure_sequence_changed)
 	_tracked_structure = in_structure_or_null
 	if _tracked_structure != null and not _tracked_structure.sequence_changed.is_connected(_on_tracked_structure_sequence_changed):
@@ -225,6 +226,14 @@ func _on_rise_nanometers_spin_box_slider_value_confirmed(in_value: float) -> voi
 	_tracked_structure.set_rise_nanometers(in_value)
 	_tracked_structure.end_edit()
 	_workspace_context.snapshot_moment("Set Dna Rise per Base")
+
+
+func _on_initial_twist_spin_box_slider_value_confirmed(in_value: float) -> void:
+	assert(_tracked_structure != null)
+	_tracked_structure.start_edit()
+	_tracked_structure.set_initial_twist_rad(deg_to_rad(in_value))
+	_tracked_structure.end_edit()
+	_workspace_context.snapshot_moment("Set Initial Helix Twist")
 
 
 func _on_strand_policy_button_group_button_pressed(in_button: Button) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.gd
@@ -6,6 +6,7 @@ var _dna_sequence_text_edit: TextEdit
 var _dna_radius_spin_box_slider: SpinBoxSlider
 var _bases_per_turn_spin_box_slider: SpinBoxSlider
 var _rise_nanometers_spin_box_slider: SpinBoxSlider
+var _initial_twist_spin_box_slider: SpinBoxSlider
 var _strand_a_button: Button
 var _strand_b_button: Button
 var _strand_double_button: Button
@@ -18,6 +19,7 @@ func _notification(what: int) -> void:
 		_dna_radius_spin_box_slider = %DnaRadiusSpinBoxSlider as SpinBoxSlider
 		_bases_per_turn_spin_box_slider = %BasesPerTurnSpinBoxSlider as SpinBoxSlider
 		_rise_nanometers_spin_box_slider = %RiseNanometersSpinBoxSlider as SpinBoxSlider
+		_initial_twist_spin_box_slider = %InitialTwistSpinBoxSlider as SpinBoxSlider
 		_strand_a_button = %StrandAButton as Button
 		_strand_b_button = %StrandBButton as Button
 		_strand_double_button = %StrandDoubleButton as Button

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
@@ -86,6 +86,19 @@ allow_greater = true
 suffix = "nm"
 custom_arrow_step = 0.05
 
+[node name="Label5" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer"]
+layout_mode = 2
+text = "Twist"
+
+[node name="InitialTwistSpinBoxSlider" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer" instance=ExtResource("3_w42n7")]
+unique_name_in_owner = true
+layout_mode = 2
+max_value = 360.0
+step = 0.01
+allow_greater = true
+suffix = "º"
+custom_arrow_step = 1.0
+
 [node name="Label2" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer"]
 layout_mode = 2
 text = "Strands"


### PR DESCRIPTION
BUG: Initial Twist of DNA Structures cannot be set from UI