### PR TITLE
Fix bond order of P=O in DNA backbone

### DIFF
--- a/godot_project/autoloads/dna_builder/templates/backbone0.tres
+++ b/godot_project/autoloads/dna_builder/templates/backbone0.tres
@@ -1,11 +1,11 @@
-[gd_resource type="Resource" load_steps=2 format=4]
+[gd_resource type="Resource" load_steps=2 format=4 uid="uid://hy8bee2oqjff"]
 
-[ext_resource type="Script" path="res://autoloads/dna_builder/templates/packed_molecule.gd" id="1_wqgvg"]
+[ext_resource type="Script" uid="uid://8g2sevldq0c2" path="res://autoloads/dna_builder/templates/packed_molecule.gd" id="1_wqgvg"]
 
 [resource]
 script = ExtResource("1_wqgvg")
 atoms = PackedVector4Array(-0.0173954, 0.101276, 0.168953, 15, 0.109705, 0.0967765, 0.244653, 8, -0.0235953, 0.199076, 0.0581526, 8, -0.123595, -0.136423, 0.198753, 6, -0.0522954, -0.0448235, 0.113653, 8, -0.231995, -0.206923, 0.119653, 6, -0.357495, -0.132923, 0.119353, 8, -0.202195, -0.229523, -0.0285474, 6, -0.255995, -0.355323, -0.0676474, 8, -0.279395, -0.119123, -0.100847, 6, -0.404795, -0.125623, -0.0142474, 6)
-bonds = Array[Vector3i]([Vector3i(0, 1, 1), Vector3i(0, 2, 1), Vector3i(0, 4, 1), Vector3i(3, 4, 1), Vector3i(3, 5, 1), Vector3i(5, 6, 1), Vector3i(5, 7, 1), Vector3i(6, 10, 1), Vector3i(7, 8, 1), Vector3i(7, 9, 1), Vector3i(9, 10, 1)])
+bonds = Array[Vector3i]([Vector3i(0, 1, 2), Vector3i(0, 2, 1), Vector3i(0, 4, 1), Vector3i(3, 4, 1), Vector3i(3, 5, 1), Vector3i(5, 6, 1), Vector3i(5, 7, 1), Vector3i(6, 10, 1), Vector3i(7, 8, 1), Vector3i(7, 9, 1), Vector3i(9, 10, 1)])
 base_to_backbone_atom_id = 10
 next_backbone_atom_id = 0
 previous_backbone_atom_id = 8

--- a/godot_project/autoloads/dna_builder/templates/backbone0_h.tres
+++ b/godot_project/autoloads/dna_builder/templates/backbone0_h.tres
@@ -1,11 +1,11 @@
-[gd_resource type="Resource" load_steps=2 format=4]
+[gd_resource type="Resource" load_steps=2 format=4 uid="uid://ceoi8pklwt6gy"]
 
-[ext_resource type="Script" path="res://autoloads/dna_builder/templates/packed_molecule.gd" id="1_qvnkp"]
+[ext_resource type="Script" uid="uid://8g2sevldq0c2" path="res://autoloads/dna_builder/templates/packed_molecule.gd" id="1_qvnkp"]
 
 [resource]
 script = ExtResource("1_qvnkp")
 atoms = PackedVector4Array(-0.0173954, 0.101276, 0.168953, 15, 0.109705, 0.0967765, 0.244653, 8, -0.0235953, 0.199076, 0.0581526, 8, -0.123595, -0.136423, 0.198753, 6, -0.0522954, -0.0448235, 0.113653, 8, -0.231995, -0.206923, 0.119653, 6, -0.357495, -0.132923, 0.119353, 8, -0.202195, -0.229523, -0.0285474, 6, -0.255995, -0.355323, -0.0676474, 8, -0.279395, -0.119123, -0.100847, 6, -0.404795, -0.125623, -0.0142474, 6, -0.168213, -0.0822969, 0.279553, 1, -0.0553235, -0.20899, 0.237766, 1, -0.23753, -0.300744, 0.1708, 1, -0.0974017, -0.228152, -0.0501226, 1, -0.298958, -0.14303, -0.203291, 1, -0.230373, -0.0241896, -0.095057, 1, -0.462563, -0.212399, -0.0383662, 1)
