### PR TITLE
Prevent sending shortcut inputs to viewport when a control of the side panel is focused

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
+++ b/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
@@ -305,6 +305,9 @@ func _unhandled_input(event: InputEvent) -> void:
 		return
 	if !is_visible_in_tree():
 		return
+	if event is InputEventKey and get_viewport().gui_get_focus_owner() != null:
+		# Ignore all input when some control has input control
+		return
 	if InitialInfoScreen.was_closed:
 		editor_viewport.forward_viewport_input(event)
 


### PR DESCRIPTION
Task: BUG - Infinte Scroll pressing Option-E