### PR TITLE
Make virtual motors use the CustomExternalForce class from openmm

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.tscn
@@ -86,10 +86,11 @@ layout_mode = 2
 [node name="LinearMaxForceSpinBox" parent="LimitForceHBoxContainer" instance=ExtResource("2_crlk1")]
 unique_name_in_owner = true
 layout_mode = 2
-step = 0.001
-value = 5.0
+max_value = 50000.0
+step = 0.1
+value = 1000.0
 allow_greater = true
-suffix = "aN"
+suffix = "kJ / mol"
 custom_arrow_step = 0.001
 
 [node name="Label5" type="Label" parent="."]

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.gd
@@ -9,14 +9,14 @@ var _parameters_wref: WeakRef = weakref(null) # WeakRef<NanoRotaryMotorParameter
 # Rotary Settings Controls
 var _rotary_ramp_in_time: TimeSpanPicker
 var _rotary_ramp_out_time: TimeSpanPicker
-var _rotary_top_speed_check_box: CheckBox
 var _rotary_top_speed_spin_box: SpinBoxSlider
-var _rotary_max_torque_check_box: CheckBox
-var _rotary_max_torque_spin_box: SpinBoxSlider
+var _rotary_limit_force_check_button: CheckButton
+var _rotary_max_force_spin_box: SpinBoxSlider
 var _rotary_jerk_limit_check_box: CheckBox
 var _rotary_jerk_limit_spin_box_slider: SpinBoxSlider
 var _rotary_clockwise_button: Button
 var _rotary_counter_clockwise_button: Button
+
 
 # when not null an snapshot in this workspace will be taken on change from UI
 var _workspace_snapshot_target: WorkspaceContext = null
@@ -29,10 +29,9 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_SCENE_INSTANTIATED:
 		_rotary_ramp_in_time = %RotaryRampInTime as TimeSpanPicker
 		_rotary_ramp_out_time = %RotaryRampOutTime as TimeSpanPicker
-		_rotary_top_speed_check_box = %RotaryTopSpeedCheckBox as CheckBox
 		_rotary_top_speed_spin_box = %RotaryTopSpeedSpinBox as SpinBoxSlider
-		_rotary_max_torque_check_box = %RotaryMaxTorqueCheckBox as CheckBox
-		_rotary_max_torque_spin_box = %RotaryMaxTorqueSpinBox as SpinBoxSlider
+		_rotary_limit_force_check_button = %LimitForceCheckButton as CheckButton
+		_rotary_max_force_spin_box = %RotaryMaxForceSpinBox as SpinBoxSlider
 		_rotary_jerk_limit_check_box = %RotaryJerkLimitCheckBox as CheckBox
 		_rotary_jerk_limit_spin_box_slider = %RotaryJerkLimitSpinBoxSlider as SpinBoxSlider
 		_rotary_clockwise_button = %RotaryClockwiseButton as Button
@@ -40,10 +39,9 @@ func _notification(what: int) -> void:
 		# Rotary controls signals
 		_rotary_ramp_in_time.time_span_changed.connect(_on_rotary_ramp_in_time_time_span_changed)
 		_rotary_ramp_out_time.time_span_changed.connect(_on_rotary_ramp_out_time_time_span_changed)
-		_rotary_top_speed_check_box.toggled.connect(_on_rotary_top_speed_check_box_toggled)
 		_rotary_top_speed_spin_box.value_confirmed.connect(_on_rotary_top_speed_spin_box_value_confirmed)
-		_rotary_max_torque_check_box.toggled.connect(_on_rotary_max_torque_check_box_toggled)
-		_rotary_max_torque_spin_box.value_confirmed.connect(_rotary_max_torque_spin_box_value_confirmed)
+		_rotary_limit_force_check_button.toggled.connect(_on_limit_force_check_button_toggled)
+		_rotary_max_force_spin_box.value_confirmed.connect(_on_rotary_max_force_spin_box_value_confirmed)
 		_rotary_jerk_limit_check_box.toggled.connect(_on_rotary_jerk_limit_check_box_toggled)
 		_rotary_clockwise_button.toggled.connect(_on_rotary_clockwise_button_toggled)
 		_rotary_counter_clockwise_button.toggled.connect(_on_rotary_counter_clockwise_button_toggled)
@@ -89,14 +87,12 @@ func _on_rotary_motor_parameters_changed() -> void:
 	_rotary_ramp_out_time.time_span_femtoseconds = TimeSpanPicker.unit_to_femtoseconds(
 			parameters.ramp_out_time_in_nanoseconds, TimeSpanPicker.Unit.NANOSECOND)
 	_rotary_ramp_out_time.editable = parameters.cycle_type != NanoVirtualMotorParameters.CycleType.CONTINUOUS
-	_rotary_top_speed_check_box.set_pressed_no_signal(parameters.max_speed_type == NanoRotaryMotorParameters.MaxSpeedType.TOP_SPEED)
-	_rotary_top_speed_spin_box.editable = _rotary_top_speed_check_box.button_pressed
-	var top_revolutions_per_picoseconds: float = parameters.top_revolutions_per_nanosecond
+	var top_revolutions_per_picoseconds: float = parameters.top_revolutions_per_nanosecond / 1000
 	_rotary_top_speed_spin_box.set_value_no_signal(top_revolutions_per_picoseconds)
 	_update_rotary_top_speed_tooltip()
-	_rotary_max_torque_check_box.set_pressed_no_signal(parameters.max_speed_type == NanoRotaryMotorParameters.MaxSpeedType.MAX_TORQUE)
-	_rotary_max_torque_spin_box.editable = _rotary_max_torque_check_box.button_pressed
-	_rotary_max_torque_spin_box.set_value_no_signal(parameters.max_torque)
+	_rotary_limit_force_check_button.set_pressed_no_signal(parameters.limit_maximum_force)
+	_rotary_max_force_spin_box.visible = parameters.limit_maximum_force
+	_rotary_max_force_spin_box.set_value_no_signal(parameters.max_force)
 	_rotary_jerk_limit_check_box.set_pressed_no_signal(parameters.is_jerk_limited)
 	_rotary_jerk_limit_spin_box_slider.editable = _rotary_jerk_limit_check_box.button_pressed
 	_rotary_jerk_limit_spin_box_slider.set_value_no_signal(parameters.jerk_limit)
