### PR TITLE
DNA: Automatically switch to and from AtomsAndBonds mode when simulation starts/stops

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=10 format=3 uid="uid://6h5ogu2meano"]
+[gd_scene load_steps=11 format=3 uid="uid://6h5ogu2meano"]
 
 [ext_resource type="PackedScene" uid="uid://bdeg2b7ycyi66" path="res://editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn" id="1_mfh7i"]
 [ext_resource type="Script" uid="uid://cdcgvv0jwwf6c" path="res://editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd" id="2_q7pc7"]
 [ext_resource type="PackedScene" uid="uid://b2b25o2443x3b" path="res://editor/controls/general/info_label.tscn" id="3_673q0"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_673q0"]
+
+[sub_resource type="ButtonGroup" id="ButtonGroup_gmhsj"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_q7pc7"]
 
@@ -262,6 +264,12 @@ size_flags_vertical = 4
 text = "[center]ℹ In this mode, atoms can be selected, moved, relaxed, etc, but cannot be deleted or modified. New atoms and bonds cannot b added[/center]"
 message = &"In this mode, atoms can be selected, moved, relaxed, etc, but cannot be deleted or modified. New atoms and bonds cannot b added"
 effect = "none"
+
+[node name="RandSequenceButton" parent="VBoxContainer/SequencePanelContainer/VBoxContainer/HBoxContainer" index="0"]
+button_group = SubResource("ButtonGroup_gmhsj")
+
+[node name="UserDefinedSequenceButton" parent="VBoxContainer/SequencePanelContainer/VBoxContainer/HBoxContainer" index="1"]
+button_group = SubResource("ButtonGroup_gmhsj")
 
 [node name="StrandAButton" parent="VBoxContainer/PanelContainer/VBoxContainer/MarginContainer/GridContainer/HBoxContainer" index="0"]
 button_group = SubResource("ButtonGroup_q7pc7")

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -312,7 +312,9 @@ func _update_controls() -> void:
 func _has_valid_atoms() -> bool:
 	if not is_instance_valid(_workspace_context):
 		return false
-	return _workspace_context.has_valid_atoms() or _workspace_context.has_valid_particle_emitters()
+	return _workspace_context.has_valid_atoms() \
+			or _workspace_context.has_valid_particle_emitters() \
+			or _workspace_context.has_valid_dna_objects()
 
 
 func _is_simulation_complete() -> bool:
@@ -514,6 +516,13 @@ func _on_button_start_pause_pressed() -> void:
 			if _workspace_context.has_motors() and FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAG_VIRTUAL_MOTORS_SIMULATION_WARNING):
 				_motors_warning_dialog.popup_centered()
 				await _motors_warning_dialog.closed
+			
+			# Turn all Dna Structures into atoms and bonds
+			for ctx: StructureContext in _workspace_context.get_all_structure_contexts():
+				if ctx.nano_structure is DnaStructure:
+					ctx.clear_selection()
+					var dna := ctx.nano_structure as DnaStructure
+					dna.set_edit_mode(DnaStructure.EditMode.AtomsAndBonds)
 			
 			# Copy simulation config to Workspace's simulation params
 			var params: SimulationParameters = _workspace_context.workspace.simulation_parameters
@@ -747,6 +756,13 @@ func _on_button_revert_pressed() -> void:
 			await promise.wait_for_fulfill()
 			if not promise.get_result():
 				return
+		
+		# Turn all Dna Structures back into simplified representation
+		for ctx: StructureContext in _workspace_context.get_all_structure_contexts():
+			if ctx.nano_structure is DnaStructure:
+				var dna := ctx.nano_structure as DnaStructure
+				dna.set_edit_mode(DnaStructure.EditMode.SequenceAndPath)
+		
 		_workspace_context.abort_simulation_if_running()
 		_status = Status.INACTIVE
 

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.tscn
@@ -98,7 +98,6 @@ value = 20.0
 allow_greater = true
 suffix = "steps"
 custom_arrow_step = 100.0
-select_all_on_focus = true
 
 [node name="Label5" type="Label" parent="PanelContainer/VBoxContainer/GridContainer"]
 layout_mode = 2
@@ -116,7 +115,6 @@ value = 200.0
 allow_greater = true
 suffix = "frames"
 custom_arrow_step = 100.0
-select_all_on_focus = true
 
 [node name="Label6" type="Label" parent="PanelContainer/VBoxContainer/GridContainer"]
 layout_mode = 2

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -164,6 +164,19 @@ func get_baked_path(in_path_override: Curve3D = null) -> PackedVector3Array:
 	return _baked_path.duplicate()
 
 
+func notify_added_to_workspace(in_workspace_context: WorkspaceContext) -> void:
+	if not in_workspace_context.about_to_apply_simulation.is_connected(_on_about_to_apply_simulation):
+		in_workspace_context.about_to_apply_simulation.connect(_on_about_to_apply_simulation)
+
+
+func _on_about_to_apply_simulation() -> void:
+	if _edit_mode == DnaStructure.EditMode.AtomsAndBonds:
+		start_edit()
+		apply_simulation_state()
+		end_edit()
+		set_edit_mode(DnaStructure.EditMode.SequenceAndPath)
+
+
 #region: Edit tracking
 func set_edit_mode(in_mode: EditMode) -> void:
 	# This may be counter intuitive, but logic is you should not be able to change
@@ -196,6 +209,11 @@ func set_edit_mode(in_mode: EditMode) -> void:
 		atoms_added.emit(atoms_to_signal)
 		bonds_created.emit(bonds_to_signal)
 	edit_mode_changed.emit(in_mode)
+
+
+func apply_simulation_state() -> void:
+	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
+	push_warning("TODO: Adjust path to roughly match the positions of atoms")
 
 
 func get_edit_mode() -> EditMode:
@@ -699,7 +717,8 @@ func atom_get_position(in_atom_id: int) -> Vector3:
 ## This is uniquely supported to update atoms positions during simulation
 func atom_set_position(in_atom_id: int, in_pos: Vector3) -> bool:
 	assert(_is_being_edited)
-	assert(_edit_mode == EditMode.AtomsAndBonds, "Atoms and Bonds cannot be edited in this mode")
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return false
 	const TO_UPDATE_POSITION = true
 	_get_atom_data(in_atom_id, TO_UPDATE_POSITION).position = in_pos
 	_signal_queue_atoms_moved.push_back(in_atom_id)
@@ -710,6 +729,8 @@ func atom_set_position(in_atom_id: int, in_pos: Vector3) -> bool:
 ## for performance reasons - this way [code]changed[/code] signal is emitted only once
 func atoms_set_positions(in_atoms: PackedInt32Array, in_positions: PackedVector3Array) -> void:
 	assert(in_atoms.size() == in_positions.size())
+	if _edit_mode != EditMode.AtomsAndBonds:
+		return
 	for i in in_atoms.size():
 		atom_set_position(in_atoms[i], in_positions[i])
 

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -663,6 +663,7 @@ func end_simulation_if_running() -> void:
 func apply_simulation_if_running() -> void:
 	if !is_simulating():
 		return
+	
 	OpenMM.request_abort_simulation(_simulation)
 	about_to_apply_simulation.emit()
 	_simulation = null
@@ -1321,6 +1322,15 @@ func has_valid_particle_emitters() -> bool:
 			var template: AtomicStructure = null if parameters == null else parameters.get_molecule_template()
 			var atoms_count: int = 0 if template == null else template.get_valid_atoms_count()
 			if atoms_count > 0:
+				return true
+	return false
+
+
+func has_valid_dna_objects() -> bool:
+	for context: StructureContext in _structure_contexts.values():
+		if context.nano_structure is DnaStructure:
+			var dna := context.nano_structure as DnaStructure
+			if dna.get_sequence_length() > 0:
 				return true
 	return false
 


### PR DESCRIPTION
Task: DNA: Automatically switch between path and atoms+bonds mode when simulation starts/stops