### PR TITLE
Fix a case where user could not move the camera and it should

### DIFF
--- a/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_child_list/structure_child_list.gd
+++ b/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_child_list/structure_child_list.gd
@@ -86,6 +86,10 @@ func toggle_what_to_show() -> void:
 	set_what_to_show(WHAT_TO_SHOW_INVERTED[_what_to_show])
 
 
+func get_what_to_show() -> WhatToShow:
+	return _what_to_show
+
+
 func _on_workspace_context_structure_added(in_nano_structure: NanoStructure) -> void:
 	var other_parent_id: int = in_nano_structure.int_parent_guid
 	var self_parent_id: int = \

--- a/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_selector_bar.gd
+++ b/godot_project/editor/controls/workspace_view/controls/structure_selector/structure_selector_bar.gd
@@ -160,7 +160,6 @@ func _on_structure_list_structure_context_selected(out_selected_structure_contex
 func _on_structure_list_more_childs_requested(
 			out_parent_structure_context: StructureContext,
 			in_clicked_global_button_rect: Rect2) -> void:
-	_showing_more_childs = true
 	var parent_id: int = 0 if out_parent_structure_context == null else out_parent_structure_context.nano_structure.int_guid
 	var active_id: int = _workspace_context.get_current_structure_context().nano_structure.int_guid
 	var list: StructureChildList = _get_or_create_list(parent_id)
@@ -179,6 +178,7 @@ func _on_structure_list_more_childs_requested(
 	list.toggle_what_to_show()
 	list.rebuild_list()
 	list.show()
+	_showing_more_childs = list.get_what_to_show() == StructureChildList.WhatToShow.ALL
 	_hide_floating_lists_not_in_path_to(null if parent_id == 0 else out_parent_structure_context.nano_structure)
 
 


### PR DESCRIPTION
Task: BUG: can't move the camera after clicking on the group selector UI on top