### PR TITLE
Prevent moving a partially selected DNA to a new group

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
@@ -70,7 +70,7 @@ func _update_selected_info() -> void:
 			total_bonds_selected += context.get_selected_bonds().size()
 			total_springs_selected += context.get_selected_springs().size()
 			if context.nano_structure is DnaStructure:
-				total_control_points_selected += context.get_selected_dna_spline_countrol_points().size()
+				total_control_points_selected += context.get_selected_dna_spline_control_points().size()
 		elif context.nano_structure is NanoShape:
 			total_shapes_selected += 1
 		elif context.nano_structure is NanoVirtualMotor:

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.gd
@@ -213,5 +213,3 @@ func _update_controls() -> void:
 
 func _generate_new_structure_name() -> String:
 	return tr(&"Group {0}").format([_highest_index + 1])
-
-

--- a/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/selection_input_handler.gd
@@ -568,7 +568,7 @@ func _screen_selection_logic(
 						need_to_create_snapshot = true
 				MultiStructureHitResult.HitType.HIT_DNA_CONTROL_POINT:
 					var hit_control_point: int = multi_structure_hit_result.closest_hit_dna_control_point_id
-					if hit_control_point in hit_context.get_selected_dna_spline_countrol_points():
+					if hit_control_point in hit_context.get_selected_dna_spline_control_points():
 						hit_context.deselect_dna_control_points([hit_control_point])
 						if not need_to_create_snapshot:
 							snapshot_name = "Unselect DNA control point"

--- a/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/transform_input_handler.gd
@@ -122,7 +122,7 @@ func _init_initial_positions_and_determine_center() -> Vector3:
 			_structure_context_2_initial_object_transforms[context.get_int_guid()] = Transform3D(Basis(), context.nano_structure.get_position())
 		elif context.nano_structure is DnaStructure:
 			if context.has_selection():
-				var control_points: Array = context.get_selected_dna_spline_countrol_points()
+				var control_points: Array = context.get_selected_dna_spline_control_points()
 				selection_size += control_points.size()
 				for p: int in control_points:
 					center_pos += context.nano_structure.get_control_point_position(p)
@@ -257,7 +257,7 @@ func _apply_selection_transform() -> void:
 		elif nano_structure is DnaStructure:
 			var dna := nano_structure as DnaStructure
 			var sequence: String = dna.get_sequence()
-			var points_to_transform: PackedInt32Array = context.get_selected_dna_spline_countrol_points()
+			var points_to_transform: PackedInt32Array = context.get_selected_dna_spline_control_points()
 			dna.start_edit()
 			for p: int in points_to_transform:
 				action_created = true
@@ -341,7 +341,7 @@ func _get_gizmo_center_position() -> Vector3:
 			center_pos += atom_init_pos
 		
 		# Phase 1.1: DNA's control points
-		selection = context.get_selected_dna_spline_countrol_points()
+		selection = context.get_selected_dna_spline_control_points()
 		selection_size += selection.size()
 		for control_point_idx: int in selection:
 			var control_point_pos: Vector3 = context.nano_structure.get_control_point_position(control_point_idx)
@@ -459,7 +459,7 @@ func _force_gizmo_update() -> void:
 				selection_size += 1
 				# Anchors does not trigger `has_transformable_objects_selected = true` because they dont rotate
 			elif context.nano_structure is DnaStructure:
-				selection_size += context.get_selected_dna_spline_countrol_points().size()
+				selection_size += context.get_selected_dna_spline_control_points().size()
 			elif context.is_dna_structure_fully_selected():
 				selection_size += (context.nano_structure as DnaStructure).get_control_point_count()
 		

--- a/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
+++ b/godot_project/editor/ring_menu_levels/edit_menu/ring_action_delete.gd
@@ -183,12 +183,12 @@ func _can_delete_dna_control_points(out_context: StructureContext, in_from_cut_c
 	if in_from_cut_command:
 		return false
 	return  out_context.nano_structure is DnaStructure \
-			and out_context.get_selected_dna_spline_countrol_points().size() > 0
+			and out_context.get_selected_dna_spline_control_points().size() > 0
 
 
 func _action_delete_dna_control_points(out_context: StructureContext) -> void:
 	assert(out_context.nano_structure is DnaStructure)
-	var selected_points: PackedInt32Array = out_context.get_selected_dna_spline_countrol_points()
+	var selected_points: PackedInt32Array = out_context.get_selected_dna_spline_control_points()
 	out_context.clear_selection()
 	assert(selected_points.size() > 0)
 	if !_did_create_undo_action:
@@ -277,7 +277,7 @@ func _can_delete_objects(in_context: StructureContext, in_from_cut_command: bool
 		if in_from_cut_command:
 			# Cannot cut individual control points, can only cut the entire structure
 			pass # already: dna_spline_selected == in_context.is_dna_structure_fully_selected()
-		elif in_context.get_selected_dna_spline_countrol_points().size() >= in_context.nano_structure.get_control_point_count() - 1:
+		elif in_context.get_selected_dna_spline_control_points().size() >= in_context.nano_structure.get_control_point_count() - 1:
 			# EXCEPTION: DnaStructure gets deleted if all but 1 control point are selected
 			dna_spline_selected = true
 	

--- a/godot_project/project_workspace/structs/dna_structure.gd
+++ b/godot_project/project_workspace/structs/dna_structure.gd
@@ -1820,9 +1820,6 @@ func is_spline_within_screen_rect(in_camera: Camera3D, screen_rect: Rect2i) -> b
 	return true
 
 
-
-
-
 func create_state_snapshot() -> Dictionary:
 	var state_snapshot: Dictionary = super.create_state_snapshot()
 	

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
@@ -288,7 +288,7 @@ func invert_selection() -> void:
 	# ---- DNA Structures ----
 	if nano_structure is DnaStructure:
 		var dna_structure := nano_structure as DnaStructure
-		var selected_points: PackedInt32Array = _structure_context.get_selected_dna_spline_countrol_points()
+		var selected_points: PackedInt32Array = _structure_context.get_selected_dna_spline_control_points()
 		var new_selection: Array = PackedInt32Array(range(dna_structure.get_control_point_count()))
 		for p in selected_points:
 			new_selection.erase(p)
@@ -412,7 +412,7 @@ func deselect_dna_control_points(in_control_points: PackedInt32Array) -> void:
 		selection_changed.emit()
 
 
-func get_selected_dna_spline_countrol_points() -> PackedInt32Array:
+func get_selected_dna_spline_control_points() -> PackedInt32Array:
 	return _dna_control_point_selection.keys()
 
 

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_info.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_info.gd
@@ -51,7 +51,7 @@ static func create_selection_info(structure_context: StructureContext, in_info_t
 					var editor: Control = NanoShapeUtils.create_shape_property_editor(property, true)
 					shape_dimensions[prop_name.capitalize() + suffix] = editor
 	elif nano_structure is DnaStructure:
-		for control_point: int in structure_context.get_selected_dna_spline_countrol_points():
+		for control_point: int in structure_context.get_selected_dna_spline_control_points():
 			const ALWAYS_EDITABLE = SelectionInfo.Type.READ_WRITE_PROPERTIES
 			info["Control Point #%d" % control_point] = {"": _create_dna_control_point_position_property(ALWAYS_EDITABLE, structure_context, control_point)}
 	elif nano_structure is NanoVirtualMotor and structure_context.is_motor_selected():

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -170,7 +170,7 @@ func has_selection(in_recursive: bool = false) -> bool:
 func has_transformable_selection() -> bool:
 	return is_any_atom_selected() \
 		or _selection_db.is_virtual_object_selected() \
-		or _selection_db.get_selected_dna_spline_countrol_points().size() > 0
+		or _selection_db.get_selected_dna_spline_control_points().size() > 0
 
 
 func has_cached_selection_set() -> bool:
@@ -208,7 +208,7 @@ func is_spring_selected(in_spring_id: int) -> bool:
 func dna_structure_has_selection() -> bool:
 	if not nano_structure is DnaStructure:
 		return false
-	if _selection_db.get_selected_dna_spline_countrol_points().size() > 0:
+	if _selection_db.get_selected_dna_spline_control_points().size() > 0:
 		return true
 	return false
 
@@ -217,7 +217,7 @@ func is_dna_structure_fully_selected() -> bool:
 	if not nano_structure is DnaStructure:
 		return false
 	var dna_structure := nano_structure as DnaStructure
-	return _selection_db.get_selected_dna_spline_countrol_points().size() == dna_structure.get_control_point_count()
+	return _selection_db.get_selected_dna_spline_control_points().size() == dna_structure.get_control_point_count()
 
 
 func is_virtual_object_selected() -> bool:
@@ -419,8 +419,8 @@ func deselect_dna_control_points(in_control_points_to_deselect: PackedInt32Array
 	return _selection_db.deselect_dna_control_points(in_control_points_to_deselect)
 
 
-func get_selected_dna_spline_countrol_points() -> PackedInt32Array:
-	return _selection_db.get_selected_dna_spline_countrol_points()
+func get_selected_dna_spline_control_points() -> PackedInt32Array:
+	return _selection_db.get_selected_dna_spline_control_points()
 
 
 func set_virtual_object_selected(in_selected: bool) -> void:
@@ -564,4 +564,3 @@ func _on_dna_control_points_selection_changed() -> void:
 
 func _on_dna_control_points_deselected(in_deselected_control_points: PackedInt32Array) -> void:
 	dna_control_points_deselected.emit(in_deselected_control_points)
-

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -828,7 +828,7 @@ func _on_dna_path_changed(in_structure_context_id: int) -> void:
 		# There's an special case where changing the lenght of a sequence can trim the amount of
 		# control points, if those control points are selected this causes problems
 		var dna: DnaStructure = structure_context.nano_structure as DnaStructure
-		var points_to_unselect: PackedInt32Array = structure_context.get_selected_dna_spline_countrol_points()
+		var points_to_unselect: PackedInt32Array = structure_context.get_selected_dna_spline_control_points()
 		for i: int in range(points_to_unselect.size()-1, -1, -1):
 			var point_idx: int = points_to_unselect[i]
 			if point_idx < dna.get_control_point_count():

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -1355,6 +1355,11 @@ static func _can_move_selection_to_another_group(in_workspace_context: Workspace
 		if not context.nano_structure is AtomicStructure:
 			has_selection = true
 			continue
+		if context.nano_structure is DnaStructure:
+			if not context.is_dna_structure_fully_selected():
+				return false
+			else:
+				continue
 		var structure: AtomicStructure = context.nano_structure as AtomicStructure
 		var selected_atoms: PackedInt32Array = context.get_selected_atoms()
 		var selected_bonds: PackedInt32Array = context.get_selected_bonds()


### PR DESCRIPTION
card: BUG: Can move a DNA Object to a new group without being fully selected

---

This also includes a typo fix `countrol -> control`