### PR TITLE
Dont draw edges of the back of DNA's bounding box

### DIFF
--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -545,6 +545,15 @@ func _path_representation_draw_aabb(in_dna_structure: DnaStructure) -> void:
 		p2[c] = start[c]
 		corners.append(p2)
 		corners_2d.append(camera.unproject_position(p2))
+	var farthest_idx: int = -1
+	var fathest_distance_sqrd: float = 0
+	for i in corners.size():
+		var corner_distance_sqrd: float = camera.global_position.distance_squared_to(corners[i])
+		if corner_distance_sqrd > fathest_distance_sqrd:
+			farthest_idx = i
+			fathest_distance_sqrd = corner_distance_sqrd
+	corners.remove_at(farthest_idx)
+	corners_2d.remove_at(farthest_idx)
 	for i: int in range(corners_2d.size() - 1):
 		for j: int in range(i, corners_2d.size()):
 			var common: int = 0


### PR DESCRIPTION
Task: UX: Bounding box od DNA structures is too bussy, could not draw the back faces lines

|Before|After|
|--|--|
|<img width="713" height="529" alt="image" src="https://github.com/user-attachments/assets/36c2d104-b737-4f55-a9e6-dd8dde1b9974" />|<img width="710" height="444" alt="image" src="https://github.com/user-attachments/assets/8fb950d3-72b5-476e-87fb-08777d979f14" />|

