### PR TITLE
Add a dropdown to Workspace tab to change DNA representation

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
@@ -4,6 +4,7 @@ class_name BondsSettings extends DynamicContextControl
 var _bonds_toggle: CheckButton
 var _labels_toggle: CheckButton
 var _hydrogens_toggle: CheckButton
+var _dna_representation_option_button: OptionButton
 var _hide_simulation_boundaries_toggle: CheckButton
 var _hide_reference_shapes_toggle: CheckButton
 var _hide_virtual_motors_toggle: CheckButton
@@ -18,11 +19,18 @@ func _notification(what: int) -> void:
 		_bonds_toggle = $Settings/PanelContainer/VBoxContainer/ShowBondsToggle
 		_labels_toggle = $Settings/PanelContainer/VBoxContainer/ShowLabelsToggle
 		_hydrogens_toggle = $Settings/PanelContainer/VBoxContainer/ShowHydrogensToggle
+		_dna_representation_option_button = %DnaRepresentationOptionButton
 		_hide_simulation_boundaries_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideSimulationBoundariesToggle
 		_hide_reference_shapes_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideReferenceShapesToggle
 		_hide_virtual_motors_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideVirtualMotorsToggle
 		_hide_particle_emitters_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideParticleEmittersToggle
 		_hide_anchors_and_springs_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideAnchorsAndSpringsToggle
+		
+		FeatureFlagManager.on_feature_flag_toggled.connect(_on_feature_flag_toggled)
+		_on_feature_flag_toggled(
+			FeatureFlagManager.FEATURE_FLAGS_DNA_BUILDER,
+			FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAGS_DNA_BUILDER)
+		)
 
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:
@@ -35,6 +43,8 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 		settings.bond_visibility_changed.connect(_on_bond_visibility_changed)
 	if not settings.hydrogen_visibility_changed.is_connected(_on_hydrogen_visibility_changed):
 		settings.hydrogen_visibility_changed.connect(_on_hydrogen_visibility_changed)
+	if not settings.dna_representation_changed.is_connected(_on_dna_representation_changed):
+		settings.dna_representation_changed.connect(_on_dna_representation_changed)
 	if not settings.atom_labels_visibility_changed.is_connected(_on_atom_labels_visibility_changed):
 		settings.atom_labels_visibility_changed.connect(_on_atom_labels_visibility_changed)
 	if not in_workspace_context.history_changed.is_connected(_on_workspace_context_history_changed):
@@ -42,9 +52,15 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	_bonds_toggle.set_pressed_no_signal(_workspace_context.are_bonds_visualised())
 	_labels_toggle.set_pressed_no_signal(_workspace_context.are_atom_labels_visualised())
 	_hydrogens_toggle.set_pressed_no_signal(_workspace_context.are_hydrogens_visualized())
+	_on_dna_representation_changed(settings.get_dna_representation())
 	_hide_simulation_boundaries_toggle.set_pressed_no_signal(not settings.get_display_simulation_boundaries())
 	_update_visibility_during_representation_toggles()
 	return true
+
+
+func _on_feature_flag_toggled(in_path: String, in_value: bool) -> void:
+	if in_path == FeatureFlagManager.FEATURE_FLAGS_DNA_BUILDER:
+		%DnaSettingsContainer.visible = in_value
 
 
 func _on_workspace_context_history_changed() -> void:
@@ -79,6 +95,12 @@ func _on_hydrogen_visibility_changed(in_visible: bool) -> void:
 	_hydrogens_toggle.set_pressed_no_signal(in_visible)
 
 
+func _on_dna_representation_changed(in_representation: RepresentationSettings.DnaRepresentation) -> void:
+	_dna_representation_option_button.set_block_signals(true)
+	_dna_representation_option_button.select(in_representation)
+	_dna_representation_option_button.set_block_signals(false)
+
+
 func _on_atom_labels_visibility_changed(in_visible: bool) -> void:
 	_labels_toggle.set_pressed_no_signal(in_visible)
 
@@ -111,6 +133,12 @@ func _on_show_hydrogens_toggle_toggled(button_pressed: bool) -> void:
 
 func _on_show_potential_atoms_toggle_toggled(button_pressed: bool) -> void:
 	_workspace_context.workspace.representation_settings.set_display_auto_posing(button_pressed)
