### PR TITLE
Prevent editor from relaxing when only Dna object exists

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/relax_tools_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/relax_tools_panel.tscn
@@ -68,12 +68,14 @@ size_flags_horizontal = 4
 [node name="ButtonRunRelaxation" type="Button" parent="VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+theme_type_variation = &"CrystalButton"
 text = "Run Relaxation"
 icon = ExtResource("3_885b2")
 
 [node name="ButtonViewAlerts" type="Button" parent="VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+theme_type_variation = &"CrystalButton"
 text = "View 4 Alerts..."
 
 [node name="OpenMMFailureTracker" parent="." instance=ExtResource("4_5qhdq")]

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -1318,6 +1318,8 @@ static func _can_relax_all_visible(in_workspace_context: WorkspaceContext) -> bo
 	for context in visible_structures:
 		if not context.nano_structure is AtomicStructure:
 			continue
+		if context.nano_structure is DnaStructure:
+			continue
 		if context.nano_structure.get_valid_atoms_count() > 0:
 			# At least 1 visible atom
 			return true
@@ -1329,6 +1331,8 @@ static func _can_relax_all(in_workspace_context: WorkspaceContext) -> bool:
 			in_workspace_context.get_all_structure_contexts()
 	for context in visible_structures:
 		if not context.nano_structure is AtomicStructure:
+			continue
+		if context.nano_structure is DnaStructure:
 			continue
 		if context.nano_structure.get_valid_atoms_count() > 0:
 			return true


### PR DESCRIPTION
Task: CRASH: Relaxing all atoms in a project with only DNA Object