### PR TITLE
Fix UI not matching the `SequencePolicy` property of selected DNA Object

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
@@ -54,7 +54,7 @@ func _sequence_button_button_group_pressed() -> void:
 	_sequence_length_spin_box_slider.visible = true
 	_dna_sequence_text_edit.editable = pressed_button == _user_defined_sequence_button
 	_dna_sequence_text_edit.visible = true
-	if _tracked_structure == null:
+	if _tracked_structure == null or _updating_ui == true:
 		return
 	_tracked_structure.start_edit()
 	if _rand_sequence_button.button_pressed:
@@ -62,6 +62,7 @@ func _sequence_button_button_group_pressed() -> void:
 	else:
 		_tracked_structure.set_sequence_policy(DnaStructure.SequencePolicy.UserDefined)
 	_tracked_structure.end_edit()
+	_workspace_context.snapshot_moment("Set Dna Sequence Mode")
 
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:
@@ -118,6 +119,11 @@ func _update_ui() -> void:
 		_updating_ui = true
 		if _dna_sequence_text_edit.text != _tracked_structure.get_sequence():
 			_on_tracked_structure_sequence_changed(_tracked_structure.get_sequence())
+		match _tracked_structure.get_sequence_policy():
+			DnaStructure.SequencePolicy.RandomlyGenerated:
+				_rand_sequence_button.button_pressed = true
+			DnaStructure.SequencePolicy.UserDefined:
+				_user_defined_sequence_button.button_pressed = true
 		_dna_radius_spin_box_slider.set_value_no_signal(_tracked_structure.get_dna_radius_nanometers())
 		_bases_per_turn_spin_box_slider.set_value_no_signal(_tracked_structure.get_bases_per_turn())
 		_rise_nanometers_spin_box_slider.set_value_no_signal(_tracked_structure.get_rise_nanometers())

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
@@ -121,6 +121,9 @@ text = "User Specified"
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 116)
 layout_mode = 2
+context_menu_enabled = false
+shortcut_keys_enabled = false
+middle_mouse_paste_enabled = false
 scroll_fit_content_height = false
 
 [node name="SequenceLengthContainer" type="HBoxContainer" parent="VBoxContainer/SequencePanelContainer/VBoxContainer"]

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -664,6 +664,10 @@ func set_sequence_policy(in_policy: SequencePolicy) -> void:
 		set_sequence_length(prev_length)
 
 
+func get_sequence_policy() -> SequencePolicy:
+	return _sequence_policy
+
+
 func set_sequence(in_sequence: String) -> void:
 	assert(_is_being_edited)
 	assert(_sequence_policy == SequencePolicy.UserDefined, "Cannot set sequence when is meant to be generated randomly")
@@ -1723,6 +1727,7 @@ func create_state_snapshot() -> Dictionary:
 	state_snapshot["script.resource_path"] = get_script().resource_path
 	state_snapshot["_track_atoms"] = _track_atoms
 	state_snapshot["_curve"] = _create_curve_snapshot()
+	state_snapshot["_sequence_policy"] = _sequence_policy
 	state_snapshot["_sequence"] = _sequence
 	state_snapshot["_parameters"] = _parameters.create_state_snapshot()
 	state_snapshot["_base_transform_cache"] = _base_transform_cache.duplicate()
@@ -1745,6 +1750,7 @@ func create_state_snapshot() -> Dictionary:
 func apply_state_snapshot(in_state_snapshot: Dictionary) -> void:
 	_track_atoms = in_state_snapshot["_track_atoms"]
 	_set_curve_snapshot(in_state_snapshot["_curve"])
+	_sequence_policy = in_state_snapshot["_sequence_policy"]
 	_sequence = in_state_snapshot["_sequence"]
 	_parameters.apply_state_snapshot(in_state_snapshot["_parameters"])
 	_base_transform_cache = in_state_snapshot["_base_transform_cache"].duplicate()


### PR DESCRIPTION
Task: CRASH: Dna Editor Panel crashes when undoing a change in sequence with user defined sequence