### PR TITLE
Creating springs with shift + clic now respects the 'Ignore hydrogens` toggle

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd
@@ -29,12 +29,13 @@ func _notification(what: int) -> void:
 
 func _ready() -> void:
 	_atom_to_anchor_button.button_group.pressed.connect(_on_spring_type_button_group_pressed.unbind(1))
-	_ignore_hydrogens_check_button.toggled.connect(_on_ignore_hydrogens_check_button_toggled.unbind(1))
+	_ignore_hydrogens_check_button.toggled.connect(_on_ignore_hydrogens_check_button_toggled)
 	_auto_create_springs_button.pressed.connect(_on_auto_create_springs_button_pressed)
 
 
 func should_show(in_workspace_context: WorkspaceContext) -> bool:
 	_ensure_workspace_initialized(in_workspace_context)
+	_ignore_hydrogens_check_button.set_pressed_no_signal(_workspace_context.create_object_parameters.get_spring_ignore_hydrogen())
 	
 	if not in_workspace_context.get_current_structure_context().nano_structure.can_contain_child_structure():
 		return false
@@ -75,7 +76,8 @@ func _on_spring_type_button_group_pressed() -> void:
 	_update_selection_info_label()
 
 
-func _on_ignore_hydrogens_check_button_toggled() -> void:
+func _on_ignore_hydrogens_check_button_toggled(in_pressed: bool) -> void:
+	_workspace_context.create_object_parameters.set_spring_ignore_hydrogens(in_pressed)
 	_update_selection_info_label()
 
 

--- a/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/add_springs_input_handler.gd
@@ -5,6 +5,7 @@ var _render_candidates: bool = false
 var _candidate_spring_ends: PackedVector3Array = []
 var _springs_end_candidates_outdated: bool = false
 var _press_down_position: Vector2 = Vector2(-100, -100)
+var _ignore_hydrogens: bool = false
 
 # region virtual
 ## VIRTUAL: Returns true when the the input handler expects to process inputs
@@ -48,7 +49,6 @@ func handle_inputs_resume() -> void:
 	else:
 		const HIDEN_SPRINGS: PackedVector3Array = []
 		_get_rendering().virtual_anchor_preview_set_spring_ends(HIDEN_SPRINGS)
-		
 
 
 func handle_input_omission() -> void:
@@ -166,12 +166,21 @@ func forward_input(in_input_event: InputEvent, _in_camera: Camera3D, out_context
 
 
 func _update_springs_end_candidates() -> void:
+	var ignore_hydrogens: bool = get_workspace_context().create_object_parameters.get_spring_ignore_hydrogen()
+	if _ignore_hydrogens != ignore_hydrogens:
+		_ignore_hydrogens = ignore_hydrogens
+		_springs_end_candidates_outdated = true
 	if not _springs_end_candidates_outdated:
 		return
 	_candidate_spring_ends = PackedVector3Array()
 	for context: StructureContext in get_workspace_context().get_structure_contexts_with_selection():
+		var structure: AtomicStructure = context.nano_structure as AtomicStructure
+		if not structure:
+			continue
 		for atom_id: int in context.get_selected_atoms():
-			_candidate_spring_ends.push_back(context.nano_structure.atom_get_position(atom_id))
+			if _ignore_hydrogens and structure.atom_is_hydrogen(atom_id):
+				continue
+			_candidate_spring_ends.push_back(structure.atom_get_position(atom_id))
 	_springs_end_candidates_outdated = false
 
 
@@ -181,6 +190,8 @@ func _create_springs_for_atoms(in_nano_struct: AtomicStructure, in_atoms: Packed
 	out_created_springs.clear()
 	in_nano_struct.start_edit()
 	for atom_id: int in in_atoms:
+		if in_params.get_spring_ignore_hydrogen() and in_nano_struct.atom_is_hydrogen(atom_id):
+			continue
 		var spring_id: int = in_nano_struct.spring_create(in_anchor_id, atom_id,
 				in_params.get_spring_constant_force(),
 				in_params.get_spring_equilibrium_length_is_auto(),

--- a/godot_project/project_workspace/workspace_context/create_object_parameters.gd
+++ b/godot_project/project_workspace/workspace_context/create_object_parameters.gd
@@ -16,6 +16,7 @@ signal snap_to_shape_surface_changed(enabled: bool)
 signal spring_constant_force_changed(force: float)
 signal spring_equilibrium_length_is_auto_changed(is_auto: bool)
 signal spring_equilibrium_manual_length_changed(manual_length: float)
+signal spring_ignore_hydrogens_changed(enabled: bool)
 # validate_bonds_requested signal is used as intermediator between relax_tools_panel and validate_bonds_panel
 signal validate_bonds_requested(atom_set: AtomicStructure.AtomSet)
 
@@ -86,6 +87,8 @@ var _spring_constant_force: float = 5000000.0 # nN/nm
 var _spring_equilibrium_length_is_auto: bool = true
 
 var _spring_equilibrium_manual_length: float
+
+var _spring_ignore_hydrogens: bool = false
 
 var _default_shape: int = 0
 
@@ -298,3 +301,12 @@ func set_spring_equilibrium_manual_length(in_manual_length: float) -> void:
 
 func get_spring_equilibrium_manual_length() -> float:
 	return _spring_equilibrium_manual_length
+
+
+func set_spring_ignore_hydrogens(in_enabled: bool) -> void:
+	_spring_ignore_hydrogens = in_enabled
+	spring_ignore_hydrogens_changed.emit()
+
+
+func get_spring_ignore_hydrogen() -> bool:
+	return _spring_ignore_hydrogens


### PR DESCRIPTION
Card: BUG - Ignore Selected Hydrogens no longer works when connecting springs to atoms

---

The `Ignore hydrogens` toggle from the `Auto create springs` panel works as expected.
But from what I understand from the card, I assume Jonathan tried to create springs with the shift+click shortcut, and thought the toggle didn't work.

This PR adds a new `spring_ignore_hydrogens` to the `create object parameters` class, and that setting is used when previewing and creating springs with shift+click. 

The UI was not changed at all, but I'm not sure where to move that `ignore hydrogen` toggle button.