### PR TITLE
Fix Visual representation of DNA strands not matching position of generated atoms

### DIFF
--- a/godot_project/autoloads/dna_builder/templates/adenine.tres
+++ b/godot_project/autoloads/dna_builder/templates/adenine.tres
@@ -7,4 +7,5 @@ script = ExtResource("1_ndu00")
 atoms = PackedVector4Array(0.0593836, -0.101862, 0.00187003, 7, -0.0802858, -0.0896164, 0.00208003, 6, -0.108114, 0.0491834, 0.00190003, 6, 0.0139528, 0.11927, 0.000900026, 7, 0.112849, 0.0289628, 0.00104003, 6, -0.244242, 0.0890022, 0.00237003, 6, -0.339684, -0.00840737, 2.00261e-05, 7, -0.303798, -0.140971, 0.000600026, 6, -0.177457, -0.187182, 0.00182003, 7, -0.286699, 0.221306, 0.01506, 7)
 bonds = Array[Vector3i]([Vector3i(0, 4, 1), Vector3i(0, 1, 1), Vector3i(1, 8, 1), Vector3i(1, 2, 2), Vector3i(2, 3, 1), Vector3i(2, 5, 1), Vector3i(3, 4, 2), Vector3i(5, 6, 2), Vector3i(5, 9, 1), Vector3i(6, 7, 1), Vector3i(7, 8, 2)])
 base_to_backbone_atom_id = 0
-backbone_to_backbone_atom_id = -1
+next_backbone_atom_id = -1
+previous_backbone_atom_id = -1

--- a/godot_project/editor/rendering/dna_structure_renderer/assets/dna_base_representation.tscn
+++ b/godot_project/editor/rendering/dna_structure_renderer/assets/dna_base_representation.tscn
@@ -33,7 +33,7 @@ mesh = SubResource("SphereMesh_i33sh")
 
 [node name="A" type="MeshInstance3D" parent="Origin"]
 unique_name_in_owner = true
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0)
+transform = Transform3D(-1, -7.6427e-15, 8.74228e-08, -8.74228e-08, 1.31133e-07, -1, -3.82133e-15, -1, -1.31133e-07, 0, 0, 0)
 
 [node name="BackboneA" type="MeshInstance3D" parent="Origin/A"]
 unique_name_in_owner = true
@@ -59,7 +59,7 @@ skeleton = NodePath("../..")
 
 [node name="B" type="MeshInstance3D" parent="Origin"]
 unique_name_in_owner = true
-transform = Transform3D(-1, -8.74228e-08, -3.82137e-15, 0, -4.37114e-08, 1, -8.74228e-08, 1, 4.37114e-08, 0, 0, 0)
+transform = Transform3D(1, 8.74228e-08, 8.74228e-08, 8.74228e-08, -4.37104e-08, -1, -8.74228e-08, 1, -4.37104e-08, 0, 0, 0)
 
 [node name="BackboneB" type="MeshInstance3D" parent="Origin/B"]
 unique_name_in_owner = true


### PR DESCRIPTION
- The entire helix was rotated 180º, which semmed right with 2 strands, but was wrong with 1 strand

BUG: When Calculating DNA positions for a single strand, the position of the wrong strand are calculated