### PR TITLE
Make workspace and side panel tabs not grab focus

### DIFF
--- a/godot_project/editor/MolecularEditor.tscn
+++ b/godot_project/editor/MolecularEditor.tscn
@@ -52,7 +52,6 @@ offset_bottom = 0.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_vertical = 3
-current_tab = 0
 
 [node name="TabBarActiveWorkspaces" parent="MainContainer/WorkArea" instance=ExtResource("4_8puqg")]
 layout_mode = 1

--- a/godot_project/editor/controls/dock_area/docker_tab_container/docker_tab_bar.tscn
+++ b/godot_project/editor/controls/dock_area/docker_tab_container/docker_tab_bar.tscn
@@ -42,8 +42,10 @@ offset_right = 170.0
 grow_vertical = 0
 size_flags_horizontal = 3
 size_flags_vertical = 8
-tab_count = 2
+focus_mode = 0
+current_tab = 0
 clip_tabs = false
+tab_count = 2
 tab_0/title = "Workspace"
 tab_1/title = "Selection"
 

--- a/godot_project/editor/controls/workspace_view/tab_bar_active_workspaces.tscn
+++ b/godot_project/editor/controls/workspace_view/tab_bar_active_workspaces.tscn
@@ -40,6 +40,7 @@ custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
 offset_right = 284.0
 offset_bottom = 40.0
+focus_mode = 0
 theme_type_variation = &"WorkspaceTabBar"
 current_tab = 0
 tab_alignment = 1


### PR DESCRIPTION
- This solves an issue where keyboard shortcuts doesn't work when those controls are focused, which is common while navigating

Task: BUG: WASD key buttons doesn't work after swotching worksapce tabs until mouse clicks the viewport