### PR TITLE
When exporting a project, add a setting to export DNA Objects as a collection of atoms and bonds

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -252,12 +252,20 @@ func save_workspace(in_workspace: Workspace, in_path: String = "") -> void:
 	_update_window_title()
 
 
-func export_workspace(in_workspace: Workspace, in_path: String = "") -> void:
+func export_workspace(in_workspace: Workspace, in_path: String = "", in_export_dna: bool = false) -> void:
 	var path: String = in_path
 	if path.is_empty():
 		Editor_Utils.get_editor().show_export_workspace_dialog(in_workspace)
 		return
+	var revert_dna_modes: Array[DnaStructure]
+	if in_export_dna and not get_current_workspace_context().is_simulating():
+		for structure: NanoStructure in in_workspace.get_structures():
+			if structure is DnaStructure and structure.get_edit_mode() == DnaStructure.EditMode.SequenceAndPath:
+				revert_dna_modes.append(structure)
+				structure.set_edit_mode(DnaStructure.EditMode.AtomsAndBonds)
 	var err: Error = ResourceSaver.save(in_workspace, path)
+	for structure: DnaStructure in revert_dna_modes:
+		structure.set_edit_mode(DnaStructure.EditMode.SequenceAndPath)
 	if err != OK:
 		Editor_Utils.get_editor().prompt_error_msg(tr(&"Failed to export to file {0} with error '{1}'").format([path, error_string(err)]))
 
@@ -482,8 +490,8 @@ func _on_molecular_editor_load_workspace_confirmed(in_path: String) -> void:
 	load_and_activate_workspace(in_path)
 
 
-func _on_molecular_editor_export_workspace_confirmed(in_workspace: Workspace, in_path: String) -> void:
-	export_workspace(in_workspace, in_path)
+func _on_molecular_editor_export_workspace_confirmed(in_workspace: Workspace, in_path: String, in_export_dna: bool) -> void:
+	export_workspace(in_workspace, in_path, in_export_dna)
 
 
 func _on_about_msep_one_confirmed() -> void:

--- a/godot_project/editor/MolecularEditor.gd
+++ b/godot_project/editor/MolecularEditor.gd
@@ -4,7 +4,7 @@ class_name MolecularEditor
 
 signal load_workspace_confirmed(in_path: String)
 signal save_workspace_confirmed(in_workspace: Workspace, in_path: String)
-signal export_workspace_confirmed(in_workspace: Workspace, in_path: String)
+signal export_workspace_confirmed(in_workspace: Workspace, in_path: String, in_export_dna_enabled: bool)
 
 
 const WINDOW_MINIMUM_SIZE := Vector2i(930, 560)
@@ -138,7 +138,7 @@ func _on_export_file_dialog_file_selected(in_path: String) -> void:
 		var workspace: WeakRef = export_file_dialog.get_meta(&"__workspace__", null)
 		assert(workspace.get_ref() != null and workspace.get_ref() is Workspace,
 			"Workspace is invalid, cannot save")
-		export_workspace_confirmed.emit(workspace.get_ref(), in_path)
+		export_workspace_confirmed.emit(workspace.get_ref(), in_path, export_file_dialog.is_export_dna_enabled())
 
 
 func show_open_workspace_dialog() -> void:

