### PR TITLE
Fix 'Maintain locked atoms in position' treated as always enabled during relaxation

### DIFF
--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -1619,7 +1619,7 @@ static func _do_tween_atom_positions(
 		var structure_atom_pair: Array = in_payload.request_atom_id_to_structure_and_atom_id_map[i]
 		var structure: AtomicStructure = out_workspace_context.workspace.get_structure_by_int_guid(structure_atom_pair[0]) as AtomicStructure
 		var atom_id: int = structure_atom_pair[1]
-		if structure.atom_is_locked(atom_id):
+		if in_payload.lock_atoms and structure.atom_is_locked(atom_id):
 			continue
 		var start_pos: Vector3 = in_payload.raw_initial_positions[i]
 		var end_pos: Vector3 = in_target_positions[i]


### PR DESCRIPTION
Card: BUG - Locked Atoms remain locked during relaxation, even when you tell the app not to do so.