### PR TITLE
Prevent moving molecules to another group when connected by atom-to-atom springs linked to an unselected molecule

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.gd
@@ -155,7 +155,7 @@ func _update_apply_button_state() -> void:
 			(_check_box_add_to_existing.button_pressed or not new_group_name_is_empty)
 	_button_set_structure.disabled = not can_apply
 	
-	var default_message: String = tr(&"When adding a molecule to a group, make sure it is entirely selected.")
+	var default_message: String = tr(&"When grouping a molecule, or group of molecules connected with springs; make sure it is entirely selected.")
 	var notice_message: String
 	if can_apply:
 		notice_message = default_message
@@ -179,7 +179,7 @@ func _get_active_group_picker() -> NanoGroupPicker:
 func _on_label_select_only_notice_meta_clicked(meta: Variant) -> void:
 	match meta:
 		"select_linked":
-			WorkspaceUtils.select_connected(_workspace_context, true)
+			WorkspaceUtils.select_connected(_workspace_context, true, true)
 		_:
 			assert(false, "Unknown meta! %s" % str(meta))
 			return

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.tscn
@@ -80,8 +80,9 @@ can_select_current = false
 unique_name_in_owner = true
 self_modulate = Color(1, 1, 1, 0.2)
 layout_mode = 2
-text = "[center][shake start=4 length=14 freq=0.5 sat=0.8 val=0.8 connected=1]ℹ When adding a molecule to a group, make sure it is entirely selected.[/shake][/center]"
-message = &"When adding a molecule to a group, make sure it is entirely selected."
+text = "[center]ℹ When grouping a molecule, or group of molecules connected with springs; make sure it is entirely selected.[/center]"
+message = &"When grouping a molecule, or group of molecules connected with springs; make sure it is entirely selected."
+effect = "none"
 effect_affects_message = true
 
 [node name="MarginContainer" type="MarginContainer" parent="."]

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/atom_selection/atom_selection.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/atom_selection/atom_selection.gd
@@ -174,10 +174,12 @@ func select_by_type(in_types: PackedInt32Array) -> AtomSelectionResult:
 	return select_atoms_and_get_auto_selected_bonds(atoms_to_select)
 
 
-func select_connected(in_show_hidden_objects: bool = false) -> AtomSelectionResult:
+func select_connected(in_show_hidden_objects: bool = false, in_linked_by_springs: bool = false) -> AtomSelectionResult:
 	var related_structure: AtomicStructure = _structure_context.nano_structure as AtomicStructure
 	var atoms_to_select: Dictionary = {}
 	var bonds_to_visit: Dictionary = _bonds_partially_influenced_by_atoms.duplicate()
+	if in_linked_by_springs:
+		_select_connected_by_springs(atoms_to_select, bonds_to_visit)
 	bonds_to_visit.merge(_bonds_selection)
 	var all_bonds_visited: bool = false
 	var hidden_atoms_to_show: PackedInt32Array = PackedInt32Array()
@@ -225,6 +227,21 @@ func select_connected(in_show_hidden_objects: bool = false) -> AtomSelectionResu
 	clear_selection_layers()
 	return select_atoms_and_get_auto_selected_bonds(atoms_list)
 
+
+func _select_connected_by_springs(out_atoms_to_select: Dictionary, out_bonds_to_visit: Dictionary) -> void:
+	var related_structure: AtomicStructure = _structure_context.nano_structure as AtomicStructure
+	for atom_id: int in _atoms_selection.keys():
+		for spring_id: int in related_structure.atom_get_springs(atom_id):
+			if not related_structure.spring_is_atom_to_atom(spring_id):
+				continue
+			var other_atom: int = related_structure.spring_get_second_atom_id(spring_id)
+			if other_atom == atom_id:
+				other_atom = related_structure.spring_get_atom_id(spring_id)
+			if other_atom in _atoms_selection:
+				continue
+			out_atoms_to_select[other_atom] = true
+			for bond_id: int in related_structure.atom_get_bonds(other_atom):
+				out_bonds_to_visit[bond_id] = true
 
 func can_grow_selection() -> bool:
 	if _bonds_partially_influenced_by_atoms.size() + _non_selected_bonds_fully_influenced_by_atoms.size() > 0:

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
@@ -195,10 +195,10 @@ func select_by_type(types_to_select: PackedInt32Array) -> void:
 	_process_atom_selection_result(result)
 
 
-func select_connected(in_show_hidden_objects: bool) -> AtomSelection.AtomSelectionResult:
+func select_connected(in_show_hidden_objects: bool, in_linked_by_springs: bool) -> AtomSelection.AtomSelectionResult:
 	var nano_structure: NanoStructure = _structure_context.nano_structure
 	assert(!nano_structure.is_being_edited(), "Setting the selection while structure is changing is insecure and should be avoided")
