### PR TITLE
MacOS: Fix application not showing potential join atoms when 'Show potential atoms' setting is OFF, but 'Force Show Potential Join Atoms' key modifiers (Option+Command) is pressed

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_posing_atom_input_handler.gd
@@ -528,6 +528,10 @@ func _is_shortcut_pressed() -> bool:
 		Input.is_key_pressed(KEY_ALT) and
 		not Input.is_key_pressed(KEY_SHIFT) and
 		not Input.is_key_pressed(KEY_META)
+	) or (
+		_is_mac and
+		Input.is_key_pressed(KEY_ALT) and
+		not Input.is_key_pressed(KEY_SHIFT)
 	)
 
 


### PR DESCRIPTION
Task: BUG: MACOS: Option+Cmd shortcut to show "join" candidates doesn't work when "show potential atom positions" is disabled