### PR TITLE
Add some filters to AutoCreateSprings panel to avoid creating springs that are unlikely to be desired

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd
@@ -3,14 +3,16 @@ extends DynamicContextControl
 var _atom_to_anchor_button: Button
 var _atom_to_atom_button: Button
 var _max_spring_length_slider: SpinBoxSlider
+var _ignore_hydrogens_check_button: CheckButton
+var _no_springs_within_same_molecule_check_button: CheckButton
 var _no_selection_label: InfoLabel
 var _auto_create_springs_button: Button
-
 
 
 var _workspace_context: WorkspaceContext
 
 var _has_atom_selection: bool
+var _has_atom_selection_ignoring_hydrogens: bool
 var _has_anchor_selection: bool
 
 
@@ -19,12 +21,15 @@ func _notification(what: int) -> void:
 		_atom_to_anchor_button = %AtomToAnchorButton as Button
 		_atom_to_atom_button = %AtomToAtomButton as Button
 		_max_spring_length_slider = %MaxSpringLengthSlider as SpinBoxSlider
+		_ignore_hydrogens_check_button = %IgnoreHydrogensCheckButton as CheckButton
+		_no_springs_within_same_molecule_check_button = %NoSpringsWithinSameMoleculeCheckButton as CheckButton
 		_no_selection_label = %NoSelectionLabel as InfoLabel
 		_auto_create_springs_button = %AutoCreateSpringsButton as Button
 
 
 func _ready() -> void:
 	_atom_to_anchor_button.button_group.pressed.connect(_on_spring_type_button_group_pressed.unbind(1))
+	_ignore_hydrogens_check_button.toggled.connect(_on_ignore_hydrogens_check_button_toggled.unbind(1))
 	_auto_create_springs_button.pressed.connect(_on_auto_create_springs_button_pressed)
 
 
@@ -44,17 +49,25 @@ func _ensure_workspace_initialized(in_workspace_context: WorkspaceContext) -> vo
 	if _workspace_context == in_workspace_context:
 		return
 	_workspace_context = in_workspace_context
-	_workspace_context.selection_in_structures_changed.connect(_on_workspace_selection_changed.unbind(1))
+	_workspace_context.history_changed.connect(_on_workspace_context_history_changed)
 	_update_selection_info_label()
 
-func _on_workspace_selection_changed() -> void:
+
+func _on_workspace_context_history_changed() -> void:
 	_has_atom_selection = false
+	_has_atom_selection_ignoring_hydrogens = false
 	_has_anchor_selection = false
 	for ctx: StructureContext in _workspace_context.get_structure_contexts_with_selection():
+		var selected_atoms: PackedInt32Array = ctx.get_selected_atoms()
 		if ctx.nano_structure is NanoVirtualAnchor:
 			_has_anchor_selection = true
-		elif ctx.get_selected_atoms().size() > 0:
+		elif selected_atoms.size() > 0:
 			_has_atom_selection = true
+			_remove_hydrogens(ctx, selected_atoms)
+			if selected_atoms.size() > 0:
+				_has_atom_selection_ignoring_hydrogens = true
+		if _has_anchor_selection and _has_atom_selection_ignoring_hydrogens:
+			break
 	_update_selection_info_label()
 
 
@@ -62,9 +75,16 @@ func _on_spring_type_button_group_pressed() -> void:
 	_update_selection_info_label()
 
 
+func _on_ignore_hydrogens_check_button_toggled() -> void:
+	_update_selection_info_label()
+
+
 func _update_selection_info_label() -> void:
+	var has_selection: bool = _has_atom_selection
+	if _ignore_hydrogens_check_button.button_pressed == true:
+		has_selection = _has_atom_selection_ignoring_hydrogens
 	if _atom_to_anchor_button.button_pressed:
-		match [_has_atom_selection, _has_anchor_selection]:
+		match [has_selection, _has_anchor_selection]:
 			[true, true]:
 				_no_selection_label.hide()
 			[true, false]:
@@ -102,6 +122,8 @@ func _create_atom_to_anchor_springs() -> void:
 		if ctx.nano_structure is NanoVirtualAnchor:
 			anchors.append(ctx)
 		var selected_atoms: PackedInt32Array = ctx.get_selected_atoms()
