### PR TITLE
Remove deprecated toggle to 'Include Hydrogens' in DNA Objects

### DIFF
--- a/godot_project/autoloads/dna_builder/DnaBuilder.gd
+++ b/godot_project/autoloads/dna_builder/DnaBuilder.gd
@@ -72,7 +72,7 @@ func _build_nucleotide(
 		) -> PackedMolecule:
 	assert(in_base in ["A", "T", "G", "C"], "Unknown base: %s" % in_base)
 	
-	var template: PackedMolecule = get_template(in_base, in_params.include_hydrogens)
+	var template: PackedMolecule = get_template(in_base)
 	var result := PackedMolecule.new()
 	
 	# Calculate helix position
@@ -101,7 +101,7 @@ func _build_nucleotide(
 	var backbone_centroid: Vector3 = \
 		(Vector3.RIGHT * backbone_distance).rotated(Vector3.BACK, angle)
 	backbone_centroid.z += z_offset
-	template = get_template("backbone%d" % strand, in_params.include_hydrogens)
+	template = get_template("backbone%d" % strand)
 	assert(template.base_to_backbone_atom_id >= 0, "Unconfigured b	ase_to_backbone_atom_id for " + "backbone%d" % strand)
 	if is_dev_tool_enabled():
 		# Show the centroid position. Argon for Backbone
@@ -117,7 +117,7 @@ func _build_nucleotide(
 	return result
 
 
-func get_template(in_base: String, in_include_hydrogens: bool = false) -> PackedMolecule:
+func get_template(in_base: String) -> PackedMolecule:
 	const FILENAMES = {
 		"A" : "adenine",
 		"T" : "thymine",
@@ -126,19 +126,19 @@ func get_template(in_base: String, in_include_hydrogens: bool = false) -> Packed
 		"backbone0" : "backbone0",
 		"backbone1" : "backbone1",
 	}
-	const PATH = "res://autoloads/dna_builder/templates/%s.tres"
+	const PATH = "res://autoloads/dna_builder/templates/%s_h.tres"
 	assert(in_base in FILENAMES.keys(), "Unknown base %s" % in_base)
-	var filename: String = FILENAMES[in_base] + ("_h" if in_include_hydrogens else "")
+	var filename: String = FILENAMES[in_base]
 	if not _base_templates.has(filename) or is_dev_tool_enabled():
 		_base_templates[filename] = ResourceLoader.load(PATH % filename, "", ResourceLoader.CACHE_MODE_IGNORE)
 	return _base_templates[filename]
 
-func get_template_atom_count(in_base: String, in_include_hydrogens: bool = false) -> int:
-	return get_template(in_base, in_include_hydrogens).atoms.size()
+func get_template_atom_count(in_base: String) -> int:
+	return get_template(in_base).atoms.size()
 
 
-func get_template_bond_count(in_base: String, in_include_hydrogens: bool = false) -> int:
-	return get_template(in_base, in_include_hydrogens).bonds.size()
+func get_template_bond_count(in_base: String) -> int:
+	return get_template(in_base).bonds.size()
 
 
 func _dump_template(

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.gd
@@ -37,7 +37,6 @@ func _notification(what: int) -> void:
 				_strand_b_button.button_pressed = true
 			DnaStructure.StrandPolicy.DOUBLE:
 				_strand_double_button.button_pressed = true
-		_include_hydrogens_check_button.button_pressed = default_params.include_hydrogens
 		_dna_sequence_text_edit.text_changed.connect(_on_dna_sequence_text_edit_text_changed)
 		_create_button.pressed.connect(_on_create_button_pressed)
 		_update_create_button()
@@ -70,7 +69,6 @@ func _on_create_button_pressed() -> void:
 		_:
 			push_error("Invalid strand polocy_button: ",
 				"<null>" if strand_button == null else str(get_path_to(strand_button)))
-	params.include_hydrogens = _include_hydrogens_check_button.button_pressed
 	if OS.is_debug_build() and DnaBuilder.is_dev_tool_enabled():
 		DnaBuilder.DNA_BASES_OFFSET = %OffsetSpinBoxSlider.value
 

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
@@ -25,7 +25,6 @@ func _notification(what: int) -> void:
 		_rise_nanometers_spin_box_slider.value_confirmed.connect(_on_rise_nanometers_spin_box_slider_value_confirmed)
 		_initial_twist_spin_box_slider.value_confirmed.connect(_on_initial_twist_spin_box_slider_value_confirmed)
 		_strand_a_button.button_group.pressed.connect(_on_strand_policy_button_group_button_pressed)
-		_include_hydrogens_check_button.toggled.connect(_on_include_hydrogens_check_button_toggled)
 
 
 func _sequence_button_button_group_pressed() -> void:
@@ -101,7 +100,6 @@ func _update_ui() -> void:
 		_strand_a_button.set_pressed_no_signal(_tracked_structure.get_strand_policy() == StrandPolicy.A)
 		_strand_b_button.set_pressed_no_signal(_tracked_structure.get_strand_policy() == StrandPolicy.B)
 		_strand_double_button.set_pressed_no_signal(_tracked_structure.get_strand_policy() == StrandPolicy.DOUBLE)
-		_include_hydrogens_check_button.set_pressed_no_signal(_tracked_structure.get_include_hydrogens())
 
 
 func _on_tracked_structure_sequence_changed(in_sequence: String) -> void:
@@ -197,11 +195,3 @@ func _on_strand_policy_button_group_button_pressed(in_button: Button) -> void:
 	_tracked_structure.set_strand_policy(policy)
 	_tracked_structure.end_edit()
 	_workspace_context.snapshot_moment("Set Strand Mode")
-
-
-func _on_include_hydrogens_check_button_toggled(in_button_pressed: bool) -> void:
-	assert(_tracked_structure != null)
-	_tracked_structure.start_edit()
-	_tracked_structure.set_include_hydrogens(in_button_pressed)
-	_tracked_structure.end_edit()
-	_workspace_context.snapshot_moment("Set Dna Object includes hydrogens")

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.gd
@@ -14,7 +14,6 @@ var _initial_twist_spin_box_slider: SpinBoxSlider
 var _strand_a_button: Button
 var _strand_b_button: Button
 var _strand_double_button: Button
-var _include_hydrogens_check_button: CheckButton
 
 
 func _notification(what: int) -> void:
@@ -31,7 +30,6 @@ func _notification(what: int) -> void:
 		_strand_a_button = %StrandAButton as Button
 		_strand_b_button = %StrandBButton as Button
 		_strand_double_button = %StrandDoubleButton as Button
-		_include_hydrogens_check_button = %IncludeHydrogensCheckButton as CheckButton
 		assert(_rand_sequence_button.button_group == _user_defined_sequence_button.button_group)
 		if not _rand_sequence_button.button_group.pressed.is_connected(_sequence_button_button_group_pressed):
 			_rand_sequence_button.button_group.pressed.connect(_sequence_button_button_group_pressed.unbind(1))

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
@@ -204,9 +204,3 @@ value = 1.0
 allow_greater = true
 suffix = "nm"
 custom_arrow_step = 0.1
-
-[node name="IncludeHydrogensCheckButton" type="CheckButton" parent="VBoxContainer/PanelContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-button_pressed = true
-text = "· Include Hydrogens"

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -347,16 +347,6 @@ func get_strands() -> Array[Strand]:
 		_:
 			assert(false, "Should not happen")
 			return []
-
-
-func set_include_hydrogens(in_include_hydrogens: bool) -> void:
-	assert(_is_being_edited, "I'm not being edited currently, make sure start_edit() is called first")
-	_signal_queue_parameters_changed = true
-	_parameters.include_hydrogens = in_include_hydrogens
-
-
-func get_include_hydrogens() -> bool:
-	return _parameters.include_hydrogens
 #endregion
 
 
@@ -620,12 +610,12 @@ func get_valid_atoms_count() -> int:
 		return 0
 	if _atoms_count_cache == -1:
 		var base_count: Dictionary[String, int] = {
-			"A" : DnaBuilder.get_template_atom_count("A", _parameters.include_hydrogens),
-			"T" : DnaBuilder.get_template_atom_count("T", _parameters.include_hydrogens),
-			"G" : DnaBuilder.get_template_atom_count("G", _parameters.include_hydrogens),
-			"C" : DnaBuilder.get_template_atom_count("C", _parameters.include_hydrogens),
+			"A" : DnaBuilder.get_template_atom_count("A"),
+			"T" : DnaBuilder.get_template_atom_count("T"),
+			"G" : DnaBuilder.get_template_atom_count("G"),
+			"C" : DnaBuilder.get_template_atom_count("C"),
 			"X" : 0,
-			"B" : DnaBuilder.get_template_atom_count("backbone0", _parameters.include_hydrogens)
+			"B" : DnaBuilder.get_template_atom_count("backbone0")
 		}
 		_atoms_count_cache = base_count["B"] * _sequence.length()
 		if get_strand_policy() == StrandPolicy.DOUBLE:
@@ -650,12 +640,12 @@ func get_atom_ids_for_strand(in_strand: Strand) -> PackedInt32Array:
 		# Update cache
 		_atoms_ids_cache[in_strand] = PackedInt32Array()
 		var base_count: Dictionary[String, int] = {
-			"A" : DnaBuilder.get_template_atom_count("A", _parameters.include_hydrogens),
-			"T" : DnaBuilder.get_template_atom_count("T", _parameters.include_hydrogens),
-			"G" : DnaBuilder.get_template_atom_count("G", _parameters.include_hydrogens),
-			"C" : DnaBuilder.get_template_atom_count("C", _parameters.include_hydrogens),
+			"A" : DnaBuilder.get_template_atom_count("A"),
+			"T" : DnaBuilder.get_template_atom_count("T"),
+			"G" : DnaBuilder.get_template_atom_count("G"),
+			"C" : DnaBuilder.get_template_atom_count("C"),
 			"X" : 0,
-			"B" : DnaBuilder.get_template_atom_count("backbone0", _parameters.include_hydrogens)
+			"B" : DnaBuilder.get_template_atom_count("backbone0")
 		}
 		for base_idx: int in _sequence.length():
 			# Backbone
@@ -923,12 +913,12 @@ func get_bond_ids_for_strand(in_strand: Strand) -> PackedInt32Array:
 		# Update cache
 		_bonds_ids_cache[in_strand] = PackedInt32Array()
 		var base_count: Dictionary[String, int] = {
-			"A" : DnaBuilder.get_template_bond_count("A", _parameters.include_hydrogens),
-			"T" : DnaBuilder.get_template_bond_count("T", _parameters.include_hydrogens),
-			"G" : DnaBuilder.get_template_bond_count("G", _parameters.include_hydrogens),
-			"C" : DnaBuilder.get_template_bond_count("C", _parameters.include_hydrogens),
+			"A" : DnaBuilder.get_template_bond_count("A"),
+			"T" : DnaBuilder.get_template_bond_count("T"),
+			"G" : DnaBuilder.get_template_bond_count("G"),
+			"C" : DnaBuilder.get_template_bond_count("C"),
 			"X" : 0,
-			"B" : DnaBuilder.get_template_bond_count("backbone0", _parameters.include_hydrogens)
+			"B" : DnaBuilder.get_template_bond_count("backbone0")
 		}
 		for base_idx: int in _sequence.length():
 			# Backbone
@@ -1016,12 +1006,12 @@ func get_valid_bonds_count() -> int:
 	if _bonds_count_cache == -1:
 		const GLUE_BOND = 1
 		var base_count: Dictionary[String, int] = {
-			"A" : DnaBuilder.get_template_bond_count("A", _parameters.include_hydrogens) + GLUE_BOND,
-			"T" : DnaBuilder.get_template_bond_count("T", _parameters.include_hydrogens) + GLUE_BOND,
-			"G" : DnaBuilder.get_template_bond_count("G", _parameters.include_hydrogens) + GLUE_BOND,
-			"C" : DnaBuilder.get_template_bond_count("C", _parameters.include_hydrogens) + GLUE_BOND,
+			"A" : DnaBuilder.get_template_bond_count("A") + GLUE_BOND,
+			"T" : DnaBuilder.get_template_bond_count("T") + GLUE_BOND,
+			"G" : DnaBuilder.get_template_bond_count("G") + GLUE_BOND,
+			"C" : DnaBuilder.get_template_bond_count("C") + GLUE_BOND,
 			"X" : 0,
-			"B" : DnaBuilder.get_template_bond_count("backbone0", _parameters.include_hydrogens)
+			"B" : DnaBuilder.get_template_bond_count("backbone0")
 		}
 		_bonds_count_cache = (base_count["B"] + GLUE_BOND) * _sequence.length() - GLUE_BOND
 		if get_strand_policy() == StrandPolicy.DOUBLE:
@@ -1050,7 +1040,7 @@ func get_bond(in_bond_id: int) -> Vector3i:
 		var id_info: UnpackedBondId = _unpack_bond_id(in_bond_id)
 		if id_info.is_backbone:
 			var base: String = "backbone1" if id_info.strand == Strand.B else "backbone0"
-			var template: PackedMolecule = DnaBuilder.get_template(base, get_include_hydrogens())
+			var template: PackedMolecule = DnaBuilder.get_template(base)
 			if id_info.is_glue_bond:
 				bond_data.x = _get_atom_id(id_info.base_idx - 1, id_info.strand, true, template.next_backbone_atom_id)
 				bond_data.y = _get_atom_id(id_info.base_idx, id_info.strand, true, template.previous_backbone_atom_id)
@@ -1064,10 +1054,10 @@ func get_bond(in_bond_id: int) -> Vector3i:
 			var base: String = _sequence[id_info.base_idx]
 			if id_info.strand == Strand.B:
 				base = DnaBuilder.DNA_COMPLEMENT.get(base, "X")
-			var template: PackedMolecule = DnaBuilder.get_template(base, get_include_hydrogens())
+			var template: PackedMolecule = DnaBuilder.get_template(base)
 			if id_info.is_glue_bond:
 				var backbone: String = "backbone1" if id_info.strand == Strand.B else "backbone0"
-				var backbone_template: PackedMolecule = DnaBuilder.get_template(backbone, get_include_hydrogens())
+				var backbone_template: PackedMolecule = DnaBuilder.get_template(backbone)
 				bond_data.x = _get_atom_id(id_info.base_idx, id_info.strand, false, template.base_to_backbone_atom_id)
 				bond_data.y = _get_atom_id(id_info.base_idx, id_info.strand, true, backbone_template.base_to_backbone_atom_id)
 				bond_data.z = 1
@@ -1117,7 +1107,7 @@ func _get_base_template_for_unpacked_atom(in_packed: UnpackedAtomId) -> PackedMo
 	var base: String = "backbone0" if in_packed.is_backbone else _sequence[in_packed.base_idx]
 	if in_packed.strand == Strand.B:
 		base = "backbone1" if in_packed.is_backbone else DnaBuilder.DNA_COMPLEMENT.get(base, "X")
-	return DnaBuilder.get_template(base, get_include_hydrogens())
+	return DnaBuilder.get_template(base)
 
 
 func _get_base_template_for_unpacked_bond(in_packed: UnpackedBondId) -> PackedMolecule:
@@ -1126,7 +1116,7 @@ func _get_base_template_for_unpacked_bond(in_packed: UnpackedBondId) -> PackedMo
 	var base: String = "backbone0" if in_packed.is_backbone else _sequence[in_packed.base_idx]
 	if in_packed.strand == Strand.B:
 		base = "backbone1" if in_packed.is_backbone else DnaBuilder.DNA_COMPLEMENT.get(base, "X")
-	return DnaBuilder.get_template(base, get_include_hydrogens())
+	return DnaBuilder.get_template(base)
 
 
 static func _unpack_bond_id(in_bond_id: int) -> UnpackedBondId:
@@ -1693,7 +1683,7 @@ class AtomData:
 		if base == "X":
 			assert(false, "Invalid atom ID %d" % id_data.original_id)
 			return
-		var base_template: PackedMolecule = DnaBuilder.get_template(base, owner.get_include_hydrogens())
+		var base_template: PackedMolecule = DnaBuilder.get_template(base)
 		assert(id_data.sub_atom_id < base_template.atoms.size(),
 			"Invalid atom ID %d (sub_atom_id = %d)" % [id_data.original_id, id_data.sub_atom_id])
 		var atom_info: Vector4 = base_template.atoms[id_data.sub_atom_id]

--- a/godot_project/project_workspace/structs/dna_structure_parameters.gd
+++ b/godot_project/project_workspace/structs/dna_structure_parameters.gd
@@ -13,7 +13,6 @@ enum StrandPolicy {
 @export var dna_radius_nanometers: float = 1.0
 @export var initial_twist_rad: float = 0.0
 @export var strand_policy:= StrandPolicy.DOUBLE
-@export var include_hydrogens: bool = true
 
 
 var _is_read_only: bool = false
@@ -37,7 +36,6 @@ func create_state_snapshot() -> Dictionary:
 	state_snapshot["dna_radius_nanometers"] = dna_radius_nanometers
 	state_snapshot["initial_twist_rad"] = initial_twist_rad
 	state_snapshot["strand_policy"] = strand_policy
-	state_snapshot["include_hydrogens"] = include_hydrogens
 	return state_snapshot
 
 
@@ -47,4 +45,3 @@ func apply_state_snapshot(in_state_snapshot: Dictionary) -> void:
 	dna_radius_nanometers = in_state_snapshot["dna_radius_nanometers"]
 	initial_twist_rad = in_state_snapshot["initial_twist_rad"]
 	strand_policy = in_state_snapshot["strand_policy"]
-	include_hydrogens = in_state_snapshot["include_hydrogens"]


### PR DESCRIPTION
Task: CRASH: toggling "Include hydrogens" in a DNA structure while visualizing as Atoms and Bonds