### PR TITLE
when hovering a group, show all group springs with hover color

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/spring_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/spring_renderer/spring_renderer.gd
@@ -157,6 +157,13 @@ func change_spring_color(in_spring_id: int, in_color: Color, is_selected: bool) 
 	_multimesh.update_particle_color(in_spring_id, in_color, Color())
 
 
+func change_all_springs_color(in_color: Color) -> void:
+	for spring_id: int in _multimesh.get_particles_ids():
+		# Preserve instance state
+		in_color.a = _multimesh.get_particle_color(spring_id).a
+		_multimesh.update_particle_color(spring_id, in_color, Color())
+
+
 func set_global_color(in_color: Color) -> void:
 	_material.set_color(in_color)
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/springs_representation/springs_representation.gd
@@ -13,6 +13,7 @@ var _workspace_context: WorkspaceContext
 var _structure_id: int = Workspace.INVALID_STRUCTURE_ID
 
 var _hovered_spring: int = AtomicStructure.INVALID_SPRING_ID
+var _hovered_all: bool = false
 var _anchors_to_related_springs: Dictionary = {
 	# anchor_id : PackedInt32Array<spring_id>
 }
@@ -168,6 +169,7 @@ func refresh_all() -> void:
 
 func clear() -> void:
 	_hovered_spring = AtomicStructure.INVALID_SPRING_ID
+	_hovered_all = false
 	_anchors_to_related_springs.clear()
 	_highlighted_atoms.clear()
 
@@ -281,22 +283,46 @@ func _update_is_selectable_uniform() -> void:
 	_spring_renderer.set_global_color(global_color)
 
 
-func handle_hover_structure_changed(_in_toplevel_hovered_structure_context: StructureContext,
+func handle_hover_structure_changed(in_toplevel_hovered_structure_context: StructureContext,
 			in_hovered_structure_context: StructureContext, _in_atom_id: int, _in_bond_id: int,
 			in_spring_id: int) -> void:
 	var structure_context: StructureContext = _workspace_context.get_structure_context(_structure_id)
+	var hovered_as_a_group: bool = false
 	if in_hovered_structure_context != structure_context:
 		# Hovered bond is not part of this structure, remove roll over if needed
 		in_spring_id = AtomicStructure.INVALID_SPRING_ID
+		if in_toplevel_hovered_structure_context != null:
+			hovered_as_a_group = in_toplevel_hovered_structure_context == structure_context or \
+				_workspace_context.workspace.is_a_ancestor_of_b(
+					in_toplevel_hovered_structure_context.nano_structure, structure_context.nano_structure
+				)
+	else: # in_hovered_structure_context == structure_context
+		if in_toplevel_hovered_structure_context != null:
+			hovered_as_a_group = true
 	
 	if not structure_context.nano_structure.spring_has(_hovered_spring):
 		# Previous hovered spring was deleted
 		_hovered_spring = AtomicStructure.INVALID_SPRING_ID
 	
-	if _hovered_spring == in_spring_id:
+	if _hovered_spring == in_spring_id and hovered_as_a_group == _hovered_all:
 		return
 	
-	if _hovered_spring != AtomicStructure.INVALID_SPRING_ID:
+	if _hovered_all != hovered_as_a_group:
+		_hovered_all = hovered_as_a_group
+		_hovered_spring = in_spring_id
+		if hovered_as_a_group:
+			_spring_renderer.change_all_springs_color(COLOR_HOVER)
+		else:
+			var selected_as_a_group: bool = structure_context.is_fully_selected()
+			_spring_renderer.change_all_springs_color(
+				COLOR_HIGHLIGHT if selected_as_a_group else COLOR_LOWLIGHT
+			)
+			if in_spring_id != AtomicStructure.INVALID_SPRING_ID:
+				var is_spring_selected: bool = structure_context.is_spring_selected(in_spring_id)
+				_spring_renderer.change_spring_color(in_spring_id, COLOR_HOVER, is_spring_selected)
+		return
+	
+	if _hovered_spring != AtomicStructure.INVALID_SPRING_ID and not _hovered_all:
 		var is_hovered_selected: bool = structure_context.is_spring_selected(_hovered_spring)
 		var color := COLOR_HIGHLIGHT if is_hovered_selected else COLOR_LOWLIGHT
 		_spring_renderer.change_spring_color(_hovered_spring, color, is_hovered_selected)

--- a/godot_project/project_workspace/workspace.gd
+++ b/godot_project/project_workspace/workspace.gd
@@ -442,14 +442,14 @@ func get_parent_structure(in_child: NanoStructure) -> NanoStructure:
 	return get_structure_by_int_guid(in_child.int_parent_guid)
 
 
-func is_a_ancestor_of_b(in_ancestor_candidate: NanoStructure, in_descendant_candidate: NanoStructure) -> bool:
-	assert(has_structure_with_int_guid(in_ancestor_candidate.int_guid), "in_ancestor_candidate is not part of the workspace")
-	assert(has_structure_with_int_guid(in_descendant_candidate.int_guid), "in_descendant_candidate is not part of the workspace")
-	if in_ancestor_candidate == in_descendant_candidate:
+func is_a_ancestor_of_b(in_parent_candidate: NanoStructure, in_child_candidate: NanoStructure) -> bool:
+	assert(has_structure_with_int_guid(in_parent_candidate.int_guid), "in_parent_candidate is not part of the workspace")
+	assert(has_structure_with_int_guid(in_child_candidate.int_guid), "in_child_candidate is not part of the workspace")
+	if in_parent_candidate == in_child_candidate:
 		return false
-	var structure: NanoStructure = get_parent_structure(in_descendant_candidate) as NanoStructure
+	var structure: NanoStructure = get_parent_structure(in_child_candidate) as NanoStructure
 	while structure != null:
-		if structure == in_ancestor_candidate:
+		if structure == in_parent_candidate:
 			return true
 		structure = get_parent_structure(structure)
 	return false

--- a/godot_project/utils/segmented_multimesh/segmented_multi_mesh.gd
+++ b/godot_project/utils/segmented_multimesh/segmented_multi_mesh.gd
@@ -83,6 +83,10 @@ func set_bias(new_bias: float) -> SegmentedMultimesh:
 	return self
 
 
+func get_particles_ids() -> PackedInt32Array:
+	return PackedInt32Array(_external_id_to_particle.keys())
+
+
 func get_particle_color(in_external_id: int) -> Color:
 	var particle_data: Particle = _external_id_to_particle[in_external_id]
 	return particle_data.color


### PR DESCRIPTION
Task: BUG: When hovering the atom of a group, the springs of the group doesn't highlight