### PR TITLE
Prevent creating an empty undo step for hiding selection when selection cannot be hidden

### DIFF
--- a/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
+++ b/godot_project/editor/controls/menu_bar/menu_view/menu_view.gd
@@ -54,9 +54,10 @@ func _update_for_context(in_context: WorkspaceContext) -> void:
 		var has_visible_objects: bool = in_context.get_visible_structure_contexts().size() > 0
 		var has_selected_objects: bool = in_context.get_structure_contexts_with_selection().size() > 0
 		var has_hidden_objects: bool = in_context.has_hidden_objects()
+		var can_hide: bool = in_context.has_hiddable_selection()
 		set_item_disabled(get_item_index(ID_FOCUS_ON_VISIBLE_OBJECTS), !has_visible_objects)
 		set_item_disabled(get_item_index(ID_FOCUS_ON_SELECTED_OBJECTS), !has_selected_objects)
-		set_item_disabled(get_item_index(ID_HIDE_SELECTED_OBJECTS), !has_selected_objects)
+		set_item_disabled(get_item_index(ID_HIDE_SELECTED_OBJECTS), !can_hide)
 		set_item_disabled(get_item_index(ID_SHOW_HIDDEN_OBJECTS), !has_hidden_objects)
 		set_item_disabled(get_item_index(ID_OVERRIDE_DEFAULT_COLORS), !in_context.is_any_atom_selected())
 		

--- a/godot_project/editor/ring_menu_levels/view_menu/ring_action_hide_selected_objects.gd
+++ b/godot_project/editor/ring_menu_levels/view_menu/ring_action_hide_selected_objects.gd
@@ -23,7 +23,7 @@ func get_icon() -> RingMenuIcon:
 
 
 func _has_selection() -> bool:
-	return is_instance_valid(_workspace_context) and _workspace_context.has_selection()
+	return is_instance_valid(_workspace_context) and _workspace_context.has_hiddable_selection()
 
 
 func _execute_action() -> void:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1086,6 +1086,15 @@ func has_selection() -> bool:
 	return false
 
 
+func has_hiddable_selection() -> bool:
+	for context: StructureContext in _structure_contexts.values():
+		if context.nano_structure.get_visible() and context.has_selection():
+			if context.nano_structure is DnaStructure and not context.is_fully_selected():
+				continue
+			return true
+	return false
+
+
 func has_transformable_selection() -> bool:
 	var transformable_selection: bool = false
 	for context: StructureContext in _structure_contexts.values():


### PR DESCRIPTION
Task: BUG: Selecting some (but not all) DNA Control Points allows to create an empty "Hide Selected Objects" Undo state