+
+
+func _on_dna_representation_option_button_item_selected(index: int) -> void:
+	var dna_representation := index as RepresentationSettings.DnaRepresentation
+	_workspace_context.workspace.representation_settings \
+		.set_dna_representation(dna_representation)
 
 
 func _on_hide_simulation_boundaries_toggle_toggled(button_pressed: bool) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
@@ -46,6 +46,29 @@ layout_mode = 2
 button_pressed = true
 text = "Show Potential Atom Positions"
 
+[node name="DnaSettingsContainer" type="HBoxContainer" parent="Settings/PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Control" type="Control" parent="Settings/PanelContainer/VBoxContainer/DnaSettingsContainer"]
+custom_minimum_size = Vector2(1, 0)
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Settings/PanelContainer/VBoxContainer/DnaSettingsContainer"]
+layout_mode = 2
+text = "DNA Representation"
+
+[node name="DnaRepresentationOptionButton" type="OptionButton" parent="Settings/PanelContainer/VBoxContainer/DnaSettingsContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 10
+selected = 0
+item_count = 2
+popup/item_0/text = "Simplified"
+popup/item_0/id = 0
+popup/item_1/text = "Atoms and Bonds"
+popup/item_1/id = 1
+
 [node name="Title" type="Label" parent="Settings/PanelContainer/VBoxContainer"]
 layout_mode = 2
 theme_type_variation = &"HeaderSmall"
@@ -89,6 +112,7 @@ text = "Anchors and Springs
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowLabelsToggle" to="." method="_on_show_labels_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowHydrogensToggle" to="." method="_on_show_hydrogens_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowPotentialAtomsToggle" to="." method="_on_show_potential_atoms_toggle_toggled"]
+[connection signal="item_selected" from="Settings/PanelContainer/VBoxContainer/DnaSettingsContainer/DnaRepresentationOptionButton" to="." method="_on_dna_representation_option_button_item_selected"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideSimulationBoundariesToggle" to="." method="_on_hide_simulation_boundaries_toggle_toggled"]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideReferenceShapesToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"reference_shapes"]]
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideVirtualMotorsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"virtual_motors"]]

--- a/godot_project/project_workspace/structs/representation_settings.gd
+++ b/godot_project/project_workspace/structs/representation_settings.gd
@@ -8,6 +8,7 @@ signal should_hide_virtual_object_during_simulation_changed(object_type: StringN
 signal bond_visibility_changed(are_visible: bool)
 signal hydrogen_visibility_changed(are_visible: bool)
 signal atom_labels_visibility_changed(are_visible: bool)
+signal dna_representation_changed(representation: DnaRepresentation)
 signal theme_changed()
 signal color_schema_changed(new_color_schema: PeriodicTable.ColorSchema)
 
@@ -21,6 +22,12 @@ enum UserAtomSizeSource {
 	PHYSICAL_RADIUS,
 	VAN_DER_WAALS_RADIUS
 }
+
+enum DnaRepresentation {
+	SIMPLIFIED = 0,
+	ATOMS_AND_BONDS = 1,
+}
+
 
 @export var _rendering_representation := Rendering.Representation.BALLS_AND_STICKS
 
@@ -43,6 +50,8 @@ enum UserAtomSizeSource {
 @export var _display_auto_posing: bool = ATOMS_AUTO_POSING_VISIBLE_BY_DEFAULT
 
 @export var _display_simulation_boundaries: bool = SIMULATION_BOUNDARIES_VISIBLE_BY_DEFAULT
+
+@export var _dna_representation := DnaRepresentation.SIMPLIFIED
 
 @export var _custom_selection_outline_color_enabled: bool = false
 
@@ -135,6 +144,17 @@ func set_display_simulation_boundaries(new_display_simulation_boundaries: bool) 
 
 func get_display_simulation_boundaries() -> bool:
 	return _display_simulation_boundaries
+
+
+func set_dna_representation(in_representation: DnaRepresentation) -> void:
+	if _dna_representation != in_representation:
+		_dna_representation = in_representation
+		emit_changed()
+		dna_representation_changed.emit(in_representation)
+
+
+func get_dna_representation() -> DnaRepresentation:
+	return _dna_representation
 
 
 func set_bond_visibility_and_notify(new_bond_visibility: bool) -> void:


### PR DESCRIPTION
- Hidden under feature flags
- For now emits a signal on change, but does nothing

Task: New feature - View DNA as Atoms and Bonds