### PR TITLE
Make all buttons in the main window non focusable to don't interfeer with keyboard inputs

### DIFF
--- a/godot_project/autoloads/initial_info_screen/initial_info_screen.gd
+++ b/godot_project/autoloads/initial_info_screen/initial_info_screen.gd
@@ -67,6 +67,7 @@ func _on_button_close_pressed() -> void:
 
 func appear(in_fade_time: float = 0.3) -> void:
 	show()
+	_button_close.focus_mode = Control.FOCUS_ALL
 	_button_close.grab_focus()
 	if in_fade_time <= 0:
 		_blur = 1

--- a/godot_project/autoloads/ui_behavior/ui_behavior.gd
+++ b/godot_project/autoloads/ui_behavior/ui_behavior.gd
@@ -18,6 +18,8 @@ func _on_node_added(node: Node) -> void:
 		if node.text_submitted.is_connected(_on_line_edit_text_submitted):
 			return
 		node.text_submitted.connect(_on_line_edit_text_submitted.bind(node), CONNECT_DEFERRED)
+	if node is Button and node.get_viewport() == get_tree().root:
+		node.focus_mode = Control.FOCUS_NONE
 	if node is AcceptDialog:
 		var child_count: int = node.get_child_count(true)
 		var buttons_container: HBoxContainer


### PR DESCRIPTION
Task: BUG - Editor Window no longer gets focus after using pull-down menu