-bonds = Array[Vector3i]([Vector3i(0, 1, 1), Vector3i(0, 2, 1), Vector3i(0, 4, 1), Vector3i(3, 4, 1), Vector3i(3, 5, 1), Vector3i(5, 6, 1), Vector3i(5, 7, 1), Vector3i(6, 10, 1), Vector3i(7, 8, 1), Vector3i(7, 9, 1), Vector3i(9, 10, 1), Vector3i(3, 11, 1), Vector3i(3, 12, 1), Vector3i(5, 13, 1), Vector3i(7, 14, 1), Vector3i(9, 15, 1), Vector3i(9, 16, 1), Vector3i(10, 17, 1)])
+bonds = Array[Vector3i]([Vector3i(0, 1, 2), Vector3i(0, 2, 1), Vector3i(0, 4, 1), Vector3i(3, 4, 1), Vector3i(3, 5, 1), Vector3i(5, 6, 1), Vector3i(5, 7, 1), Vector3i(6, 10, 1), Vector3i(7, 8, 1), Vector3i(7, 9, 1), Vector3i(9, 10, 1), Vector3i(3, 11, 1), Vector3i(3, 12, 1), Vector3i(5, 13, 1), Vector3i(7, 14, 1), Vector3i(9, 15, 1), Vector3i(9, 16, 1), Vector3i(10, 17, 1)])
 base_to_backbone_atom_id = 10
 next_backbone_atom_id = 0
 previous_backbone_atom_id = 8

--- a/godot_project/autoloads/dna_builder/templates/backbone1.tres
+++ b/godot_project/autoloads/dna_builder/templates/backbone1.tres
@@ -1,11 +1,11 @@
-[gd_resource type="Resource" load_steps=2 format=4]
+[gd_resource type="Resource" load_steps=2 format=4 uid="uid://bsl5m6axsoofx"]
 
-[ext_resource type="Script" path="res://autoloads/dna_builder/templates/packed_molecule.gd" id="1_var2y"]
+[ext_resource type="Script" uid="uid://8g2sevldq0c2" path="res://autoloads/dna_builder/templates/packed_molecule.gd" id="1_var2y"]
 
 [resource]
 script = ExtResource("1_var2y")
 atoms = PackedVector4Array(-0.0173954, -0.101276, -0.168953, 15, 0.109705, -0.0967765, -0.244653, 8, -0.0235953, -0.199076, -0.0581526, 8, -0.123595, 0.136423, -0.198753, 6, -0.0522954, 0.0448235, -0.113653, 8, -0.231995, 0.206923, -0.119653, 6, -0.357495, 0.132923, -0.119353, 8, -0.202195, 0.229523, 0.0285474, 6, -0.255995, 0.355323, 0.0676474, 8, -0.279395, 0.119123, 0.100847, 6, -0.404795, 0.125623, 0.0142474, 6)
-bonds = Array[Vector3i]([Vector3i(0, 1, 1), Vector3i(0, 2, 1), Vector3i(0, 4, 1), Vector3i(3, 4, 1), Vector3i(3, 5, 1), Vector3i(5, 6, 1), Vector3i(5, 7, 1), Vector3i(6, 10, 1), Vector3i(7, 8, 1), Vector3i(7, 9, 1), Vector3i(9, 10, 1)])
+bonds = Array[Vector3i]([Vector3i(0, 1, 2), Vector3i(0, 2, 1), Vector3i(0, 4, 1), Vector3i(3, 4, 1), Vector3i(3, 5, 1), Vector3i(5, 6, 1), Vector3i(5, 7, 1), Vector3i(6, 10, 1), Vector3i(7, 8, 1), Vector3i(7, 9, 1), Vector3i(9, 10, 1)])
 base_to_backbone_atom_id = 10
 next_backbone_atom_id = 8
 previous_backbone_atom_id = 0