+		if _ignore_hydrogens_check_button.button_pressed:
+			_remove_hydrogens(ctx, selected_atoms)
 		if selected_atoms.size() > 0:
 			atoms[ctx] = selected_atoms
 	
@@ -147,15 +169,23 @@ func _create_atom_to_atom_springs() -> void:
 		var structure: AtomicStructure = ctx.nano_structure as AtomicStructure
 		var springs_added: PackedInt32Array = []
 		var atom_selection: PackedInt32Array = ctx.get_selected_atoms()
+		if _ignore_hydrogens_check_button.button_pressed:
+			_remove_hydrogens(ctx, atom_selection)
 		if atom_selection.size() <= 1:
 			continue
 		var atom_pos: Dictionary[int, Vector3]
 		for atom_id: int in atom_selection:
 			atom_pos[atom_id] = structure.atom_get_position(atom_id)
+		var out_molecule_map: Dictionary[int, PackedInt32Array] = {
+			# atom_id : atoms_in_molecule(array shared among all atom keys)
+		}
 		for i in atom_selection.size() - 1:
 			for j in range(i + 1, atom_selection.size()):
 				var atom1: int = atom_selection[i]
 				var atom2: int = atom_selection[j]
+				if _no_springs_within_same_molecule_check_button.button_pressed \
+					and _are_atoms_within_same_molecule(atom1, atom2, structure, out_molecule_map):
+						continue
 				if atom_pos[atom1].distance_squared_to(atom_pos[atom2]) > max_distance_sqrd:
 					continue
 				if structure.spring_between_atoms_exists(atom1, atom2):
@@ -178,3 +208,48 @@ func _create_atom_to_atom_springs() -> void:
 			new_spring_count += springs_added.size()
 	if new_spring_count > 0:
 		_workspace_context.snapshot_moment("Create %d Springs" % new_spring_count)
+
+
+func _remove_hydrogens(
+		in_structure_context: StructureContext,
+		out_selected_atoms: PackedInt32Array) -> void:
+	if out_selected_atoms.is_empty():
+		return
+	var structure: AtomicStructure = in_structure_context.nano_structure as AtomicStructure
+	for i in range(out_selected_atoms.size() - 1, -1, -1):
+		if structure.atom_is_hydrogen(out_selected_atoms[i]):
+			out_selected_atoms.remove_at(i)
+
+
+func _are_atoms_within_same_molecule(
+		atom1: int, atom2: int,
+		in_structure: AtomicStructure,
+		out_molecule_map: Dictionary[int, PackedInt32Array]) -> bool:
+	_scan_molecule(atom1, in_structure, out_molecule_map)
+	_scan_molecule(atom2, in_structure, out_molecule_map)
+	if atom2 in out_molecule_map[atom1]:
+		assert(out_molecule_map[atom1] == out_molecule_map[atom2])
+		return true
+	return false
+
+func _scan_molecule(in_atom_id: int,
+		in_structure: AtomicStructure,
+		out_molecule_map: Dictionary[int, PackedInt32Array]) -> void:
+	if in_atom_id in out_molecule_map:
+		# already scanned
+		return
+	var molecule: PackedInt32Array = []
+	var atoms_to_visit: PackedInt32Array = [in_atom_id]
+	var visited_atoms: Dictionary[int, bool] = {}
+	var next_loop: Dictionary[int, bool] = {}
+	while atoms_to_visit.size() > 0:
+		next_loop = {}
+		for atom_id in atoms_to_visit:
+			molecule.append(atom_id)
+			out_molecule_map[atom_id] = molecule
+			visited_atoms[atom_id] = true
+			for bond_id in in_structure.atom_get_bonds(atom_id):
+				var other_atom: int = in_structure.atom_get_bond_target(atom_id, bond_id)
+				if visited_atoms.get(other_atom, false) == false:
+					next_loop[other_atom] = true
+		atoms_to_visit = PackedInt32Array(next_loop.keys())

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://b6vo1tf20ylkp"]
+[gd_scene load_steps=7 format=3 uid="uid://b6vo1tf20ylkp"]
 
 [ext_resource type="Script" uid="uid://bbgedydv4ho3f" path="res://editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd" id="1_k222l"]
 [ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="2_k222l"]
 [ext_resource type="PackedScene" uid="uid://b2b25o2443x3b" path="res://editor/controls/general/info_label.tscn" id="2_yoee2"]
 [ext_resource type="Texture2D" uid="uid://wbe2syrxllv8" path="res://editor/controls/menu_bar/menu_create/menu_atoms/icons/icon_AutoBonder_16px.svg" id="3_3tg0t"]