-	var result: AtomSelection.AtomSelectionResult = _atom_selection.select_connected(in_show_hidden_objects)
+	var result: AtomSelection.AtomSelectionResult = _atom_selection.select_connected(in_show_hidden_objects, in_linked_by_springs)
 	_process_atom_selection_result(result)
 	return result
 

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -352,8 +352,8 @@ func select_by_type(types_to_select: PackedInt32Array) -> void:
 	return _selection_db.select_by_type(types_to_select)
 
 
-func select_connected(in_show_hidden_objects: bool = false) -> AtomSelection.AtomSelectionResult: 
-	return _selection_db.select_connected(in_show_hidden_objects)
+func select_connected(in_show_hidden_objects: bool = false, in_linked_by_springs: bool = false) -> AtomSelection.AtomSelectionResult: 
+	return _selection_db.select_connected(in_show_hidden_objects, in_linked_by_springs)
 
 
 func find_atoms_and_bonds_connected_to(in_atom_id: int) -> Dictionary[StringName, PackedInt32Array]:

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -20,8 +20,8 @@ static func select_by_type(out_workspace_context: WorkspaceContext, types: Packe
 	_select_by_type(out_workspace_context, types)
 
 
-static func select_connected(out_workspace_context: WorkspaceContext, in_show_hidden_objects: bool = false) -> void:
-	_select_connected(out_workspace_context, in_show_hidden_objects)
+static func select_connected(out_workspace_context: WorkspaceContext, in_show_hidden_objects: bool = false, in_linked_by_springs: bool = false) -> void:
+	_select_connected(out_workspace_context, in_show_hidden_objects, in_linked_by_springs)
 
 
 static func grow_selection(out_workspace_context: WorkspaceContext) -> void:
@@ -545,11 +545,14 @@ static func _select_by_type(out_workspace_context: WorkspaceContext, types: Pack
 	out_workspace_context.snapshot_moment("Select Atoms by Type")
 
 
-static func _select_connected(out_workspace_context: WorkspaceContext, in_show_hidden_objects: bool) -> void:
+static func _select_connected(
+		out_workspace_context: WorkspaceContext,
+		in_show_hidden_objects: bool,
+		in_linked_by_springs: bool) -> void:
 	var all_structures: Array[StructureContext] = out_workspace_context.get_structure_contexts_with_selection()
 	var selection_changed: bool = false
 	for struct_context in all_structures:
-		var result: AtomSelection.AtomSelectionResult = struct_context.select_connected(in_show_hidden_objects)
+		var result: AtomSelection.AtomSelectionResult = struct_context.select_connected(in_show_hidden_objects, in_linked_by_springs)
 		selection_changed = selection_changed or result.selection_changed
 	if selection_changed:
 		out_workspace_context.snapshot_moment("Select Connected Atoms")
@@ -1344,20 +1347,32 @@ static func _can_move_selection_to_another_group(in_workspace_context: Workspace
 			in_workspace_context.get_structure_contexts_with_selection()
 	if selected_structures.is_empty():
 		return false
+	var has_selection: bool = false
 	for context in selected_structures:
-		var structure: NanoStructure = context.nano_structure
+		if not context.nano_structure is AtomicStructure:
+			has_selection = true
+			continue
+		var structure: AtomicStructure = context.nano_structure as AtomicStructure
 		var selected_atoms: PackedInt32Array = context.get_selected_atoms()
 		var selected_bonds: PackedInt32Array = context.get_selected_bonds()
+		has_selection = has_selection or not selected_atoms.is_empty()
 		# 1. Check if all bonds connected to selected atoms are also selected
 		for atom_id in selected_atoms:
 			var atom_bonds: PackedInt32Array = structure.atom_get_bonds(atom_id)
-			if atom_bonds.is_empty():
-				# Atom is unbound, We allow it
-				continue
 			for atom_bond_id in atom_bonds:
 				if not atom_bond_id in selected_bonds:
 					# At least one bond is not selected
 					# This means molecule is not fully selected
+					return false
+			var atom_springs: PackedInt32Array = structure.atom_get_springs(atom_id)
+			for spring_id in atom_springs:
+				if not structure.spring_is_atom_to_atom(spring_id):
+					continue
+				var other_atom_id: int = structure.spring_get_second_atom_id(spring_id)
+				if other_atom_id == atom_id:
+					# Other atom is actually the first atom
+					other_atom_id = structure.spring_get_atom_id(spring_id)
+				if not other_atom_id in selected_atoms:
 					return false
 		# 2. Check if all atoms connected to selected bonds are also selected
 		for bond_id in selected_bonds:
@@ -1366,7 +1381,7 @@ static func _can_move_selection_to_another_group(in_workspace_context: Workspace
 				# At least one atom is not selected
 				# This means molecule is not fully selected
 				return false
-	return true
+	return has_selection
 
 
 static func _can_create_particle_emitter_from_selection(in_workspace_context: WorkspaceContext) -> bool:


### PR DESCRIPTION
Task: CRASH: Moving an atom to another group, when it has an atom-to-atom spring to an unselected atom