### PR TITLE
In MacOS, propagate to viewport the presses of Command key

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/editor_viewport.gd
+++ b/godot_project/editor/controls/editor_viewport_container/editor_viewport.gd
@@ -17,7 +17,8 @@ const INPUT_EVENT_ACTIONS_WHITELIST: Array[StringName] = [
 ]
 
 const INPUT_KEYS_WHITELIST: Array[Key] = [
-	KEY_ALT
+	KEY_ALT,
+	KEY_META,
 ]
 
 ## Returns the WorkspaceContext associated to the active workspace


### PR DESCRIPTION
This is a follow-up to https://github.com/MSEP-one/msep.one/pull/502
Forwarding only Alt/Option keys was not enough, and not forwarding shift will prevent the original issue that we had

Task: BUG - CNTL-Option can toggle app into a state where the editor does not match the 'Show Potential Atom Positions" control in the Workspace tab