### PR TITLE
When making hydrogens visible, select them if the group was selected

### DIFF
--- a/godot_project/editor/ring_menu_levels/atoms/ring_action_add_hydrogens.gd
+++ b/godot_project/editor/ring_menu_levels/atoms/ring_action_add_hydrogens.gd
@@ -46,7 +46,10 @@ func _execute_action() -> void:
 		added = 0,
 		removed = 0
 	}
-	_workspace_context.enable_hydrogens_visualization(false)
+	var did_show_hydrogens: bool = false
+	if not _workspace_context.are_hydrogens_visualized():
+		did_show_hydrogens = true
+		_workspace_context.enable_hydrogens_visualization(false)
 	for context in target_structures:
 		if not context.nano_structure is AtomicStructure:
 			continue
@@ -71,6 +74,9 @@ func _execute_action() -> void:
 	if delta_hydrogens.added > 0 or delta_hydrogens.removed > 0:
 		hydrogen_atoms_count_changed.emit(delta_hydrogens.added, delta_hydrogens.removed)
 		_workspace_context.snapshot_moment(tr("Correct Hydrogens"))
+	elif did_show_hydrogens:
+		_workspace_context.snapshot_moment(tr("Change Hydrogen Visibility"))
+		
 
 
 func _complete_atom_valence(

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1013,6 +1013,7 @@ func enable_hydrogens_visualization(clear_selection: bool = true) -> void:
 		return
 	
 	var rendering: Rendering = get_editor_viewport().get_rendering()
+	var active_context: StructureContext = get_current_structure_context()
 	for context: StructureContext in _structure_contexts.values():
 		if not context.nano_structure is AtomicStructure:
 			# Ignore virtual objects
@@ -1020,7 +1021,11 @@ func enable_hydrogens_visualization(clear_selection: bool = true) -> void:
 		context.nano_structure.enable_hydrogens_visibility()
 		if clear_selection:
 			context.clear_selection()
-	
+		else:
+			if context != active_context and context.has_selection():
+				# For consistency, hydrogens of selected child groups
+				# needs to be selected when becoming visible
+				context.select_all()
 	rendering.enable_hydrogens()
 	workspace.representation_settings.set_hydrogen_visibility_and_notify(true)
 


### PR DESCRIPTION
- When making hydrogens visible from "correct hydrogens", if no hydrogen was created, add an undo step for making hydrogens visible

Task: BUG - Hydrogens Appearing at incorrect times
