### PR TITLE
Fix warnings caused by invalid NodePath's

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_dna_panel.tscn
@@ -54,17 +54,17 @@ button_group = SubResource("ButtonGroup_t5a7f")
 [node name="SugarSameAsBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer3" index="2"]
 button_group = SubResource("ButtonGroup_t5a7f")
 
-[node name="DontColorizeBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2" index="1"]
+[node name="DontColorizeBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="1"]
 button_pressed = false
 button_group = SubResource("ButtonGroup_t2pju")
 
-[node name="PerStrandBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2" index="2"]
+[node name="PerStrandBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="2"]
 button_group = SubResource("ButtonGroup_t2pju")
 
-[node name="PerGrooveButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2" index="3"]
+[node name="PerGrooveButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="3"]
 button_group = SubResource("ButtonGroup_t2pju")
 
-[node name="PerBaseTypeButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2" index="4"]
+[node name="PerBaseTypeButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="4"]
 button_pressed = true
 button_group = SubResource("ButtonGroup_t2pju")
 

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
@@ -90,16 +90,16 @@ button_group = SubResource("ButtonGroup_0us75")
 [node name="SugarSameAsBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer3" index="2"]
 button_group = SubResource("ButtonGroup_0us75")
 
-[node name="DontColorizeBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2" index="1"]
+[node name="DontColorizeBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="1"]
 button_group = SubResource("ButtonGroup_iwofu")
 
-[node name="PerStrandBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2" index="2"]
+[node name="PerStrandBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="2"]
 button_group = SubResource("ButtonGroup_iwofu")
 
-[node name="PerGrooveButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2" index="3"]
+[node name="PerGrooveButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="3"]
 button_group = SubResource("ButtonGroup_iwofu")
 
-[node name="PerBaseTypeButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2" index="4"]
+[node name="PerBaseTypeButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="4"]
 button_group = SubResource("ButtonGroup_iwofu")
 
 [node name="AdvancedOptionsButton" type="Button" parent="VBoxContainer" index="6" node_paths=PackedStringArray("panel")]


### PR DESCRIPTION
These warnings are a small regression from https://github.com/MSEP-one/msep.one/pull/659

Task: BUG: Warning prints caused by regression