### PR TITLE
Whitelist forwarding of Ctrl button presses (for windows and linux)

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/editor_viewport.gd
+++ b/godot_project/editor/controls/editor_viewport_container/editor_viewport.gd
@@ -19,6 +19,7 @@ const INPUT_EVENT_ACTIONS_WHITELIST: Array[StringName] = [
 const INPUT_KEYS_WHITELIST: Array[Key] = [
 	KEY_ALT,
 	KEY_META,
+	KEY_CTRL,
 ]
 
 ## Returns the WorkspaceContext associated to the active workspace


### PR DESCRIPTION
In #572 we whitelisted KEY_META to fix the bug on macos, but the bug persists in Windows and Linux, so this PR is whitelisting Ctrl button too for those platforms

Task: BUG - CNTL-Option can toggle app into a state where the editor does not match the 'Show Potential Atom Positions" control in the Workspace tab