--- a/godot_project/editor/MolecularEditor.tscn
+++ b/godot_project/editor/MolecularEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://cgb7a8s4egpox"]
+[gd_scene load_steps=11 format=3 uid="uid://cgb7a8s4egpox"]
 
 [ext_resource type="Script" uid="uid://dv8mr4midqkwd" path="res://editor/MolecularEditor.gd" id="1_u8b6i"]
 [ext_resource type="PackedScene" uid="uid://b711oqbglehtg" path="res://editor/controls/menu_bar/menu_bar.tscn" id="2_a3o8y"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://d27bh6k3cluw1" path="res://editor/controls/workspace_view/tab_container_active_workspaces.tscn" id="5_3fwwi"]
 [ext_resource type="Script" uid="uid://d2k0yfuvhmtby" path="res://editor/controls/general/nano_file_dialog.gd" id="6_2adso"]
 [ext_resource type="PackedScene" uid="uid://dj61no1d5t16w" path="res://editor/controls/import_file_dialog/import_file_dialog.tscn" id="6_criww"]
+[ext_resource type="PackedScene" uid="uid://dgpgayamq4wyw" path="res://editor/controls/export_file_dialog/export_file_dialog.tscn" id="7_cbhof"]
 [ext_resource type="PackedScene" uid="uid://18crkb1kbthw" path="res://editor/controls/template_library_dialog/template_library_dialog.tscn" id="7_uupny"]
 [ext_resource type="PackedScene" uid="uid://dg7wgefiwe42n" path="res://editor/controls/camera_position_dialog/camera_position_dialog.tscn" id="8_1w46u"]
 [ext_resource type="PackedScene" uid="uid://ddist487qh8in" path="res://editor/controls/video_tutorials_dialog/video_tutorials_dialog.tscn" id="9_18n8r"]
@@ -77,13 +78,8 @@ access = 2
 filters = PackedStringArray("*.msep1 ; MSEP.one Workspace")
 script = ExtResource("6_2adso")
 
-[node name="ExportFileDialog" type="FileDialog" parent="."]
+[node name="ExportFileDialog" parent="." instance=ExtResource("7_cbhof")]
 unique_name_in_owner = true
-title = "Export a File"
-size = Vector2i(392, 175)
-access = 2
-filters = PackedStringArray("*.xyz ; XYZ format", "*.pdb ; Protein Data Bank format")
-script = ExtResource("6_2adso")
 
 [node name="TemplateLibraryDialog" parent="." instance=ExtResource("7_uupny")]
 unique_name_in_owner = true

--- a/godot_project/editor/controls/export_file_dialog/export_file_dialog.gd
+++ b/godot_project/editor/controls/export_file_dialog/export_file_dialog.gd
@@ -1,0 +1,38 @@
+extends NanoFileDialog
+
+
+const _MAIN_CONTAINER_INTERNAL_INDEX = 3
+const ExportSettingsScn: PackedScene = preload("uid://dtxfj1243co7v")
+
+
+var _main_container: VBoxContainer = null
+var _export_settings: VBoxContainer = null
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_SCENE_INSTANTIATED:
+		hide()
+		# Godot overrides title and OK text when instancing the dialog
+		# Because of that we manually set it from code
+		title = tr(&"Export a File")
+		ok_button_text = tr(&"Save")
+		if _export_settings == null:
+			_main_container = get_child(_MAIN_CONTAINER_INTERNAL_INDEX, true) as VBoxContainer
+			assert(_main_container)
+			_export_settings = ExportSettingsScn.instantiate()
+			_main_container.add_child(_export_settings)
+
+
+func _ready() -> void:
+	about_to_popup.connect(_on_about_to_popup)
+
+
+func is_export_dna_enabled() -> bool:
+	return _export_settings.is_export_dna_enabled()
+
+
+func _on_about_to_popup() -> void:
+	_export_settings.set_export_dna_enabled(true)
+	_export_settings.visible = _export_settings.should_show()
+
+

--- a/godot_project/editor/controls/export_file_dialog/export_file_dialog.gd.uid
+++ b/godot_project/editor/controls/export_file_dialog/export_file_dialog.gd.uid
@@ -1,0 +1,1 @@
+uid://drvivjbvt3g7p

--- a/godot_project/editor/controls/export_file_dialog/export_file_dialog.tscn
+++ b/godot_project/editor/controls/export_file_dialog/export_file_dialog.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3 uid="uid://dgpgayamq4wyw"]
+
+[ext_resource type="Script" uid="uid://drvivjbvt3g7p" path="res://editor/controls/export_file_dialog/export_file_dialog.gd" id="1_nmlx1"]
+
+[node name="ExportFileDialog" type="FileDialog"]
+auto_translate_mode = 1
+title = "Export a File"
+size = Vector2i(392, 175)
+access = 2
+filters = PackedStringArray("*.xyz ; XYZ format", "*.pdb ; Protein Data Bank format")
+script = ExtResource("1_nmlx1")

