### PR TITLE
When creating anchors and springs, consider the 'Snap to Reference Shapes surfaces' setting

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
@@ -376,6 +376,21 @@ func _process_create_spring_result(in_camera: Camera3D, in_input_event: InputEve
 			anchor = hit_context.nano_structure as NanoVirtualAnchor
 			anchor_context = hit_context
 			assert(is_instance_valid(anchor))
+		MultiStructureHitResult.HitType.HIT_SHAPE:
+			if is_snap_to_shape_surface_enabled(_workspace_context):
+				if _drag_state != _DRAG_FROM_ATOM:
+					# Cannot create spring from anchor to anchor
+					return false
+				# Create an Anchor in empty space to bind source atom
+				created_anchor = true
+				anchor = NanoVirtualAnchor.new()
+				anchor.set_structure_name("AnchorPoint")
+				anchor.set_position(_get_rendering().virtual_anchor_preview_get_position())
+				workspace.add_structure(anchor, workspace_context.get_current_structure_context().nano_structure)
+				anchor_context = workspace_context.get_nano_structure_context(anchor)
+				anchor_context.select_all(true)
+			else:
+				return false
 		MultiStructureHitResult.HitType.HIT_NOTHING:
 			if _drag_state != _DRAG_FROM_ATOM:
 				# Cannot create spring from anchor to anchor

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -662,7 +662,8 @@ func _is_shape_selectable() -> bool:
 	var create_object_parameters: CreateObjectParameters = get_workspace_context().create_object_parameters
 	var select_mode_enabled: bool = not create_object_parameters.get_create_mode_enabled()
 	var is_creating_atoms: bool = create_object_parameters.get_create_mode_type() == CreateObjectParameters.CreateModeType.CREATE_ATOMS_AND_BONDS
+	var is_creating_anchors: bool = create_object_parameters.get_create_mode_type() == CreateObjectParameters.CreateModeType.CREATE_ANCHORS_AND_SPRINGS
 	var snap_to_surface_enabled: bool = create_object_parameters.get_snap_to_shape_surface()
-	if select_mode_enabled or not is_creating_atoms:
+	if select_mode_enabled or not (is_creating_atoms or is_creating_anchors):
 		return true
 	return not snap_to_surface_enabled


### PR DESCRIPTION
Task; BUG: Cannot create an anchor into a motor, emitter, or shape
Note: it was decided only shapes needs fixing, only if the setting is enabled

https://github.com/user-attachments/assets/0b4fbe76-030e-43fa-98cc-bdac10f3885c

