### PR TITLE
Don't show DNA Objects as a group in the Group Selector at the top of the viewport

### DIFF
--- a/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_button/structure_selector_button.gd
+++ b/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_button/structure_selector_button.gd
@@ -81,7 +81,7 @@ func _has_children_not_in_path(in_nano_structure: NanoStructure) -> bool:
 
 func _is_not_in_path_to_active_structure(in_nano_structure: NanoStructure) -> bool:
 	# Shapes, Motors, and DNAStructures are intentionally hidden of the list
-	var is_valid_group: bool = not in_nano_structure.is_virtual_object()
+	var is_valid_group: bool = not in_nano_structure.is_virtual_object() and not in_nano_structure is DnaStructure
 	if not is_valid_group:
 		return false
 	var path: Array[NanoStructure] = _get_path_to_current_structure()

--- a/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_child_list/structure_child_list.gd
+++ b/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_child_list/structure_child_list.gd
@@ -130,7 +130,7 @@ func _get_child_structures() -> Array[NanoStructure]:
 		children_structures = _workspace_context.workspace.get_child_structures(
 				_parent_structure_context.nano_structure)
 	var is_valid_group: Callable = func(in_nano_structure: NanoStructure) -> bool:
-		return not in_nano_structure.is_virtual_object()
+		return not in_nano_structure.is_virtual_object() and not in_nano_structure is DnaStructure
 	return children_structures.filter(is_valid_group)
 
 


### PR DESCRIPTION
Task: CRASH: DNA Objects shows in the GroupSelector at the top of the viewport. Selecting them will crash the editor

| Before | After |
|-----|------|
| <img width="1162" height="648" alt="image" src="https://github.com/user-attachments/assets/56ee5fac-6b7d-422a-b38a-35df80d59057" /> | <img width="1164" height="629" alt="image" src="https://github.com/user-attachments/assets/daf77fe2-90a7-4873-b2e1-cb9a5c62db49" /> |