### PR TITLE
Unify motors parameters

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.gd
@@ -80,8 +80,7 @@ func _on_linear_motor_parameters_changed() -> void:
 	_linear_ramp_out_time.time_span_femtoseconds = TimeSpanPicker.unit_to_femtoseconds(
 			parameters.ramp_out_time_in_nanoseconds, TimeSpanPicker.Unit.NANOSECOND)
 	_linear_ramp_out_time.editable = parameters.cycle_type != NanoVirtualMotorParameters.CycleType.CONTINUOUS
-	var top_speed_in_femtoseconds: float = parameters.top_speed_in_nanometers_by_nanoseconds / 1e+6
-	_linear_top_speed_spin_box.set_value_no_signal(top_speed_in_femtoseconds)
+	_linear_top_speed_spin_box.set_value_no_signal(parameters.top_speed_in_nanometers_by_nanoseconds)
 	_linear_max_force_spin_box.set_value_no_signal(parameters.max_force)
 	_linear_forward_polarity_button.set_pressed_no_signal(parameters.polarity == NanoLinearMotorParameters.Polarity.FORWARD)
 	_linear_backward_polarity_button.set_pressed_no_signal(parameters.polarity == NanoLinearMotorParameters.Polarity.BACKWARDS)
@@ -107,9 +106,8 @@ func _on_linear_ramp_out_time_time_span_changed(in_magnitude: float, in_unit: Ti
 	_take_snapshot_if_configured(tr(&"Ramp-Out Time"))
 
 
-func _on_linear_top_speed_spin_box_value_confirmed(in_top_speed_in_femtoseconds: float) -> void:
-	var top_speed_in_nanoseconds: float = in_top_speed_in_femtoseconds * 1e+6
-	_get_linear_parameters().top_speed_in_nanometers_by_nanoseconds = top_speed_in_nanoseconds
+func _on_linear_top_speed_spin_box_value_confirmed(in_top_speed_in_nanoseconds: float) -> void:
+	_get_linear_parameters().top_speed_in_nanometers_by_nanoseconds = in_top_speed_in_nanoseconds
 	_take_snapshot_if_configured(tr(&"Top Speed"))
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/linear_motor_parameters_editor.tscn
@@ -37,7 +37,7 @@ vertical_alignment = 1
 [node name="LinearRampInTime" parent="." instance=ExtResource("1_pb8n6")]
 unique_name_in_owner = true
 layout_mode = 2
-time_span_femtoseconds = 150.0
+time_span_femtoseconds = 75.0
 min_value_in_femtoseconds = 0.0
 
 [node name="Label2" type="Label" parent="."]
@@ -50,7 +50,7 @@ vertical_alignment = 1
 [node name="LinearRampOutTime" parent="." instance=ExtResource("1_pb8n6")]
 unique_name_in_owner = true
 layout_mode = 2
-time_span_femtoseconds = 150.0
+time_span_femtoseconds = 75.0
 min_value_in_femtoseconds = 0.0
 
 [node name="Label3" type="Label" parent="."]
@@ -63,10 +63,11 @@ vertical_alignment = 1
 [node name="LinearTopSpeedSpinBox" parent="." instance=ExtResource("2_crlk1")]
 unique_name_in_owner = true
 layout_mode = 2
+max_value = 5000.0
 step = 0.0
-value = 0.4
+value = 1000.0
 allow_greater = true
-suffix = "nm / fs"
+suffix = "nm / ns"
 custom_arrow_step = 0.001
 
 [node name="LimitForceLabel" type="Label" parent="."]

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/motor_parameters_editors/rotary_motor_parameters_editor.tscn
@@ -37,7 +37,7 @@ vertical_alignment = 1
 [node name="RotaryRampInTime" parent="." instance=ExtResource("1_ldadn")]
 unique_name_in_owner = true
 layout_mode = 2
-time_span_femtoseconds = 150.0
+time_span_femtoseconds = 75.0
 min_value_in_femtoseconds = 0.0
 
 [node name="Label2" type="Label" parent="."]
@@ -50,7 +50,7 @@ vertical_alignment = 1
 [node name="RotaryRampOutTime" parent="." instance=ExtResource("1_ldadn")]
 unique_name_in_owner = true
 layout_mode = 2
-time_span_femtoseconds = 150.0
+time_span_femtoseconds = 75.0
 min_value_in_femtoseconds = 0.0
 
 [node name="Label3" type="Label" parent="."]

--- a/godot_project/project_workspace/structs/nano_linear_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_linear_motor_parameters.gd
@@ -26,7 +26,7 @@ func _on_self_changed() -> void:
 func get_tooltip_text() -> String:
 	var tooltip: String = ""
 	var polarity_name: StringName = NanoLinearMotorParameters.Polarity.find_key(polarity)
-	tooltip += tr("Top Speed: %.1f nm/fs\n") % (top_speed_in_nanometers_by_nanoseconds / 1000000.0)
+	tooltip += tr("Top Speed: %.1f nm/ns\n") % (top_speed_in_nanometers_by_nanoseconds)
 	tooltip += tr(polarity_name.capitalize()) + "\n"
 	var with_cycle: bool = cycle_type != NanoLinearMotorParameters.CycleType.CONTINUOUS
 	if with_cycle and cycle_swap_polarity:

--- a/godot_project/project_workspace/structs/nano_virtual_motor_parameters.gd
+++ b/godot_project/project_workspace/structs/nano_virtual_motor_parameters.gd
@@ -16,9 +16,9 @@ enum CycleType { ## How cycle works
 
 var motor_type: Type = Type.UNKNOWN:
 	get = _get_motor_type
-@export var ramp_in_time_in_nanoseconds: float = TimeSpanPicker.femtoseconds_to_unit(150, TimeSpanPicker.Unit.NANOSECOND):
+@export var ramp_in_time_in_nanoseconds: float = TimeSpanPicker.femtoseconds_to_unit(75, TimeSpanPicker.Unit.NANOSECOND):
 	set = _set_ramp_in_time_in_nanoseconds
-@export var ramp_out_time_in_nanoseconds: float = TimeSpanPicker.femtoseconds_to_unit(150, TimeSpanPicker.Unit.NANOSECOND):
+@export var ramp_out_time_in_nanoseconds: float = TimeSpanPicker.femtoseconds_to_unit(75, TimeSpanPicker.Unit.NANOSECOND):
 	set = _set_ramp_out_time_in_nanoseconds
 @export_group("Cycle", "cycle_")
 ## Reffer to 

--- a/godot_project/project_workspace/workspace_context/create_object_parameters.tres
+++ b/godot_project/project_workspace/workspace_context/create_object_parameters.tres
@@ -27,11 +27,11 @@ cycle_swap_polarity = false
 cycle_eventually_stops = false
 cycle_stop_after_n_cycles = 0
 limit_maximum_force = true
-max_force = 1e+06
+max_force = 1000.0
 
 [sub_resource type="Resource" id="Resource_6rxql"]
 script = ExtResource("2_plga1")
-top_revolutions_per_nanosecond = 30.0
+top_revolutions_per_nanosecond = 120.0
 is_jerk_limited = false
 jerk_limit = 50.0
 polarity = 0
@@ -45,7 +45,7 @@ cycle_swap_polarity = false
 cycle_eventually_stops = false
 cycle_stop_after_n_cycles = 0
 limit_maximum_force = true
-max_force = 1e+06
+max_force = 1000.0
 
 [sub_resource type="CylinderMesh" id="CylinderMesh_ou6fn"]
 height = 1.0


### PR DESCRIPTION
Cards:
Change Default Motor Speeds
BUG - Motor Speed Representations don't match between linear and rotary motors

---

+ Both motors uses now use nanoseconds as the base time scale (instead of ns and fs)
+ Default top speed for the linear motor is still the same (0.001 nm/fs = 1000 nm/ns)
+ Default rotary speed was increased to 120 rev/ns
+ Default ramp up / down time was decreased to 75 fs
+ Default maximum force is set to 1000 kJ/mol
   - 1000 is low enough so nothing should explode, but still high enough to keep the gears assembly working.