### PR TITLE
Change icons to have more contrast in Academic View theme

### DIFF
--- a/godot_project/editor/controls/dock_area/icons/arrow_left.svg
+++ b/godot_project/editor/controls/dock_area/icons/arrow_left.svg
@@ -1,7 +1,50 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Svg Vector Icons : http://www.onlinewebfonts.com/icon -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1000 1000" enable-background="new 0 0 1000 1000" xml:space="preserve">
-<metadata> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
-<g><path fill="white" d="M500,10C229.4,10,10,229.4,10,500c0,270.6,219.4,490,490,490c270.6,0,490-219.4,490-490C990,229.4,770.6,10,500,10z M816.1,591.3H486.2v98L158.3,500l327.8-189.3v98h329.9V591.3z"/></g>
+
+<svg
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   enable-background="new 0 0 1000 1000"
+   xml:space="preserve"
+   id="svg2057"
+   sodipodi:docname="arrow_left.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs2061" /><sodipodi:namedview
+   id="namedview2059"
+   pagecolor="#505050"
+   bordercolor="#eeeeee"
+   borderopacity="1"
+   inkscape:showpageshadow="0"
+   inkscape:pageopacity="0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#505050"
+   showgrid="false"
+   inkscape:zoom="0.829"
+   inkscape:cx="640.53076"
+   inkscape:cy="513.87214"
+   inkscape:window-width="1920"
+   inkscape:window-height="1009"
+   inkscape:window-x="1912"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg2057" />
+<metadata
+   id="metadata2051"> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
+<circle
+   style="opacity:1;fill:#000000;fill-opacity:1;stroke-width:39.2"
+   id="path2180"
+   cx="500"
+   cy="500"
+   r="490" /><g
+   id="g2055"
+   transform="matrix(0.89795918,0,0,0.89795918,51.02041,51.02041)"><path
+     fill="#ffffff"
+     d="M 500,10 C 229.4,10 10,229.4 10,500 10,770.6 229.4,990 500,990 770.6,990 990,770.6 990,500 990,229.4 770.6,10 500,10 Z M 816.1,591.3 H 486.2 v 98 L 158.3,500 486.1,310.7 v 98 H 816 v 182.6 z"
+     id="path2053" /></g>
 </svg>

--- a/godot_project/editor/controls/dock_area/icons/arrow_right.svg
+++ b/godot_project/editor/controls/dock_area/icons/arrow_right.svg
@@ -1,7 +1,50 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Svg Vector Icons : http://www.onlinewebfonts.com/icon -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1000 1000" enable-background="new 0 0 1000 1000" xml:space="preserve">
-<metadata> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
-<g><path fill="white" d="M500,990c270.6,0,490-219.4,490-490c0-270.7-219.4-490-490-490C229.4,10,10,229.3,10,500C10,770.6,229.4,990,500,990z M171.1,425.4c0-9.2,7.5-16.8,16.8-16.8h296.4c9.2,0,16.8-7.5,16.8-16.8v-64.5c0-9.2,6.5-13,14.5-8.4l298.8,172.6c8,4.6,8,12.2,0,16.8L515.5,681c-8,4.6-14.5,0.8-14.5-8.4v-64.5c0-9.2-7.5-16.8-16.8-16.8H187.9c-9.2,0-16.8-7.5-16.8-16.8V425.4z"/></g>
+
+<svg
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   enable-background="new 0 0 1000 1000"
+   xml:space="preserve"
+   id="svg8"
+   sodipodi:docname="arrow_right.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs12" /><sodipodi:namedview
+   id="namedview10"
+   pagecolor="#505050"
+   bordercolor="#eeeeee"
+   borderopacity="1"
+   inkscape:showpageshadow="0"
+   inkscape:pageopacity="0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#505050"
+   showgrid="false"
+   inkscape:zoom="0.829"
+   inkscape:cx="499.39686"
+   inkscape:cy="500.60314"
+   inkscape:window-width="1920"
+   inkscape:window-height="1009"
+   inkscape:window-x="1912"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg8" />
+<metadata
+   id="metadata2"> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
+<circle
+   style="opacity:1;fill:#000000;stroke-width:39.2"
+   id="path347"
+   cx="500"
+   cy="500"
+   r="490" /><g
+   id="g6"
+   transform="matrix(0.89795918,0,0,0.89795918,51.02041,51.02041)"><path
+     fill="#ffffff"
+     d="M 500,990 C 770.6,990 990,770.6 990,500 990,229.3 770.6,10 500,10 229.4,10 10,229.3 10,500 10,770.6 229.4,990 500,990 Z M 171.1,425.4 c 0,-9.2 7.5,-16.8 16.8,-16.8 h 296.4 c 9.2,0 16.8,-7.5 16.8,-16.8 v -64.5 c 0,-9.2 6.5,-13 14.5,-8.4 l 298.8,172.6 c 8,4.6 8,12.2 0,16.8 L 515.5,681 c -8,4.6 -14.5,0.8 -14.5,-8.4 v -64.5 c 0,-9.2 -7.5,-16.8 -16.8,-16.8 H 187.9 c -9.2,0 -16.8,-7.5 -16.8,-16.8 z"
+     id="path4" /></g>
 </svg>


### PR DESCRIPTION
Task: BUG - White arrow in UI disappears in Academic mode.

<img width="295" height="121" alt="image" src="https://github.com/user-attachments/assets/7ba7e587-307b-43a9-990e-93914a22436c" />