--- a/godot_project/editor/controls/export_file_dialog/export_settings.gd
+++ b/godot_project/editor/controls/export_file_dialog/export_settings.gd
@@ -1,0 +1,42 @@
+extends VBoxContainer
+
+var _check_export_dna: CheckBox
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_SCENE_INSTANTIATED:
+		_check_export_dna = %CheckExportDNA as CheckBox
+
+
+func should_show() -> bool:
+	var any_visible: bool = false
+	any_visible = any_visible or _should_show_checkbox(
+		_check_export_dna,
+		FeatureFlagManager.FEATURE_FLAGS_DNA_BUILDER,
+		_does_current_workspace_has_dna
+	)
+	return any_visible
+
+
+func set_export_dna_enabled(in_enabled: bool) -> void:
+	_check_export_dna.button_pressed = in_enabled
+
+
+func is_export_dna_enabled() -> bool:
+	return _check_export_dna.visible and _check_export_dna.button_pressed
+
+
+func _should_show_checkbox(checkbox: CheckBox, feature_flag: StringName, extra_condition_callback := Callable()) -> bool:
+	var extra_condition: bool = true if extra_condition_callback.is_null() else extra_condition_callback.call()
+	checkbox.visible = FeatureFlagManager.get_flag_value(feature_flag) and extra_condition
+	return checkbox.visible
+
+
+func _does_current_workspace_has_dna() -> bool:
+	var workspace: Workspace = MolecularEditorContext.get_current_workspace()
+	if workspace == null: return false
+	for structure: NanoStructure in workspace.get_structures():
+		if structure is DnaStructure and structure.get_sequence_length() > 0:
+			return true
+	return false
+

--- a/godot_project/editor/controls/export_file_dialog/export_settings.gd.uid
+++ b/godot_project/editor/controls/export_file_dialog/export_settings.gd.uid
@@ -1,0 +1,1 @@
+uid://cs8px5yn0c6r7

--- a/godot_project/editor/controls/export_file_dialog/export_settings.tscn
+++ b/godot_project/editor/controls/export_file_dialog/export_settings.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=2 format=3 uid="uid://dtxfj1243co7v"]
+
+[ext_resource type="Script" uid="uid://cs8px5yn0c6r7" path="res://editor/controls/export_file_dialog/export_settings.gd" id="1_dryhq"]
+
+[node name="ExportSettings" type="VBoxContainer"]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 602.0
+offset_bottom = 83.0
+script = ExtResource("1_dryhq")
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 2
+theme_type_variation = &"HeaderSmall"
+text = "Export Settings"
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+layout_mode = 2
+theme_type_variation = &"SubcategoryPanel"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="PanelContainer/HBoxContainer"]
+layout_mode = 2
+text = "Options:"
+
+[node name="CheckExportDNA" type="CheckBox" parent="PanelContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+button_pressed = true
+text = "Include DNA Objects as Atoms and Bonds"

--- a/godot_project/editor/controls/import_file_dialog/import_settings.tscn
+++ b/godot_project/editor/controls/import_file_dialog/import_settings.tscn
@@ -60,8 +60,8 @@ text = "Placement:"
 [node name="OptionButtonPlacement" type="OptionButton" parent="PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 3
 selected = 0
+item_count = 3
 popup/item_0/text = "Keep original positions"
 popup/item_0/id = 0
 popup/item_1/text = "In front of the camera"

--- a/godot_project/project_workspace/file_format/external/xyz_format_saver.gd
+++ b/godot_project/project_workspace/file_format/external/xyz_format_saver.gd
@@ -35,7 +35,7 @@ func _save(resource: Resource, path: String, _flags: int) -> Error:
 	# First line - Atoms count
 	var total_atom_count: int = 0
 	for structure: NanoStructure in workspace.get_structures():
-		if structure is NanoMolecularStructure:
+		if structure is AtomicStructure:
 			total_atom_count += structure.get_valid_atoms_count()
 	file.store_line(str(total_atom_count))
 	
@@ -48,7 +48,7 @@ func _save(resource: Resource, path: String, _flags: int) -> Error:
 	
 	# Atoms positions
 	for structure: NanoStructure in workspace.get_structures():
-		if not structure is NanoMolecularStructure:
+		if not structure is AtomicStructure:
 			continue
 		
 		var atoms_count: int = structure.get_valid_atoms_count()


### PR DESCRIPTION
Task: Saving DNA Objects to formats outside of MSEP.one's

<img width="1732" height="851" alt="image" src="https://github.com/user-attachments/assets/3a38c568-d95f-4546-88f8-eb49f8d4b338" />

<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/8b16ead9-81d0-4db2-b3f4-870931db37e7" />
