### PR TITLE
Fix crash when opening RingMenu's Virtual Object submenu

### DIFF
--- a/godot_project/editor/ring_menu_levels/virtual_objects/ring_level_virtual_objects.gd
+++ b/godot_project/editor/ring_menu_levels/virtual_objects/ring_level_virtual_objects.gd
@@ -18,7 +18,6 @@ func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> voi
 	add_action(RingActionCreateMotor.new(in_workspace_context, in_menu, NanoVirtualMotorParameters.Type.ROTARY))
 	add_action(RingActionCreateMotor.new(in_workspace_context, in_menu, NanoVirtualMotorParameters.Type.LINEAR))
 	add_action(RingActionCreateDnaObject.new(in_workspace_context, in_menu))
-	if FeatureFlagManager.get_flag_value(FeatureFlagManager.FEATURE_FLAG_VIRTUAL_SPRINGS):
-		add_action(RingActionCreateAnchorsAndSprings.new(in_workspace_context, in_menu))
+	add_action(RingActionCreateAnchorsAndSprings.new(in_workspace_context, in_menu))
 	add_action(RingActionCreateParticleEmitters.new(in_workspace_context, in_menu))
 	add_action(RingActionAddShapes.new(_workspace_context, in_menu))


### PR DESCRIPTION
-This is a regression from removing several feature flags in #627

Task: CRASH: Opening RingMenu's Virtual Object submenu