### PR TITLE
Make sure DNA Object's atom colors are always tracked

### DIFF
--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -297,14 +297,8 @@ func paste(out_workspace_context: WorkspaceContext, in_auto_bond_order: int) -> 
 	var did_create_undo_action: bool = false
 	if out_workspace_context.get_current_structure_context() != null:
 		target_structure = out_workspace_context.get_current_structure_context().nano_structure
-	if target_structure is DnaStructure:
-		out_workspace_context.get_editor_viewport_container().show_warning_in_message_bar(
-			tr("Cannot paste atoms and objects inside a DNA structure.")
-		)
-		return
-	var original_to_new_structure_id: Dictionary = {
-	#	old_id<int> = new_id<int>
-	}
+	assert(not target_structure is DnaStructure, "Cannot paste atoms and objects inside a DNA structure.")
+	var original_to_new_structure_id: Dictionary[int, int] = {}
 	# reference root to allow pasting direct childs
 	var current_structure_id: int = out_workspace_context.get_current_structure_context().nano_structure.int_guid
 	original_to_new_structure_id[current_structure_id] = current_structure_id

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -260,12 +260,7 @@ func end_edit() -> void:
 				if prev_atoms_cache[atom_id].atomic_number != atom_get_atomic_number(atom_id):
 					_signal_queue_atomic_number_changed.append(Vector2i(atom_id, atom_get_atomic_number(atom_id)))
 			# NOTE: prev_atoms_cache.is_empty() means user just started tracking atoms
-			var atoms_to_check_colors: PackedInt32Array
-			if _signal_queue_colors_changed or prev_atoms_cache.is_empty() or _last_sequence != _sequence:
-				atoms_to_check_colors = all_new_atom_ids.duplicate()
-			else:
-				atoms_to_check_colors = _signal_queue_atoms_added.duplicate()
-				atoms_to_check_colors.append_array(_signal_queue_atomic_number_changed)
+			var atoms_to_check_colors: PackedInt32Array = all_new_atom_ids.duplicate()
 			_is_being_edited = true
 			for atom_id: int in atoms_to_check_colors:
 				var expected_color_or_transparent: Color = _get_atom_expected_color(atom_id)


### PR DESCRIPTION
Task: BUG: DNA Object atom's color overrides are not carried over when copypastting an object