### PR TITLE
Prevent accidentally creating an object when using the camera snap widget

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/DrawOrientationWidget.gd
+++ b/godot_project/editor/controls/editor_viewport_container/widgets/orientation_widget/DrawOrientationWidget.gd
@@ -37,8 +37,9 @@ var mouse_drag_in_widget_is_active := false
 var workspace_tools_container : Control = null
 var colliding_axis_index : int = -1
 var snap_rotation: Vector3 = Vector3.ZERO
+var snap_start_rotation: Vector3 = Vector3.ZERO
 var snap_progress: float = .0
-var snap_speed: float = 1.0
+var snap_speed: float = 4.0
 var snap_is_active: bool = false
 var orbit_radius: float = .0
 var orbit_center: Vector3 = Vector3.ZERO
@@ -205,9 +206,10 @@ func _process(_in_delta: float, in_force: bool = false, in_finish: bool = false)
 	modulate.a = widget_alpha
 	
 	if snap_is_active:
+		MolecularEditorContext.get_current_workspace_context().get_rendering().hide_all_previews()
 		if snap_progress < 1.0 - EPSILON || in_finish:
 			snap_progress = min(snap_progress + _in_delta * snap_speed, 1.0)
-			_camera.global_rotation = _camera.global_rotation.lerp(snap_rotation, \
+			_camera.global_rotation = snap_start_rotation.lerp(snap_rotation, \
 					snap_progress)
 			_camera.global_position = orbit_center - \
 			_camera.global_transform.basis.get_rotation_quaternion() * Vector3.FORWARD * \
@@ -260,6 +262,7 @@ func snap_to_rotation(in_rotation : Vector3) -> void:
 		orbit_radius = creation_distance
 	
 	snap_rotation = in_rotation
+	snap_start_rotation = _camera.global_rotation
 	
 	snap_is_active = true
 

--- a/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_atom_input_handler.gd
@@ -111,7 +111,8 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 		# do not add atom on mouse button down, it's to early to determine if user really wants to add atom or for example do a pan gesture
 		var mouse_up: bool = not in_input_event.pressed
 		if in_input_event.button_index == MOUSE_BUTTON_LEFT and mouse_up:
-			
+			var distance_sqrd_to_start: float = _press_down_position.distance_squared_to(in_input_event.global_position)
+			_press_down_position = Vector2(-100, -100)
 			var preview_atomic_number: int = get_workspace_context().create_object_parameters.get_new_atom_element()
 			var cannot_create_because_hydrogen: bool = not out_context.nano_structure.are_hydrogens_visible() \
 					and preview_atomic_number == PeriodicTable.ATOMIC_NUMBER_HYDROGEN
@@ -119,7 +120,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 				return true
 			
 			var has_modifiers: bool = input_has_modifiers(in_input_event)
-			if _press_down_position.distance_squared_to(in_input_event.global_position) > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
+			if distance_sqrd_to_start > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
 				return false
 			var atom_pos: Vector3 = rendering.atom_preview_get_position()
 			if !has_modifiers || (_check_input_event_can_bind(in_input_event) and !_check_context_can_bind(out_context, atom_pos)):

--- a/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
@@ -117,7 +117,9 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 		# wants to add them or for example do a drag gesture
 		var mouse_up: bool = not in_input_event.pressed
 		if in_input_event.button_index == MOUSE_BUTTON_LEFT and mouse_up:
-			if _press_down_position.distance_squared_to(in_input_event.global_position) > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
+			var distance_sqrd_to_start: float = _press_down_position.distance_squared_to(in_input_event.global_position)
+			_press_down_position = Vector2(-100, -100)
+			if distance_sqrd_to_start > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
 				return false
 			# Create an anchor and _candidate_spring_ends springs
 			var has_modifiers: bool = input_has_modifiers(in_input_event)

--- a/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_structure_input_handler.gd
@@ -68,7 +68,9 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, in_structur
 		return false
 		
 	if in_input_event.button_index == MOUSE_BUTTON_LEFT and in_input_event.is_released():
-		if _press_down_position.distance_squared_to(in_input_event.global_position) > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
+		var distance_sqrd_to_start: float = _press_down_position.distance_squared_to(in_input_event.global_position)
+		_press_down_position = Vector2(-100, -100)
+		if distance_sqrd_to_start > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
 			return false
 		_merge_structure(in_structure_context)
 		return true

--- a/godot_project/editor/input_handlers/molecular_structures/create_reference_shape_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_reference_shape_input_handler.gd
@@ -143,6 +143,8 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, in_context:
 		return false
 	if in_input_event is InputEventMouseButton:
 		if in_input_event.button_index == MOUSE_BUTTON_LEFT and !in_input_event.pressed:
+			var distance_sqrd_to_start: float = _press_down_position.distance_squared_to(in_input_event.global_position)
+			_press_down_position = Vector2(-100, -100)
 			if _ghost_shape.get_shape() == null:
 				# Closed the ring menu before selecting an initial shape
 				in_context.workspace_context.abort_creating_object()
@@ -150,7 +152,7 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, in_context:
 			var has_modifiers: bool = input_has_modifiers(in_input_event)
 			if has_modifiers:
 				return false
-			if _press_down_position.distance_squared_to(in_input_event.global_position) > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
+			if distance_sqrd_to_start > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
 				return false
 			assert(in_context.workspace_context.is_creating_object(), "This input handler should never work unless a shape is being created")
 			var selected_structures: Array[StructureContext] = in_context.workspace_context.get_structure_contexts_with_selection()

--- a/godot_project/editor/input_handlers/molecular_structures/create_virtual_motor_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_virtual_motor_input_handler.gd
@@ -104,7 +104,9 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, in_context:
 		return false
 	if in_input_event is InputEventMouseButton:
 		if in_input_event.button_index == MOUSE_BUTTON_LEFT and !in_input_event.pressed:
-			if _press_down_position.distance_squared_to(in_input_event.global_position) > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
+			var distance_sqrd_to_start: float = _press_down_position.distance_squared_to(in_input_event.global_position)
+			_press_down_position = Vector2(-100, -100)
+			if distance_sqrd_to_start > MAX_MOVEMENT_PIXEL_THRESHOLD_TO_DETECT_SELECTION_SQUARED:
 				return false
 			var has_modifiers: bool = input_has_modifiers(in_input_event)
 			if has_modifiers:


### PR DESCRIPTION
- Also made object previews invisible while camera snaps because clicking an axis

Task: BUG: Can accidentally create virtual objects clicking in snap camera direction widget