### PR TITLE
Dont show periodic table preview of selected atom a virtual object is also selected

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/single_atom_preview.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/single_atom_preview.gd
@@ -15,7 +15,7 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	var selected_contexts: Array[StructureContext] =  \
 			in_workspace_context.get_structure_contexts_with_selection()
 	for context in selected_contexts:
-		if context.is_shape_selected() or context.is_motor_selected():
+		if context.nano_structure.is_virtual_object() or context.nano_structure is DnaStructure:
 			return false
 		selected_atoms_count += context.get_selected_atoms().size()
 		if selected_atoms_count > 2 or not context.get_selected_bonds().is_empty():


### PR DESCRIPTION
Task: BUG: Selecting 1 atom along with DNA Object, particle emitter, and/or anchor shows both 3d preview and periodic table element preview