--- a/godot_project/autoloads/dna_builder/templates/backbone1_h.tres
+++ b/godot_project/autoloads/dna_builder/templates/backbone1_h.tres
@@ -1,11 +1,11 @@
-[gd_resource type="Resource" load_steps=2 format=4]
+[gd_resource type="Resource" load_steps=2 format=4 uid="uid://dhouxn0sfvens"]
 
-[ext_resource type="Script" path="res://autoloads/dna_builder/templates/packed_molecule.gd" id="1_y2y8t"]
+[ext_resource type="Script" uid="uid://8g2sevldq0c2" path="res://autoloads/dna_builder/templates/packed_molecule.gd" id="1_y2y8t"]
 
 [resource]
 script = ExtResource("1_y2y8t")
 atoms = PackedVector4Array(-0.0173954, -0.101276, -0.168953, 15, 0.109705, -0.0967765, -0.244653, 8, -0.0235953, -0.199076, -0.0581526, 8, -0.123595, 0.136423, -0.198753, 6, -0.0522954, 0.0448235, -0.113653, 8, -0.231995, 0.206923, -0.119653, 6, -0.357495, 0.132923, -0.119353, 8, -0.202195, 0.229523, 0.0285474, 6, -0.255995, 0.355323, 0.0676474, 8, -0.279395, 0.119123, 0.100847, 6, -0.404795, 0.125623, 0.0142474, 6, -0.168213, 0.0822969, -0.279553, 1, -0.0553235, 0.20899, -0.237766, 1, -0.23753, 0.300744, -0.1708, 1, -0.0974017, 0.228152, 0.0501226, 1, -0.298958, 0.14303, 0.203291, 1, -0.230373, 0.0241896, 0.095057, 1, -0.462563, 0.212399, 0.0383662, 1)
-bonds = Array[Vector3i]([Vector3i(0, 1, 1), Vector3i(0, 2, 1), Vector3i(0, 4, 1), Vector3i(3, 4, 1), Vector3i(3, 5, 1), Vector3i(5, 6, 1), Vector3i(5, 7, 1), Vector3i(6, 10, 1), Vector3i(7, 8, 1), Vector3i(7, 9, 1), Vector3i(9, 10, 1), Vector3i(3, 11, 1), Vector3i(3, 12, 1), Vector3i(5, 13, 1), Vector3i(7, 14, 1), Vector3i(9, 15, 1), Vector3i(9, 16, 1), Vector3i(10, 17, 1)])
+bonds = Array[Vector3i]([Vector3i(0, 1, 2), Vector3i(0, 2, 1), Vector3i(0, 4, 1), Vector3i(3, 4, 1), Vector3i(3, 5, 1), Vector3i(5, 6, 1), Vector3i(5, 7, 1), Vector3i(6, 10, 1), Vector3i(7, 8, 1), Vector3i(7, 9, 1), Vector3i(9, 10, 1), Vector3i(3, 11, 1), Vector3i(3, 12, 1), Vector3i(5, 13, 1), Vector3i(7, 14, 1), Vector3i(9, 15, 1), Vector3i(9, 16, 1), Vector3i(10, 17, 1)])
 base_to_backbone_atom_id = 10
 next_backbone_atom_id = 8
 previous_backbone_atom_id = 0


### PR DESCRIPTION
NOTE: There are still some lose oxygens with incomplete valence. This matches PYMOL (see attached screenshot) and papers:
[Why is DNA Negatively Charged?](https://www.geeksforgeeks.org/biology/why-is-dna-negatively-charged/)
DNA is negatively charged because of the presence of negatively charged phosphate groups. In the phosphate group there is single negatively charged oxygen, which makes the entire DNA negatively charged. Negativity of DNA helps in joining two strands of DNA together to form a double helical structure. Now let's make the concept more clear about Double helical structure of DNA.

Task: BUG - Include Hydrogens Feature of DNA object doesn't fill the valences completely

<img width="815" height="568" alt="image" src="https://github.com/user-attachments/assets/547c28b3-4ebf-494e-99e5-5b8a1361e085" />
