### PR TITLE
Fix isues causing to render bond preview incorrectly

### DIFF
--- a/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_object_drag_drop_input_handler.gd
@@ -330,7 +330,7 @@ func _is_atom_to_atom_drag() -> bool:
 		return false
 	if _drag_start_structure_id == AtomicStructure.INVALID_ATOMIC_NUMBER or _target_atom_id == AtomicStructure.INVALID_ATOMIC_NUMBER:
 		return false
-	return _drag_start_atom_id != _target_atom_id
+	return true
 
 
 func _ensure_creating_springs() -> void:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
@@ -718,8 +718,7 @@ static func calculate_transform_for_bond(in_first_pos: Vector3, in_sec_pos: Vect
 	# capsule stick looks like a sphere when two atoms are at the same place.
 	var length: float = max(0.025, in_first_pos.distance_to(in_sec_pos))
 	var particle_transform: Transform3D = Transform3D(Basis(), particle_position)
-	if particle_transform.origin.distance_squared_to(in_first_pos) > 0.001:
-		particle_transform = particle_transform.looking_at(in_first_pos, in_up_vector)
+	particle_transform = particle_transform.looking_at(in_first_pos, in_up_vector)
 	particle_transform = particle_transform.scaled_local(Vector3(1, 1, length))
 	return particle_transform
 

--- a/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
+++ b/godot_project/editor/rendering/ballstick_bond_preview/ballstick_bond_preview.gd
@@ -61,7 +61,8 @@ func update_all(in_first_pos: Vector3, in_sec_pos: Vector3, in_first_atomic_numb
 
 func update_second_atom_pos(in_sec_pos: Vector3) -> void:
 	_second_pos = in_sec_pos
-	_update_preview()
+	if _preview.visible:
+		_update_preview()
 
 
 func set_order(in_bond_order: int) -> void:
@@ -87,6 +88,10 @@ func _update_preview() -> void:
 	var second_data: ElementData = PeriodicTable.get_by_atomic_number(_second_atomic_number)
 	var camera: Camera3D = get_viewport().get_camera_3d()
 	var dir_between_start_and_end: Vector3 = _first_pos.direction_to(_second_pos)
+	if dir_between_start_and_end.is_zero_approx():
+		# source and target are too close, simply hide it
+		hide()
+		return
 	var up_vector: Vector3 = dir_between_start_and_end.cross(camera.global_transform.basis.y)
 	if up_vector.length_squared() == 0:
 		# When dir_between_start_and_end is the same as camera's Y axis, cross product will be ZERO


### PR DESCRIPTION
- Rendering direction of bond preview when creating short bonds was wrong
- Canceling a drag-from-atom with escape/right-click then trying to create a new bond showed the last bond one frame before showing it properly

Task: BUG: Bond Previews when creating bonded atoms looks wrong when they are too short