@@ -122,13 +118,6 @@ func _on_rotary_ramp_out_time_time_span_changed(in_magnitude: float, in_unit: Ti
 	_take_snapshot_if_configured(tr(&"Ramp-Out Time"))
 
 
-func _on_rotary_top_speed_check_box_toggled(in_button_pressed: bool) -> void:
-	_rotary_top_speed_spin_box.editable = in_button_pressed
-	if in_button_pressed:
-		_get_rotary_parameters().max_speed_type = NanoRotaryMotorParameters.MaxSpeedType.TOP_SPEED
-		_take_snapshot_if_configured(tr(&"Use Max Speed"))
-
-
 func _on_rotary_top_speed_spin_box_value_confirmed(in_top_speed: float) -> void:
 	_get_rotary_parameters().top_revolutions_per_nanosecond = in_top_speed
 	_update_rotary_top_speed_tooltip()
@@ -142,16 +131,15 @@ func _update_rotary_top_speed_tooltip() -> void:
 		[ _rotary_top_speed_spin_box.value, 1.0 / (_rotary_top_speed_spin_box.value / 1000000.0)]
 
 
-func _on_rotary_max_torque_check_box_toggled(in_button_pressed: bool) -> void:
-	_rotary_max_torque_spin_box.editable = in_button_pressed
-	if in_button_pressed:
-		_get_rotary_parameters().max_speed_type = NanoRotaryMotorParameters.MaxSpeedType.MAX_TORQUE
-		_take_snapshot_if_configured(tr(&"Use Max Torque"))
+func _on_limit_force_check_button_toggled(in_toggled: bool) -> void:
+	_get_rotary_parameters().limit_maximum_force = in_toggled
+	_take_snapshot_if_configured(tr(&"Limit Maximum Force"))
+	_rotary_max_force_spin_box.visible = in_toggled
 
 
-func _rotary_max_torque_spin_box_value_confirmed(in_max_torque: float) -> void:
-	_get_rotary_parameters().max_torque = in_max_torque
-	_take_snapshot_if_configured(tr(&"Max Torque"))
+func _on_rotary_max_force_spin_box_value_confirmed(in_max_force: float) -> void:
+	_get_rotary_parameters().max_force = in_max_force
+	_take_snapshot_if_configured(tr(&"Maximum Force"))
 
 
 func _on_rotary_jerk_limit_check_box_toggled(in_button_pressed: bool) -> void:
@@ -175,4 +163,3 @@ func _on_rotary_counter_clockwise_button_toggled(in_button_pressed: bool) -> voi
 func _on_rotary_jerk_limit_spin_box_slider_value_confirmed(in_jerk_limit: float) -> void:
 	_get_rotary_parameters().jerk_limit = in_jerk_limit
 	_take_snapshot_if_configured(tr(&"Jerk Limit"))
-

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.gd
@@ -87,8 +87,7 @@ func _on_rotary_motor_parameters_changed() -> void:
 	_rotary_ramp_out_time.time_span_femtoseconds = TimeSpanPicker.unit_to_femtoseconds(
 			parameters.ramp_out_time_in_nanoseconds, TimeSpanPicker.Unit.NANOSECOND)
 	_rotary_ramp_out_time.editable = parameters.cycle_type != NanoVirtualMotorParameters.CycleType.CONTINUOUS
-	var top_revolutions_per_picoseconds: float = parameters.top_revolutions_per_nanosecond / 1000
-	_rotary_top_speed_spin_box.set_value_no_signal(top_revolutions_per_picoseconds)
+	_rotary_top_speed_spin_box.set_value_no_signal(parameters.top_revolutions_per_nanosecond)
 	_update_rotary_top_speed_tooltip()
 	_rotary_limit_force_check_button.set_pressed_no_signal(parameters.limit_maximum_force)
 	_rotary_max_force_spin_box.visible = parameters.limit_maximum_force
@@ -125,8 +124,8 @@ func _on_rotary_top_speed_spin_box_value_confirmed(in_top_speed: float) -> void:
 
 
 func _update_rotary_top_speed_tooltip() -> void:
-	_rotary_top_speed_spin_box.tooltip_text = tr("Revolutions per Picosecond:\n" +
-		"This is the number of spins a motor will do per picosecond.\n" +
+	_rotary_top_speed_spin_box.tooltip_text = tr("Revolutions per Nanosecond:\n" +
+		"This is the number of spins a motor will do per nanosecond.\n" +
 		"At %.2f Rev/ns a motor will make a spin every %.2f femtoseconds") % \
 		[ _rotary_top_speed_spin_box.value, 1.0 / (_rotary_top_speed_spin_box.value / 1000000.0)]
 

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.tscn
@@ -1,12 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://dm1rw27pn4ruw"]
+[gd_scene load_steps=6 format=3 uid="uid://dm1rw27pn4ruw"]
 
 [ext_resource type="PackedScene" uid="uid://m1q18cpkrt8n" path="res://editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/time_span_picker.tscn" id="1_ldadn"]
 [ext_resource type="Script" uid="uid://c3a3er2v22tly" path="res://editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.gd" id="1_pdebe"]
 [ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="2_03etg"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_uca0l"]
-
-[sub_resource type="ButtonGroup" id="ButtonGroup_un2j1"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_cg2to"]
 
@@ -55,16 +53,6 @@ layout_mode = 2
 time_span_femtoseconds = 150.0
 min_value_in_femtoseconds = 0.0
 
-[node name="RotaryTopSpeedCheckBox" type="CheckBox" parent="."]
-unique_name_in_owner = true
-editor_description = "Unimplemented"
-visible = false
-layout_mode = 2
-size_flags_horizontal = 3
-button_pressed = true
-button_group = SubResource("ButtonGroup_un2j1")
-text = "Top Speed"
-
 [node name="Label3" type="Label" parent="."]
 custom_minimum_size = Vector2(0, 38)
 layout_mode = 2
@@ -83,26 +71,29 @@ value = 30.0
 allow_greater = true
 suffix = "Rev/ns"
 
-[node name="RotaryMaxTorqueCheckBox" type="CheckBox" parent="."]
-unique_name_in_owner = true
-editor_description = "Unimplemented"
-visible = false
+[node name="LimitForceLabel" type="Label" parent="."]
+custom_minimum_size = Vector2(0, 38)
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Feature Implementation In Progress"
-disabled = true
-button_group = SubResource("ButtonGroup_un2j1")
-text = "Max Torque"
+text = " ・ Limit Max Force"
+vertical_alignment = 1
 
-[node name="RotaryMaxTorqueSpinBox" parent="." instance=ExtResource("2_03etg")]
-unique_name_in_owner = true
-editor_description = "Unimplemented"
-visible = false
+[node name="LimitForceHBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
-value = 50.0
+
+[node name="LimitForceCheckButton" type="CheckButton" parent="LimitForceHBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="RotaryMaxForceSpinBox" parent="LimitForceHBoxContainer" instance=ExtResource("2_03etg")]
+unique_name_in_owner = true
+layout_mode = 2
+max_value = 50000.0
+step = 0.1
+value = 1000.0
 allow_greater = true
-editable = false
-suffix = "m²  kg / s² mol"
+suffix = "kJ / mol"
+custom_arrow_step = 0.001
 
 [node name="RotaryJerkLimitCheckBox" type="CheckBox" parent="."]
 unique_name_in_owner = true

--- a/godot_project/project_workspace/structs/nano_linear_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_linear_motor_parameters.gd
@@ -104,4 +104,5 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	top_speed_in_nanometers_by_nanoseconds = in_snapshot.top_speed_in_nanometers_by_nanoseconds
 	polarity = in_snapshot.polarity
 	max_force = in_snapshot.max_force
+	limit_maximum_force = in_snapshot.limit_maximum_force
 	set_block_signals(was_blocking_signals)

--- a/godot_project/project_workspace/structs/nano_linear_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_linear_motor_parameters.gd
@@ -9,8 +9,6 @@ enum Polarity {
 	set = _set_top_speed_in_nanometers_by_nanoseconds
 @export var polarity: Polarity = Polarity.FORWARD:
 	set = _set_polarity
-@export var max_force: float = 1.0 * 1e6:
-	set = _set_max_force
 
 var _state_snapshot_dirty: bool = true
 var _state_snapshot: Dictionary = {}
@@ -62,13 +60,6 @@ func _set_polarity(in_polarity: Polarity) -> void:
 	emit_changed()
 
 
-func _set_max_force(in_max_force: float) -> void:
-	if max_force == in_max_force:
-		return
-	max_force = in_max_force
-	emit_changed()
-
-
 func create_state_snapshot() -> Dictionary:
 	if _state_snapshot_dirty:
 		_state_snapshot = {
@@ -86,6 +77,7 @@ func create_state_snapshot() -> Dictionary:
 			# Linear specific properties
 			"top_speed_in_nanometers_by_nanoseconds" = top_speed_in_nanometers_by_nanoseconds,
 			"polarity" = polarity,
+			"limit_maximum_force" = limit_maximum_force,
 			"max_force" = max_force,
 		}
 		_state_snapshot_dirty = false

--- a/godot_project/project_workspace/structs/nano_rotary_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_rotary_motor_parameters.gd
@@ -5,18 +5,9 @@ enum Polarity {
 	COUNTER_CLOCKWISE
 }
 
-enum MaxSpeedType {
-	TOP_SPEED,
-	MAX_TORQUE
-}
 
-
-@export var max_speed_type: MaxSpeedType = MaxSpeedType.TOP_SPEED:
-	set = _set_max_speed_type
 @export var top_revolutions_per_nanosecond: float = 30.0:
 	set = _set_top_revolutions_per_nanosecond
-@export var max_torque: float = 50.0:
-	set = _set_max_torque
 @export var is_jerk_limited: bool = false:
 	set = _set_is_jerk_limited
 @export var jerk_limit: float = 50.0:
@@ -72,24 +63,10 @@ func _get_motor_type() -> Type:
 	return Type.ROTARY
 
 
-func _set_max_speed_type(in_max_speed_type: MaxSpeedType) -> void:
-	if max_speed_type == in_max_speed_type:
-		return
-	max_speed_type = in_max_speed_type
-	emit_changed()
-
-
 func _set_top_revolutions_per_nanosecond(in_top_revolutions_per_nanosecond: float) -> void:
 	if top_revolutions_per_nanosecond == in_top_revolutions_per_nanosecond:
 		return
 	top_revolutions_per_nanosecond = in_top_revolutions_per_nanosecond
-	emit_changed()
-
-
-func _set_max_torque(in_max_torque: float) -> void:
-	if max_torque == in_max_torque:
-		return
-	max_torque = in_max_torque
 	emit_changed()
 
 
@@ -128,9 +105,7 @@ func create_state_snapshot() -> Dictionary:
 			"cycle_eventually_stops" = cycle_eventually_stops,
 			"cycle_stop_after_n_cycles" = cycle_stop_after_n_cycles,
 			# Rotary specific properties
-			"max_speed_type" = max_speed_type,
 			"top_revolutions_per_nanosecond" = top_revolutions_per_nanosecond,
-			"max_torque" = max_torque,
 			"is_jerk_limited" = is_jerk_limited,
 			"jerk_limit" = jerk_limit,
 			"polarity" = polarity,
@@ -155,9 +130,7 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	cycle_eventually_stops = in_snapshot.cycle_eventually_stops
 	cycle_stop_after_n_cycles = in_snapshot.cycle_stop_after_n_cycles
 	# Rotary specific properties
-	max_speed_type = in_snapshot.max_speed_type
 	top_revolutions_per_nanosecond = in_snapshot.top_revolutions_per_nanosecond
-	max_torque = in_snapshot.max_torque
 	is_jerk_limited = in_snapshot.is_jerk_limited
 	jerk_limit = in_snapshot.jerk_limit
 	polarity = in_snapshot.polarity

--- a/godot_project/project_workspace/structs/nano_rotary_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_rotary_motor_parameters.gd
@@ -106,12 +106,15 @@ func create_state_snapshot() -> Dictionary:
 			"cycle_stop_after_n_cycles" = cycle_stop_after_n_cycles,
 			# Rotary specific properties
 			"top_revolutions_per_nanosecond" = top_revolutions_per_nanosecond,
+			"limit_maximum_force" = limit_maximum_force,
+			"max_force" = max_force,
 			"is_jerk_limited" = is_jerk_limited,
 			"jerk_limit" = jerk_limit,
 			"polarity" = polarity,
 		}
 		_state_snapshot_dirty = false
 	return _state_snapshot.duplicate(true)
+
 
 func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	# prevent `changed` and any other signal from being emited whil state snapshot is being applied
@@ -131,6 +134,8 @@ func apply_state_snapshot(in_snapshot: Dictionary) -> void:
 	cycle_stop_after_n_cycles = in_snapshot.cycle_stop_after_n_cycles
 	# Rotary specific properties
 	top_revolutions_per_nanosecond = in_snapshot.top_revolutions_per_nanosecond
+	limit_maximum_force = in_snapshot.limit_maximum_force
+	max_force = in_snapshot.max_force
 	is_jerk_limited = in_snapshot.is_jerk_limited
 	jerk_limit = in_snapshot.jerk_limit
 	polarity = in_snapshot.polarity

--- a/godot_project/project_workspace/structs/nano_virtual_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_virtual_motor_parameters.gd
@@ -47,8 +47,10 @@ var motor_type: Type = Type.UNKNOWN:
 @export var cycle_stop_after_n_cycles: int = 1:
 	set = _set_cycle_stop_after_n_cycles
 
-@export var limit_maximum_force: bool = false
-
+@export var limit_maximum_force: bool = false:
+	set = _set_limit_maximum_force
+@export var max_force: float = 1.0 * 1e6:
+	set = _set_max_force
 
 func get_tooltip_text() -> String:
 	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
@@ -120,6 +122,20 @@ func _set_cycle_stop_after_n_cycles(in_cycle_stop_after_n_cycles: int) -> void:
 	if cycle_stop_after_n_cycles == in_cycle_stop_after_n_cycles:
 		return
 	cycle_stop_after_n_cycles = in_cycle_stop_after_n_cycles
+	emit_changed()
+
+
+func _set_limit_maximum_force(in_limit_maximum_force: bool) -> void:
+	if limit_maximum_force == in_limit_maximum_force:
+		return
+	limit_maximum_force = in_limit_maximum_force
+	emit_changed()
+
+
+func _set_max_force(in_max_force: float) -> void:
+	if max_force == in_max_force:
+		return
+	max_force = in_max_force
 	emit_changed()
 
 

--- a/godot_project/python/scripts/openmm_server.py
+++ b/godot_project/python/scripts/openmm_server.py
@@ -392,10 +392,6 @@ class RotaryPolarity(IntEnum):
 	CLOCKWISE = 0,
 	COUNTER_CLOCKWISE = 1
 
-class RotaryMaxSpeedType(IntEnum):
-	TOP_SPEED = 0,
-	MAX_TORQUE = 1
-
 class LinearPolarity(IntEnum):
 	FORWARD = 0,
 	BACKWARDS = 1
@@ -611,6 +607,8 @@ class MotorForce:
 		positions = state.getPositions()
 		reference_particle_position: Vec3 = positions[0]
 		axis_point: Vec3 = closest_point_in_rect_to_other(self.position, self.axis_direction, reference_particle_position)
+		if axis_point == reference_particle_position: # Particle is aligned with the rotation axis
+			return 0.0
 		axis_to_particle_dir: Vec3 = normalize_Vec3(reference_particle_position - axis_point)._value
 		up: Vec3 = Vec3(0.0, 1.0, 0.0)
 		if abs(dot_Vec3(self.axis_direction, up)) > 0.9:
@@ -646,6 +644,7 @@ class MotorForce:
 		state = simulation.context.getState(getVelocities=True, getPositions= True)
 		prev_velocities = state.getVelocities()
 		positions = state.getPositions()
+		new_velocities = prev_velocities.copy()
 		
 		# Cycle accumulation
 		current_angle: float = self.get_molecule_angle(simulation)
@@ -661,17 +660,25 @@ class MotorForce:
 		# Force calculations
 		for i in range(len(self.atom_ids)):
 			atom_id: int = self.atom_ids[i]
-			new_motor_velocity = prev_velocities[atom_id]
-			force: Vec3 = self._calculate_rotary_motor_particle_force(simulation, speed, positions[atom_id], prev_velocities[atom_id], i)
+			vector: Vec3 = self._calculate_rotary_motor_particle_vector(simulation, speed, positions[atom_id], prev_velocities[atom_id], i)
+			self.last_motor_velocities[i] = prev_velocities[atom_id] # update record for the next iter
+			if self.limit_maximum_force:
+				self.external_force.setParticleParameters(i, atom_id, vector)
+			else:
+				new_velocities[atom_id] = vector
+			
 			if atom_id in MOTOR_PER_PARTICLE_LOG_FILES:
 				prev_motor_velocity: Vec3 = self.last_motor_velocities[i]
+				new_motor_velocity = vector
 				if length_Vec3(prev_motor_velocity) > 0.0 and length_Vec3(force) > 0.0 and dot_Vec3(normalize_Vec3(prev_motor_velocity), normalize_Vec3(new_motor_velocity)) < 0.1:
 					self.particle_log(i, "		MOTOR DIRECTION SUDDENLY INVERTED!")
 					self.particle_log(i, f"		speed ({speed}) , prev_motor_velocity {prev_motor_velocity}({length_Vec3(prev_motor_velocity)}) new_motor_velocity {new_motor_velocity}({length_Vec3(new_motor_velocity)})")
-			self.last_motor_velocities[i] = prev_velocities[atom_id] # update record for the next iter
-			self.external_force.setParticleParameters(i, atom_id, force)
 		
-		self.external_force.updateParametersInContext(simulation.context)
+		if self.limit_maximum_force:
+			self.external_force.updateParametersInContext(simulation.context)
+		else:
+			simulation.context.setVelocities(new_velocities)
+		
 		return
 	
 	def _calculate_rotary_motor_particle_distance_to_axis(self, particle_pos: Vec3) -> float:
@@ -679,26 +686,30 @@ class MotorForce:
 		distance = length_Vec3(particle_pos - axis_of_rotation)
 		return distance
 	
-	def _calculate_rotary_motor_particle_force(self, simulation, speed: float, particle_pos: Vec3, previous_velocity: Vec3, i: int) -> Vec3:
+	def _calculate_rotary_motor_particle_vector(self, simulation, speed: float, particle_pos: Vec3, previous_velocity: Vec3, i: int) -> Vec3:
 		previous_velocity = (previous_velocity._value * 1000.0) * (meter / second) # convert from nm/ps to m/s
 		distance_to_axis: float = self._calculate_rotary_motor_particle_distance_to_axis(particle_pos)
-		target_speed = speed * distance_to_axis
+		target_speed: float = speed * distance_to_axis
 		axis_of_rotation: Vec3 = closest_point_in_rect_to_other(self.position, self.axis_direction, particle_pos)
 		axis_to_particle_vec: Vec3 = particle_pos - axis_of_rotation
 		axis_to_particle_dir: Vec3 = normalize_Vec3(axis_to_particle_vec)
-		move_dir: Vec3 = normalize_Vec3(cross_Vec3(axis_to_particle_dir / nanometer, self.axis_direction) * nanometer / nanosecond) * self.polarity
-		current_speed_in_desired_direction = dot_Vec3(previous_velocity, move_dir)
-		speed_delta: Vec3 = target_speed - current_speed_in_desired_direction
+		move_dir: Vec3 = normalize_Vec3(cross_Vec3(axis_to_particle_dir / nanometer, self.axis_direction) * nanometer / nanosecond)._value * self.polarity
+		current_speed_in_desired_direction: float = dot_Vec3(previous_velocity, move_dir)
+		delta_speed: float = target_speed - current_speed_in_desired_direction
+		result: Vec3
 		
-		force_quantity = speed_delta * 1.5 # Empirical approximation. This could use a proper analytical solution.
 		if self.limit_maximum_force:
+			force_quantity = delta_speed * 1.5 # Empirical approximation. This could use a proper analytical solution.
 			force_quantity = min(abs(force_quantity), self.max_force)
 		
-		# If the particle is going faster than the target speed, apply an opposing force to slow it down.
-		# (If this is not desired, set force_quantity to 0 to avoid speeding it up even more)
-		if current_speed_in_desired_direction > target_speed:
-			force_quantity = -force_quantity
-		force: Vec3 = force_quantity * move_dir._value * kilojoule_per_mole
+			# If the particle is going faster than the target speed, apply an opposing force to slow it down.
+			# (If this is not desired, set force_quantity to 0 to avoid speeding it up even more)
+			if current_speed_in_desired_direction > target_speed:
+				force_quantity = -force_quantity
+			result = force_quantity * move_dir * kilojoule_per_mole
+		else:
+			delta_velocity = delta_speed * move_dir * previous_velocity.unit
+			result = previous_velocity + delta_velocity
 		
 		atom_id: int = self.atom_ids[i]
 		if atom_id in MOTOR_PER_PARTICLE_LOG_FILES:
@@ -710,8 +721,12 @@ class MotorForce:
 			self.particle_log(i, f"	axis_to_particle_vec {axis_to_particle_vec}")
 			self.particle_log(i, f"	axis_to_particle_dir {axis_to_particle_dir}")
 			self.particle_log(i, f"	move_dir {move_dir}")
-			self.particle_log(i, f"		force ({length_Vec3(force)}kJ/mol) {force}")
-		return force
+			if self.limit_maximum_force:
+				self.particle_log(i, f"force {result}")
+			else:
+				self.particle_log(i, f"new velocity {result}")
+		
+		return result
 	
 	def _advance_linear(self, simulation):
 		if self.stopped or len(self.atom_ids) == 0:
@@ -731,28 +746,33 @@ class MotorForce:
 		
 		state = simulation.context.getState(getVelocities=True)
 		prev_velocities = state.getVelocities()
+		new_velocities = prev_velocities.copy()
 		
 		for i in range(len(self.atom_ids)):
 			atom_id: int = self.atom_ids[i]
 			previous_velocity: Vec3 = prev_velocities[atom_id]._value * 1000.0 * (meter / second) # from nm/ps to m/s
-			current_speed_in_desired_direction: float = dot_Vec3(previous_velocity, self.axis_direction * self.polarity)
-			speed_delta: float = target_speed - current_speed_in_desired_direction
+			move_dir: Vec3 = self.axis_direction * self.polarity
+			current_speed_in_desired_direction: float = dot_Vec3(previous_velocity, move_dir)
+			delta_speed: float = target_speed - current_speed_in_desired_direction
 			
-			# Calculate required force to reach target speed from current speed
-			force_quantity = speed_delta * 1.5 # Empirical approximation. This could use a proper analytical solution.
 			if self.limit_maximum_force:
+				# Calculate required force to reach target speed from current speed
+				force_quantity = delta_speed * 1.5 # Empirical approximation. This could use a proper analytical solution.
 				force_quantity = min(abs(force_quantity), self.max_force)
-			# If the particle is going faster than the target speed, apply an opposing force to slow it down.
-			# (If this is not desired, set force_quantity to 0 to avoid speeding it up even more)
-			if current_speed_in_desired_direction > target_speed:
-				force_quantity = -force_quantity
-			force: Vec3 = force_quantity * self.axis_direction * self.polarity * kilojoule_per_mole
-			self.external_force.setParticleParameters(i, atom_id, force)
-			
-			if MOTOR_DEBUG_PRINTS and self.print_counter == 0 and i == 0:
-				logging.info(f"Current speed: {current_speed_in_desired_direction} m/s - Force: {force} kJ/mol")
-		
-		self.external_force.updateParametersInContext(simulation.context)
+				# If the particle is going faster than the target speed, apply an opposing force to slow it down.
+				# (If this is not desired, set force_quantity to 0 to avoid speeding it up even more)
+				if current_speed_in_desired_direction > target_speed:
+					force_quantity = -force_quantity
+				force: Vec3 = force_quantity * move_dir * kilojoule_per_mole
+				self.external_force.setParticleParameters(i, atom_id, force)
+			else:
+				delta_velocity = delta_speed * move_dir * previous_velocity.unit
+				new_velocities[atom_id] = prev_velocities[atom_id] + delta_velocity
+				
+		if self.limit_maximum_force:
+			self.external_force.updateParametersInContext(simulation.context)
+		else:
+			simulation.context.setVelocities(new_velocities)
 		return
 
 	def _calculate_speed(self, delta_time: float) -> float:

--- a/godot_project/python/scripts/openmm_server.py
+++ b/godot_project/python/scripts/openmm_server.py
@@ -413,8 +413,8 @@ class MotorForce:
 		self.stopped = False
 		self.connected_molecules: list[int] = motor_force_data["connected_molecules"]
 		self.motor_type: MotorType = motor_force_data["parameters"]["motor_type"]
-		
 		self.ramp_in_time_in_nanoseconds: float = motor_force_data["parameters"]["ramp_in_time_in_nanoseconds"]
+		self.max_force = motor_force_data["parameters"]["max_force"]
 		self.limit_maximum_force: bool = motor_force_data["parameters"]["limit_maximum_force"]
 		match self.motor_type:
 			case MotorType.ROTARY:
@@ -422,8 +422,6 @@ class MotorForce:
 				self.polarity: float = 1.0 if rotary_polarity == RotaryPolarity.CLOCKWISE else -1.0
 				self.is_jerk_limited: bool = motor_force_data["parameters"]["is_jerk_limited"]
 				self.jerk_limit: float = motor_force_data["parameters"]["jerk_limit"]
-				self.max_speed_type: RotaryMaxSpeedType = motor_force_data["parameters"]["max_speed_type"]
-				self.max_torque: float = motor_force_data["parameters"]["max_torque"]
 				top_revolutions_per_nanosecond: float = motor_force_data["parameters"]["top_revolutions_per_nanosecond"]
 				# convert Rev/ns to RADIANS/ns
 				self.top_speed_in_radians_per_nanosecond = top_revolutions_per_nanosecond * 2.0 * PI
@@ -432,7 +430,6 @@ class MotorForce:
 				linear_polarity: LinearPolarity = motor_force_data["parameters"]["polarity"]
 				self.polarity: float = 1.0 if linear_polarity == LinearPolarity.FORWARD else -1.0
 				self.top_speed_in_nanometers_by_nanoseconds = motor_force_data["parameters"]["top_speed_in_nanometers_by_nanoseconds"]
-				self.max_force = motor_force_data["parameters"]["max_force"] * 1e-18 # Convert attoNewtons to Newtons
 			case _:
 				logging.error(f"Unknown motor type '{self.motor_type}'!")
 				pass
@@ -537,8 +534,6 @@ class MotorForce:
 		self.atom_ids: list[int] = []
 		Path(os.path.expanduser(os.path.join('~','particle_logs'))).mkdir(parents=True, exist_ok=True)
 		self.particle_log_file: list[int] = []
-		self.time_accum: float = 0
-		self.distance_accum: float = 0
 		self.cycle_counter: int = 0
 		self.cycle_time_accum: float = 0.0
 		self.cycle_distance_accum: float = 0.0
@@ -584,7 +579,48 @@ class MotorForce:
 			f.write("")
 		print(f"Initialized log path: {self.particle_log_file[i]}")
 
+	def initialize_force(self, system):
+		self.external_force = CustomExternalForce('-fx*x-fy*y-fz*z')
+		system.addForce(self.external_force)
+		self.external_force.addPerParticleParameter('fx')
+		self.external_force.addPerParticleParameter('fy')
+		self.external_force.addPerParticleParameter('fz')
+		
+		for i in range(len(self.atom_ids)):
+			atom_id: int = self.atom_ids[i]
+			self.external_force.addParticle(atom_id, Vec3(0.0, 0.0, 0.0) * kilojoules_per_mole)
+	
+	def start_simulation(self, simulation):
+		self.molecule_center = self.get_molecule_center(simulation)
+		self.molecule_angle = self.get_molecule_angle(simulation) # in radians
 
+	def get_molecule_center(self, simulation):
+		molecule_center = Vec3(0.0, 0.0, 0.0)
+		state = simulation.context.getState(getPositions = True)
+		positions = state.getPositions()
+		atom_count = len(self.atom_ids)
+		for i in range(atom_count):
+			atom_id: int = self.atom_ids[i]
+			molecule_center += positions[atom_id]._value
+		return molecule_center / atom_count
+	
+	# Returns the molecule angle (in radians) around the rotation axis.
+	# (Uses the first atom in the list as a reference point)
+	def get_molecule_angle(self, simulation) -> float:
+		state = simulation.context.getState(getPositions= True)
+		positions = state.getPositions()
+		reference_particle_position: Vec3 = positions[0]
+		axis_point: Vec3 = closest_point_in_rect_to_other(self.position, self.axis_direction, reference_particle_position)
+		axis_to_particle_dir: Vec3 = normalize_Vec3(reference_particle_position - axis_point)._value
+		up: Vec3 = Vec3(0.0, 1.0, 0.0)
+		if abs(dot_Vec3(self.axis_direction, up)) > 0.9:
+			up = Vec3(0.0, 0.0, 1.0) # Motor axis is almost vertical, use forward as UP
+		tangent: Vec3 = cross_Vec3(up, self.axis_direction)
+		tangent /= length_Vec3(tangent)
+		u: float = dot_Vec3(cross_Vec3(axis_to_particle_dir, tangent), self.axis_direction)
+		v: float = dot_Vec3(axis_to_particle_dir, tangent)
+		return math.atan2(u, v)
+	
 	def advance(self, simulation):
 		match self.motor_type:
 			case MotorType.ROTARY:
@@ -599,30 +635,43 @@ class MotorForce:
 		if self.stopped or len(self.atom_ids) == 0:
 			# Nothing to do here
 			return
-		self.time_accum += simulation.time_step_in_nanoseconds
+			
 		speed: float = self._calculate_speed(simulation.time_step_in_nanoseconds)
-		self.distance_accum += (simulation.time_step_in_nanoseconds * speed) / (2 * PI) # acum distance is in cycles
 		
 		self.print_counter = (self.print_counter + 1) % 64 # print every 64 steps
 		if self.print_counter == 0:
 			if MOTOR_DEBUG_PRINTS:
-				logging.info(f"motor speed is {speed}rad/ns , distance is {self.distance_accum}nm ")
+				logging.info(f"motor target speed is {speed}rad/ns , distance is {self.cycle_distance_accum}nm ")
 		
 		state = simulation.context.getState(getVelocities=True, getPositions= True)
 		prev_velocities = state.getVelocities()
 		positions = state.getPositions()
-		new_velocities = prev_velocities.copy()
+		
+		# Cycle accumulation
+		current_angle: float = self.get_molecule_angle(simulation)
+		previous_angle: float = self.molecule_angle
+		angle_delta = current_angle - previous_angle
+		if angle_delta > PI:
+			angle_delta -= 2 * PI
+		elif angle_delta < -PI:
+			angle_delta += 2 * PI
+		self.cycle_distance_accum += angle_delta * self.polarity
+		self.molecule_angle = current_angle
+		
+		# Force calculations
 		for i in range(len(self.atom_ids)):
 			atom_id: int = self.atom_ids[i]
-			new_motor_velocity: Vec3 = self._calculate_rotary_motor_particle_velocity(speed, positions[atom_id], i)
+			new_motor_velocity = prev_velocities[atom_id]
+			force: Vec3 = self._calculate_rotary_motor_particle_force(simulation, speed, positions[atom_id], prev_velocities[atom_id], i)
 			if atom_id in MOTOR_PER_PARTICLE_LOG_FILES:
 				prev_motor_velocity: Vec3 = self.last_motor_velocities[i]
-				if length_Vec3(prev_motor_velocity) > 0.0 and length_Vec3(new_motor_velocity) > 0.0 and dot_Vec3(normalize_Vec3(prev_motor_velocity), normalize_Vec3(new_motor_velocity)) < 0.1:
+				if length_Vec3(prev_motor_velocity) > 0.0 and length_Vec3(force) > 0.0 and dot_Vec3(normalize_Vec3(prev_motor_velocity), normalize_Vec3(new_motor_velocity)) < 0.1:
 					self.particle_log(i, "		MOTOR DIRECTION SUDDENLY INVERTED!")
 					self.particle_log(i, f"		speed ({speed}) , prev_motor_velocity {prev_motor_velocity}({length_Vec3(prev_motor_velocity)}) new_motor_velocity {new_motor_velocity}({length_Vec3(new_motor_velocity)})")
-			new_velocities[atom_id] = new_motor_velocity
-			self.last_motor_velocities[i] = new_motor_velocity # update record for the next iter
-		simulation.context.setVelocities(new_velocities)
+			self.last_motor_velocities[i] = prev_velocities[atom_id] # update record for the next iter
+			self.external_force.setParticleParameters(i, atom_id, force)
+		
+		self.external_force.updateParametersInContext(simulation.context)
 		return
 	
 	def _calculate_rotary_motor_particle_distance_to_axis(self, particle_pos: Vec3) -> float:
@@ -630,72 +679,80 @@ class MotorForce:
 		distance = length_Vec3(particle_pos - axis_of_rotation)
 		return distance
 	
-	def _calculate_rotary_motor_particle_velocity(self, speed: float, particle_pos: Vec3, i: int) -> Vec3:
+	def _calculate_rotary_motor_particle_force(self, simulation, speed: float, particle_pos: Vec3, previous_velocity: Vec3, i: int) -> Vec3:
+		previous_velocity = (previous_velocity._value * 1000.0) * (meter / second) # convert from nm/ps to m/s
 		distance_to_axis: float = self._calculate_rotary_motor_particle_distance_to_axis(particle_pos)
+		target_speed = speed * distance_to_axis
 		axis_of_rotation: Vec3 = closest_point_in_rect_to_other(self.position, self.axis_direction, particle_pos)
 		axis_to_particle_vec: Vec3 = particle_pos - axis_of_rotation
 		axis_to_particle_dir: Vec3 = normalize_Vec3(axis_to_particle_vec)
-		move_dir: Vec3 = cross_Vec3(axis_to_particle_dir / nanometer, self.axis_direction) * nanometer / nanosecond
-		velocity: Vec3 = move_dir * speed * distance_to_axis * self.polarity
+		move_dir: Vec3 = normalize_Vec3(cross_Vec3(axis_to_particle_dir / nanometer, self.axis_direction) * nanometer / nanosecond) * self.polarity
+		current_speed_in_desired_direction = dot_Vec3(previous_velocity, move_dir)
+		speed_delta: Vec3 = target_speed - current_speed_in_desired_direction
+		
+		force_quantity = speed_delta * 1.5 # Empirical approximation. This could use a proper analytical solution.
+		if self.limit_maximum_force:
+			force_quantity = min(abs(force_quantity), self.max_force)
+		
+		# If the particle is going faster than the target speed, apply an opposing force to slow it down.
+		# (If this is not desired, set force_quantity to 0 to avoid speeding it up even more)
+		if current_speed_in_desired_direction > target_speed:
+			force_quantity = -force_quantity
+		force: Vec3 = force_quantity * move_dir._value * kilojoule_per_mole
+		
 		atom_id: int = self.atom_ids[i]
 		if atom_id in MOTOR_PER_PARTICLE_LOG_FILES:
-			# This if condition is not strictly necesary, but will prevent wasting cpu on formating strings
-			self.particle_log(i, f"CALCULATE VELOCITY, time is {self.time_accum * 1000000}fs")
+			# This if condition is not strictly necessary, but will prevent wasting cpu on formating strings
+			self.particle_log(i, f"CALCULATE VELOCITY, time is {self.cycle_time_accum * 1000000}fs")
 			self.particle_log(i, f"	particle_pos {particle_pos}")
 			self.particle_log(i, f"	distance_to_axis {distance_to_axis}nm")
 			self.particle_log(i, f"	axis_of_rotation {axis_of_rotation}")
 			self.particle_log(i, f"	axis_to_particle_vec {axis_to_particle_vec}")
 			self.particle_log(i, f"	axis_to_particle_dir {axis_to_particle_dir}")
 			self.particle_log(i, f"	move_dir {move_dir}")
-			self.particle_log(i, f"		velocity ({length_Vec3(velocity)}nm/ns) {velocity}")
-		return velocity
+			self.particle_log(i, f"		force ({length_Vec3(force)}kJ/mol) {force}")
+		return force
 	
 	def _advance_linear(self, simulation):
 		if self.stopped or len(self.atom_ids) == 0:
 			# Nothing to do here
 			return
 		
-		if self.limit_maximum_force and self.max_acceleration < 0:
-			average_particle_mass: float = 0.0
-			for i in range(len(self.atom_ids)):
-				atom_id: int = self.atom_ids[i]
-				average_particle_mass += simulation.system.getParticleMass(atom_id)._value
-			average_particle_mass /= len(self.atom_ids)
-			average_particle_mass *= 1.66053907e-27 # Convert Daltons to Kilograms
-			self.max_acceleration = self.max_force / average_particle_mass
-			if MOTOR_DEBUG_PRINTS:
-				logging.info(f"Max force: {self.max_force}N, Max acceleration: {self.max_acceleration}m/s^2")
-		
-		self.time_accum += simulation.time_step_in_nanoseconds
-		new_motor_velocity: Vec3 = Vec3(0,0,0) # new motor velocity is the same for all particles linked to the motor
-		speed: float = self._calculate_speed(simulation.time_step_in_nanoseconds)
-		new_motor_velocity = self.axis_direction * speed * self.polarity * nanometer / nanosecond
-		self.distance_accum += simulation.time_step_in_nanoseconds * speed
 		self.print_counter = (self.print_counter + 1) % 64 # print every 64 steps
+		target_speed: float = self._calculate_speed(simulation.time_step_in_nanoseconds) # in m/s
+		previous_position = self.molecule_center
+		current_position = self.get_molecule_center(simulation)
+		self.cycle_distance_accum += dot_Vec3(current_position - previous_position, self.axis_direction * self.polarity)
+		self.molecule_center = current_position
 
 		if self.print_counter == 0 or self.stopped:
 			if MOTOR_DEBUG_PRINTS:
-				logging.info(f"motor velocity is {new_motor_velocity} , distance is {self.distance_accum}nm , time is {self.time_accum * 1000000}fs")
+				logging.info(f"motor target speed is {target_speed} m/s, distance is {self.cycle_distance_accum}nm , time is {self.cycle_time_accum * 1000000}fs")
 		
 		state = simulation.context.getState(getVelocities=True)
 		prev_velocities = state.getVelocities()
-		new_velocities = prev_velocities.copy()
+		
 		for i in range(len(self.atom_ids)):
 			atom_id: int = self.atom_ids[i]
-			previous_velocity: Vec3 = prev_velocities[atom_id]
-			final_velocity: Vec3 = new_motor_velocity
-			current_velocity_in_desired_direction = self.axis_direction * dot_Vec3(previous_velocity, self.axis_direction) * previous_velocity.unit
-			delta_velocity = final_velocity - current_velocity_in_desired_direction
+			previous_velocity: Vec3 = prev_velocities[atom_id]._value * 1000.0 * (meter / second) # from nm/ps to m/s
+			current_speed_in_desired_direction: float = dot_Vec3(previous_velocity, self.axis_direction * self.polarity)
+			speed_delta: float = target_speed - current_speed_in_desired_direction
 			
+			# Calculate required force to reach target speed from current speed
+			force_quantity = speed_delta * 1.5 # Empirical approximation. This could use a proper analytical solution.
 			if self.limit_maximum_force:
-				acceleration: Vec3 = delta_velocity / (simulation.time_step_in_nanoseconds * nanosecond)
-				acceleration_len: float = length_Vec3(acceleration)
-				if acceleration_len > 0.0:
-					ratio: float = max(0, min(1, self.max_acceleration / acceleration_len))
-					delta_velocity *= ratio
+				force_quantity = min(abs(force_quantity), self.max_force)
+			# If the particle is going faster than the target speed, apply an opposing force to slow it down.
+			# (If this is not desired, set force_quantity to 0 to avoid speeding it up even more)
+			if current_speed_in_desired_direction > target_speed:
+				force_quantity = -force_quantity
+			force: Vec3 = force_quantity * self.axis_direction * self.polarity * kilojoule_per_mole
+			self.external_force.setParticleParameters(i, atom_id, force)
 			
-			new_velocities[atom_id] = previous_velocity + delta_velocity
-		simulation.context.setVelocities(new_velocities)
+			if MOTOR_DEBUG_PRINTS and self.print_counter == 0 and i == 0:
+				logging.info(f"Current speed: {current_speed_in_desired_direction} m/s - Force: {force} kJ/mol")
+		
+		self.external_force.updateParametersInContext(simulation.context)
 		return
 
 	def _calculate_speed(self, delta_time: float) -> float:
@@ -720,7 +777,6 @@ class MotorForce:
 			speed = max_speed * relative_time
 		
 		if self.cycle_type == CycleType.CONTINUOUS:
-			self.cycle_distance_accum += speed * delta_time
 			return speed
 		
 		cycle_reference: float = self.cycle_time_accum if self.cycle_type == CycleType.TIMED else self.cycle_distance_accum
@@ -753,7 +809,6 @@ class MotorForce:
 				speed = max_speed * relative_time
 		else:
 			speed = max_speed
-		self.cycle_distance_accum += speed * delta_time
 		return speed
 
 	def _invert_polarity(self):
@@ -762,7 +817,6 @@ class MotorForce:
 	
 	def _stop_motor(self, simulation):
 		self.stopped = True
-	
 
 
 class ParticleEmitter:
@@ -1317,7 +1371,10 @@ def start_simulation(socket, socket_lock, simulation_id: int, parameters: Payloa
 			if atom.is_passivation_atom:
 				openff_atom_id = topology_payload.payload_to_openff_atom[i]
 				forces.nonbonded_force.setParticleParameters(openff_atom_id, charge=0.0, sigma=0.0, epsilon=0.0)
-
+		# Motors
+		for motor in topology_payload.motors_forces:
+			motor.initialize_force(openmm_system)
+		
 		if stop_exists and stop_trigger.is_set():
 			if running_simulations.pop(simulation.simulation_id, None) != None:
 				logging.info(f"Aborted simulation while starting, step #4")
@@ -1382,6 +1439,9 @@ def start_simulation(socket, socket_lock, simulation_id: int, parameters: Payloa
 		for emitter in topology_payload.emitters:
 			# Initialize ParticleEmitter molecules
 			emitter.setup(simulation, topology_payload.payload_to_openff_atom)
+		
+		for motor in topology_payload.motors_forces:
+			motor.start_simulation(simulation)
 
 		# Configure publish reporter
 		socket_publish_reporter = ZmqPublishReporter(simulation_id, socket, socket_lock, trj_freq)


### PR DESCRIPTION
Both linear and rotary motors now rely on the openmm's force class to move their particles, instead of computing the final velocity directly if the forcer limiter is active.

**The previous behavior is still available as long as "Limit Maximum force" is disabled.**

The distance and rotation accumulators (for cycles) now track the actual distance traveled by the particles instead of relying on just `target_speed * time` (since these particles can collide with other atoms now, which slows them down, or stop them completely).