### PR TITLE
Prevent Contextual Panel buttons from being accidentally activated when ENTER is pressed in QuickSearch dialog

### DIFF
--- a/godot_project/editor/controls/quick_search_dialog/quick_search_dialog.gd
+++ b/godot_project/editor/controls/quick_search_dialog/quick_search_dialog.gd
@@ -199,6 +199,8 @@ func _discover_actions_recursive(path: String, parent: TreeItem) -> void:
 func _on_about_to_popup() -> void:
 	if _action_items.is_empty():
 		_rebuild_tree()
+	# Release the focus of any other control
+	get_tree().root.gui_release_focus()
 	_search_bar.text = ""
 	_search_bar.grab_focus()
 	_filter_actions()

--- a/godot_project/editor/controls/quick_search_dialog/quick_search_dialog.tscn
+++ b/godot_project/editor/controls/quick_search_dialog/quick_search_dialog.tscn
@@ -8,7 +8,7 @@
 disable_3d = true
 title = " Quick search"
 initial_position = 2
-size = Vector2i(278, 258)
+size = Vector2i(290, 258)
 visible = true
 unresizable = false
 borderless = false
@@ -19,10 +19,10 @@ script = ExtResource("1_ox6k4")
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 4.0
-offset_top = 4.0
-offset_right = -4.0
-offset_bottom = -4.0
+offset_left = 10.0
+offset_top = 10.0
+offset_right = -10.0
+offset_bottom = -10.0
 grow_horizontal = 2
 grow_vertical = 2
 


### PR DESCRIPTION
Task: BUG: using the command palette can create duplicate objects