### PR TITLE
Copy/Cut will now still work when DNA is partially selected (will copy/cut the rest of selected objects)

### DIFF
--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -16,12 +16,6 @@ enum ClipboardContentType {
 
 
 func copy(in_workspace_context: WorkspaceContext) -> void:
-	for context: StructureContext in in_workspace_context.get_structure_contexts_with_selection():
-		if context.nano_structure is DnaStructure \
-				and not context.is_dna_structure_fully_selected():
-			in_workspace_context.workspace_main_view.editor_viewport_container.show_warning_in_message_bar(
-				tr(&"Cannot copy DNA spline control points"))
-			return
 	var selection_result: Array[Dictionary] = _get_selected_structure_and_atoms(in_workspace_context)
 	if selection_result.is_empty():
 		return
@@ -56,7 +50,8 @@ func copy(in_workspace_context: WorkspaceContext) -> void:
 			&"ParticleEmitter":
 				_copy_particle_emitter(structure_context, nano_structure, new_content)
 			&"DnaStructure":
-				_copy_dna_structure(structure_context, nano_structure, new_content)
+				if structure_context.is_dna_structure_fully_selected():
+					_copy_dna_structure(structure_context, nano_structure, new_content)
 			_:
 				push_warning("Nano structure type not implemented for copy")
 	var root_group_id: int = -1
@@ -282,15 +277,9 @@ func _copy_dna_structure(in_structure_context: StructureContext,
 
 
 func cut(out_workspace_context: WorkspaceContext) -> void:
-	for context: StructureContext in out_workspace_context.get_structure_contexts_with_selection():
-		if context.nano_structure is DnaStructure \
-				and not context.is_dna_structure_fully_selected():
-			out_workspace_context.workspace_main_view.editor_viewport_container.show_warning_in_message_bar(
-				tr(&"Cannot cut DNA spline control points"))
-			return
 	copy(out_workspace_context)
 	if out_workspace_context.has_selection():
-		out_workspace_context.action_delete.execute()
+		out_workspace_context.action_delete.execute_from_cut_command()
 
 
 func has_content() -> bool:

--- a/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
+++ b/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
@@ -29,7 +29,11 @@ func can_delete() -> bool:
 	return not selected_structures_contexts.is_empty()
 
 
-func _execute_action() -> void:
+func execute_from_cut_command() -> void:
+	_execute_action(true)
+
+
+func _execute_action(in_from_cut_command: bool = false) -> void:
 	var was_ring_menu_active: bool = _ring_menu.is_active()
 	_ring_menu.close()
 	var selected_structures_contexts: Array[StructureContext] = \
@@ -48,7 +52,7 @@ func _execute_action() -> void:
 				return
 	var deleted_structures_contexts: Array[StructureContext] = []
 	for context in selected_structures_contexts:
-		_delete_selection_of_structure(context, deleted_structures_contexts)
+		_delete_selection_of_structure(context, deleted_structures_contexts, in_from_cut_command)
 	if _did_create_undo_action:
 		if !was_ring_menu_active:
 			# When ring menu was open we avoid playing a Sfx, because "close menu"
@@ -57,11 +61,11 @@ func _execute_action() -> void:
 		_workspace_context.snapshot_moment("Delete Selection")
 
 
-func _delete_selection_of_structure(out_context: StructureContext, out_already_deleted_contexts: Array[StructureContext]) -> void:
-	if _can_delete_objects(out_context):
+func _delete_selection_of_structure(out_context: StructureContext, out_already_deleted_contexts: Array[StructureContext], in_from_cut_command: bool) -> void:
+	if _can_delete_objects(out_context, in_from_cut_command):
 		_action_delete_objects(out_context, out_already_deleted_contexts)
 		return
-	if _can_delete_dna_control_points(out_context):
+	if _can_delete_dna_control_points(out_context, in_from_cut_command):
 		_action_delete_dna_control_points(out_context)
 	if _can_delete_atoms_bonds_or_springs(out_context):
 		_action_delete_atoms_bonds_springs(out_context)
@@ -162,7 +166,9 @@ func _can_delete_atoms_bonds_or_springs(in_context: StructureContext) -> bool:
 	return false
 
 
-func _can_delete_dna_control_points(out_context: StructureContext) -> bool:
+func _can_delete_dna_control_points(out_context: StructureContext, in_from_cut_command: bool) -> bool:
+	if in_from_cut_command:
+		return false
 	return  out_context.nano_structure is DnaStructure \
 			and out_context.get_selected_dna_spline_countrol_points().size() > 0
 
@@ -233,7 +239,7 @@ func _do_remove_atoms_bonds_springs(out_context: StructureContext, in_atoms: Pac
 	out_context.nano_structure.end_edit()
 
 
-func _can_delete_objects(in_context: StructureContext) -> bool:
+func _can_delete_objects(in_context: StructureContext, in_from_cut_command: bool) -> bool:
 	if in_context.is_queued_for_deletion():
 		return false
 	
@@ -254,16 +260,19 @@ func _can_delete_objects(in_context: StructureContext) -> bool:
 	var dna_spline_selected: bool = true \
 			if not in_context.nano_structure is DnaStructure else in_context.is_dna_structure_fully_selected()
 	
-	# EXCEPTION: DnaStructure gets deleted if all but 1 control point are selected
-	if in_context.nano_structure is DnaStructure \
-			and in_context.get_selected_dna_spline_countrol_points().size() >= in_context.nano_structure.get_control_point_count() - 1:
-		dna_spline_selected = true
+	if in_context.nano_structure is DnaStructure:
+		if in_from_cut_command:
+			# Cannot cut individual control points, can only cut the entire structure
+			pass # already: dna_spline_selected == in_context.is_dna_structure_fully_selected()
+		elif in_context.get_selected_dna_spline_countrol_points().size() >= in_context.nano_structure.get_control_point_count() - 1:
+			# EXCEPTION: DnaStructure gets deleted if all but 1 control point are selected
+			dna_spline_selected = true
 	
 	var child_structures: Array[NanoStructure] = \
 			in_context.workspace_context.workspace.get_child_structures(in_context.nano_structure)
 	for child: NanoStructure in child_structures:
 		var child_context: StructureContext = in_context.workspace_context.get_nano_structure_context(child)
-		if not _can_delete_objects(child_context):
+		if not _can_delete_objects(child_context, in_from_cut_command):
 			return false
 	
 	if all_atoms_selected and shape_selected and motor_selected and anchor_selected and emitter_selected and dna_spline_selected:


### PR DESCRIPTION

Task: UX: Coping objects when one or more (but not all) control points of a DNA object doesn't work