+[ext_resource type="Script" uid="uid://d2h7xyc1cxxeo" path="res://editor/controls/dockers/workspace_docker/shared_controls/toggle_button_controlled_visibility.gd" id="3_wjjra"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_jgiuk"]
 
@@ -23,7 +24,6 @@ theme_type_variation = &"SubcategoryPanel"
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="PanelContainer"]
 layout_mode = 2
-theme_override_constants/separation = 10
 
 [node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer2"]
 layout_mode = 2
@@ -64,6 +64,28 @@ value = 1.0
 allow_greater = true
 suffix = "nm"
 
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer2"]
+layout_mode = 2
+theme_override_constants/margin_left = -6
+
+[node name="IgnoreHydrogensCheckButton" type="CheckButton" parent="PanelContainer/VBoxContainer2/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+button_pressed = true
+text = "· Ignore Selected Hydrogens"
+
+[node name="MarginContainer2" type="MarginContainer" parent="PanelContainer/VBoxContainer2" node_paths=PackedStringArray("button")]
+layout_mode = 2
+theme_override_constants/margin_left = -6
+script = ExtResource("3_wjjra")
+button = NodePath("../HBoxContainer/AtomToAtomButton")
+
+[node name="NoSpringsWithinSameMoleculeCheckButton" type="CheckButton" parent="PanelContainer/VBoxContainer2/MarginContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+button_pressed = true
+text = "· Don't Create Springs Between Atoms in the Same Molecule"
+
 [node name="InfoLabel" parent="PanelContainer/VBoxContainer2" instance=ExtResource("2_yoee2")]
 layout_mode = 2
 text = "[center]ℹ Springs created with this method always have automatic equilibrium length[/center]"
@@ -74,7 +96,11 @@ effect = "none"
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="AutoCreateSpringsButton" type="Button" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_bottom = 0
+
+[node name="AutoCreateSpringsButton" type="Button" parent="MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/dna_panel.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="3_w42n7"]
 [ext_resource type="Texture2D" uid="uid://b2w2wxk2bb4wg" path="res://editor/controls/category_container/icons/collapsed.svg" id="4_w42n7"]
 [ext_resource type="PackedScene" uid="uid://df6twl5j41stt" path="res://editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/editor_settings/color/advanced_color_picker_button.tscn" id="5_hnbyp"]
+[ext_resource type="Script" uid="uid://d2h7xyc1cxxeo" path="res://editor/controls/dockers/workspace_docker/shared_controls/toggle_button_controlled_visibility.gd" id="5_w3t4b"]
 [ext_resource type="PackedScene" uid="uid://b2b25o2443x3b" path="res://editor/controls/general/info_label.tscn" id="5_w42n7"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_imbu4"]
@@ -41,35 +42,6 @@ func _update_icon() -> void:
 [sub_resource type="ButtonGroup" id="ButtonGroup_8e3dj"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_hnbyp"]
-
-[sub_resource type="GDScript" id="GDScript_6y0sb"]
-script/source = "# This builtin script makes a control change it's visibility based on a toggle button
-extends Control
-
-@export var button: Button
-@export var invert_pressed: bool = false
-
-func _ready() -> void:
-	assert(button != null)
-	assert(button.toggle_mode == true, \"Button is not toggle_mode\")
-	button.toggled.connect(_on_button_toggled)
-	_on_button_toggled(button.button_pressed)
-	const EditDnaPanel: Script = preload(\"uid://cdcgvv0jwwf6c\")
-	if owner is EditDnaPanel:
-		owner.tracked_object_changed.connect(_on_tracked_object_changed)
-
-
-func _on_button_toggled(in_button_pressed: bool) -> void:
-	if invert_pressed:
-		in_button_pressed = not in_button_pressed
-	visible = in_button_pressed
-
-func _on_tracked_object_changed(in_object: DnaStructure) -> void:
-	if in_object == null:
-		return
-	# Update visibility
-	_on_button_toggled(button.button_pressed)
-"
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_6y0sb"]
 
@@ -329,7 +301,7 @@ text = "Per Strand"
 [node name="ColorizeBackboneContainer" type="PanelContainer" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer" node_paths=PackedStringArray("button")]
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
-script = SubResource("GDScript_6y0sb")
+script = ExtResource("5_w3t4b")
 button = NodePath("../HBoxContainer/PerStrandBackboneButton")
 
 [node name="GridContainer" type="HBoxContainer" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/ColorizeBackboneContainer"]
@@ -432,14 +404,14 @@ text = "Per Base Type"
 visible = false
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
-script = SubResource("GDScript_6y0sb")
+script = ExtResource("5_w3t4b")
 button = NodePath("../HBoxContainer2/HBoxContainer/DontColorizeBasesButton")
 invert_pressed = true
 
 [node name="PerStrandContainer" type="HBoxContainer" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/ColorizeBasesContainer" node_paths=PackedStringArray("button")]
 visible = false
 layout_mode = 2
-script = SubResource("GDScript_6y0sb")
+script = ExtResource("5_w3t4b")
 button = NodePath("../../HBoxContainer2/HBoxContainer/PerStrandBasesButton")
 
 [node name="Label" type="Label" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/ColorizeBasesContainer/PerStrandContainer"]
@@ -465,7 +437,7 @@ show_reset_button = false
 [node name="PerGrooveContainer" type="VBoxContainer" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/ColorizeBasesContainer" node_paths=PackedStringArray("button")]
 visible = false
 layout_mode = 2
-script = SubResource("GDScript_6y0sb")
+script = ExtResource("5_w3t4b")
 button = NodePath("../../HBoxContainer2/HBoxContainer/PerGrooveButton")
 
 [node name="InfoLabel" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/ColorizeBasesContainer/PerGrooveContainer" instance=ExtResource("5_w42n7")]
@@ -500,7 +472,7 @@ show_reset_button = false
 [node name="PerBaseTypeContainer" type="VBoxContainer" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/ColorizeBasesContainer" node_paths=PackedStringArray("button")]
 visible = false
 layout_mode = 2
-script = SubResource("GDScript_6y0sb")
+script = ExtResource("5_w3t4b")
 button = NodePath("../../HBoxContainer2/HBoxContainer/PerBaseTypeButton")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/ColorizeMainContainer/VBoxContainer/ColorizeBasesContainer/PerBaseTypeContainer"]

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/toggle_button_controlled_visibility.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/toggle_button_controlled_visibility.gd
@@ -1,0 +1,25 @@
+extends Control
+
+@export var button: Button
+@export var invert_pressed: bool = false
+
+func _ready() -> void:
+	assert(button != null)
+	assert(button.toggle_mode == true, "Button is not toggle_mode")
+	button.toggled.connect(_on_button_toggled)
+	_on_button_toggled(button.button_pressed)
+	const EditDnaPanel: Script = preload("uid://cdcgvv0jwwf6c")
+	if owner is EditDnaPanel:
+		owner.tracked_object_changed.connect(_on_tracked_object_changed)
+
+
+func _on_button_toggled(in_button_pressed: bool) -> void:
+	if invert_pressed:
+		in_button_pressed = not in_button_pressed
+	visible = in_button_pressed
+
+func _on_tracked_object_changed(in_object: DnaStructure) -> void:
+	if in_object == null:
+		return
+	# Update visibility
+	_on_button_toggled(button.button_pressed)

--- a/godot_project/editor/controls/dockers/workspace_docker/shared_controls/toggle_button_controlled_visibility.gd.uid
+++ b/godot_project/editor/controls/dockers/workspace_docker/shared_controls/toggle_button_controlled_visibility.gd.uid
@@ -1,0 +1,1 @@
+uid://d2h7xyc1cxxeo


### PR DESCRIPTION
- By default wont create springs to hydrogens
- (atom-to-atom springs) By default wont create springs linking atoms of the same molecule

Task: UI/UX: Add check buttons to ignore hydrogens when creating springs from selection

https://github.com/user-attachments/assets/e90a75e3-0089-45cc-9963-815f426fe872

