### PR TITLE
Emmit DnaObject.path_changed after object is no longer being edited

### DIFF
--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -203,10 +203,6 @@ func end_edit() -> void:
 		)
 	if has_changed:
 		_aabb_cache = AABB()
-		if _signal_queue_path_changed:
-			path_changed.emit()
-			_baked_path.clear()
-			_signal_queue_path_changed = false
 		# Emmit count changed signal before actual sequence
 		if _last_bases_cout != _sequence.length():
 			var count: = _sequence.length()
@@ -278,6 +274,10 @@ func end_edit() -> void:
 			_signal_queue_atoms_removed = prev_atoms_cache.keys()
 			_signal_queue_bonds_removed = prev_bonds_cache.keys()
 			super.end_edit()
+		if _signal_queue_path_changed:
+			_baked_path.clear()
+			_signal_queue_path_changed = false
+			path_changed.emit()
 		emit_changed()
 	else:
 		_is_being_edited = false

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -836,8 +836,7 @@ func _on_dna_path_changed(in_structure_context_id: int) -> void:
 			if not structure_context.has_selection():
 				# removed the last selection, let's keep selection alike
 				structure_context.select_all()
-			var contexts: Array[StructureContext] = [structure_context]
-			selection_in_structures_changed.emit(contexts)
+		_selection_modified_structure_contexts[in_structure_context_id] = true
 
 
 func _on_nano_structure_visibility_changed(_in_visible: bool, in_structure_context_id: int) -> void:


### PR DESCRIPTION
- Editing the signal too early was attempting to modify control point selection when the object was marked for edition
- Also changed how selection changed is propagated

**This is a regression from #615**
Task: Bug - Control Points remain selected, even when the DNA object is shortened and they don't exist anymore