### PR TITLE
Auto adjust DNA control points when the sequence is edited

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.gd
@@ -201,6 +201,7 @@ func _sequence_length_spin_box_slider_value_confirmed(in_value: int) -> void:
 	_tracked_structure.start_edit()
 	_tracked_structure.set_sequence_length(in_value)
 	_tracked_structure.end_edit()
+	WorkspaceUtils.focus_camera_on_aabb(_workspace_context, _tracked_structure.get_aabb())
 	_workspace_context.snapshot_moment("Set Dna Sequence Length")
 
 
@@ -219,6 +220,7 @@ func _on_dna_sequence_text_edit_text_changed() -> void:
 		_dna_sequence_text_edit.set_caret_line(caret_line)
 		_dna_sequence_text_edit.set_caret_column(caret_pos)
 		_dna_sequence_text_edit.set_block_signals(false)
+	WorkspaceUtils.focus_camera_on_aabb(_workspace_context, _tracked_structure.get_aabb())
 	_workspace_context.snapshot_moment("Set Dna Sequence")
 
 
@@ -334,7 +336,6 @@ func _on_minor_groove_color_changed(in_color: Color) -> void:
 	_tracked_structure.set_minor_groove_color(in_color)
 	_tracked_structure.end_edit()
 	_workspace_context.snapshot_moment("Set Minor Groove Color")
-
 
 
 func _on_base_type_color_changed(in_color: Color, in_base: StringName) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_dna_panel.tscn
@@ -90,16 +90,16 @@ button_group = SubResource("ButtonGroup_0us75")
 [node name="SugarSameAsBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer3" index="2"]
 button_group = SubResource("ButtonGroup_0us75")
 
-[node name="DontColorizeBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="1"]
+[node name="DontColorizeBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="0"]
 button_group = SubResource("ButtonGroup_iwofu")
 
-[node name="PerStrandBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="2"]
+[node name="PerStrandBasesButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="1"]
 button_group = SubResource("ButtonGroup_iwofu")
 
-[node name="PerGrooveButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="3"]
+[node name="PerGrooveButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="2"]
 button_group = SubResource("ButtonGroup_iwofu")
 
-[node name="PerBaseTypeButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="4"]
+[node name="PerBaseTypeButton" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/HBoxContainer2/HBoxContainer" index="3"]
 button_group = SubResource("ButtonGroup_iwofu")
 
 [node name="AdvancedOptionsButton" type="Button" parent="VBoxContainer" index="6" node_paths=PackedStringArray("panel")]

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -59,6 +59,7 @@ var _signal_queue_parameters_changed: bool = false
 var _signal_queue_colors_changed: bool = false
 var _baked_path: PackedVector3Array = []
 var _adjust_path_length_queued: bool = false
+var _adjust_path_sequence_changed: bool = false
 var _aabb_cache := AABB()
 
 @export var _springs: Dictionary = {
@@ -752,7 +753,7 @@ func set_sequence(in_sequence: String) -> void:
 	assert(_sequence_policy == SequencePolicy.UserDefined, "Cannot set sequence when is meant to be generated randomly")
 	if _sequence != in_sequence:
 		_sequence = in_sequence
-		_queue_adjust_path_length()
+		_queue_adjust_path_length(true)
 
 
 func get_sequence() -> String:
@@ -789,24 +790,51 @@ func set_sequence_length(in_length: int) -> void:
 		const BASES = ['A', 'T', 'C', 'G']
 		_sequence += BASES[rng.randi() % BASES.size()]
 	_last_rand_sequence_state = rng.state
-	_queue_adjust_path_length()
+	_queue_adjust_path_length(true)
 
 
-func _queue_adjust_path_length() -> void:
+func _queue_adjust_path_length(in_sequence_changed: bool = false) -> void:
 	assert(_is_being_edited)
 	_adjust_path_length_queued = true
+	_adjust_path_sequence_changed = _adjust_path_sequence_changed or in_sequence_changed
 
 
 func _adjust_path_length() -> void:
 	assert(_is_being_edited)
+	var should_extend_path: bool = _adjust_path_sequence_changed
+	_adjust_path_sequence_changed = false 
 	_adjust_path_length_queued = false
+	
 	const MIN_RISE_NANOMETERS: float = 0.1
 	if _parameters.rise_nanometers < MIN_RISE_NANOMETERS:
 		return
-	var expected_length: float = (get_sequence_length() - 1) * _parameters.rise_nanometers
+	
 	const THRESHOLD: float = MIN_RISE_NANOMETERS
-	if _curve.get_baked_length() - THRESHOLD < expected_length:
-		return
+	var expected_length: float = (get_sequence_length() - 1) * _parameters.rise_nanometers
+	var curve_length: float = _curve.get_baked_length() - THRESHOLD
+	if curve_length < expected_length:
+		if should_extend_path:
+			assert(get_control_point_count() >= 2, "DNA Curve doesn't have enough control points")
+			# Find where the last curve point should be
+			var length_diff: float = expected_length - curve_length
+			var last_point: Vector3 = _curve.get_baked_points()[-1]
+			var before_last_point: Vector3 = _curve.get_baked_points()[-2]
+			var dir: Vector3 = before_last_point.direction_to(last_point)
+			if dir.is_equal_approx(Vector3.ZERO):
+				dir = Vector3.UP
+			var expected_last_position: Vector3 = last_point + dir * length_diff
+			
+			# Move the curve's last point to the target position if the curve is straight
+			# or add a new point if it's curved.
+			# (Path is straight if the out direction of the second to last control point
+			# is roughly aligned with the last curve normal)
+			var before_last_out: Vector3 = _curve.get_point_out(get_control_point_count() - 2).normalized()
+			if before_last_out.dot(dir) > 0.8:
+				set_control_point_position(get_control_point_count() - 1, expected_last_position)
+			else: 
+				insert_control_point(expected_last_position)
+		else:
+			return
 	
 	if get_control_point_count() > 2:
 		var should_drop_last: bool = get_path_length_at_control_point(-2) > expected_length
@@ -2004,4 +2032,3 @@ class AtomData:
 		atom.atomic_number = data.atomic_number
 		atom.position = data.position
 		return atom
-


### PR DESCRIPTION
Card: UX: When growing a DNA Object sequence length make a best effort of relocating last control point, or creatig a new one at the end, to have the entire or most of the lenght of the chain inside of the control points

[dna_edit.webm](https://github.com/user-attachments/assets/336e78cd-1a22-4805-a20a-598bffd6aab9)
