### PR TITLE
When searching atoms by type, ignore DNA structures

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/find_atoms_by_type.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/find_atoms_by_type.gd
@@ -55,7 +55,8 @@ func _refresh_groups_tree() -> void:
 	var root: TreeItem = _groups_tree.create_item()
 	_groups_tree.hide_root = true
 	for structure: NanoStructure in _workspace_context.workspace.get_root_child_structures():
-		if not structure is AtomicStructure:
+		if not structure is AtomicStructure or structure is DnaStructure:
+			# DNA is intentionally ignored because their atoms are not interactible
 			continue
 		_add_groups_recursively(structure, root)
 
@@ -69,7 +70,8 @@ func _add_groups_recursively(in_structure: AtomicStructure, in_parent_item: Tree
 	group_item.set_meta(&"count", count)
 	group_item.set_selectable(COL_0, count > 0)
 	for structure: NanoStructure in _workspace_context.workspace.get_child_structures(in_structure):
-		if not structure is AtomicStructure:
+		if not structure is AtomicStructure or structure is DnaStructure:
+			# DNA is intentionally ignored because their atoms are not interactible
 			continue
 		_add_groups_recursively(structure, group_item)
 


### PR DESCRIPTION
Task: BUG+CRASH: "Find Visible Atoms of Type" allows to select atoms from DNA Objects