### PR TITLE
Fix wrong generation of the DNA Structure bond cache

### DIFF
--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -850,6 +850,12 @@ func get_valid_bonds() -> PackedInt32Array:
 	if _edit_mode != EditMode.AtomsAndBonds:
 		return []
 	
+	if get_strand_policy() != StrandPolicy.DOUBLE:
+		var strand: Strand = get_strands()[0]
+		if _bonds_ids_cache.get(strand, []).is_empty():
+			_bonds_ids_cache[strand] = get_bond_ids_for_strand(strand)
+		return _bonds_ids_cache[strand]
+	
 	if not _bonds_ids_cache.get(Strand.BOTH, []).is_empty():
 		return _bonds_ids_cache[Strand.BOTH]
 	


### PR DESCRIPTION
- The system was generating the bond cache using Strand.BOTH as key, thus returning wrong values when switching Strand policy

Task: CRASH: Using DNA Object to generate A Strand, then B Strand