### PR TITLE
When DNA parameters change, invalidate cache of bases positions

### DIFF
--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -215,6 +215,7 @@ func end_edit() -> void:
 			sequence_changed.emit(_sequence)
 		if _signal_queue_parameters_changed:
 			_baked_path.clear()
+			_base_transform_cache.clear()
 			_parameters.set_read_only(true)
 			parameters_changed.emit(_parameters)
 			_parameters.set_read_only(false)


### PR DESCRIPTION
BUG: Changing parameters of DNA (rise, twist, etc) doesn't update positions of atoms