### PR TITLE
Add an outline to DNA Object's control points to ensure contrast

### DIFF
--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -524,6 +524,7 @@ func _on_path_representation_drawn() -> void:
 			color = CONTROL_POINT_COLOR_HIGHLIGHTED
 		elif _hovered_control_point == cp_idx:
 			color = CONTROL_POINT_COLOR_HOVER
+		_path_representation.draw_circle(pos2d, CONTROL_POINT_RADIUS + 1, Color.BLACK)
 		_path_representation.draw_circle(pos2d, CONTROL_POINT_RADIUS, color)
 
 


### PR DESCRIPTION
Task: UX: DNA Control points can be hard to see when atoms and bonds are coloryzed

|Before|After|
|--|--|
|<img width="271" height="173" alt="image" src="https://github.com/user-attachments/assets/4b39e7e0-9799-4f96-8cd6-b2a36e1d8212" />|<img width="281" height="181" alt="image" src="https://github.com/user-attachments/assets/285c904b-d21e-4b27-9459-4fcc637ba808" />|
