### PR TITLE
When changing Atoms representation, ensure visibility of hydrogens is mantained

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/atomic_structure_renderer.gd
@@ -226,6 +226,10 @@ func change_representation(new_representation: Rendering.Representation) -> void
 	
 	_current_representation.refresh_all()
 	_current_representation.show()
+	if is_hydrogen_rendering_enabled():
+		_current_representation.hydrogens_rendering_on()
+	else:
+		_current_representation.hydrogens_rendering_off()
 	_refresh_label_visibility_state()
 	_reset_representation_highlight(old_representation, old_rendering_representation, new_representation)
 

--- a/godot_project/editor/ring_menu_levels/view_menu/representation_menu/ring_action_mechanical_simulation.gd
+++ b/godot_project/editor/ring_menu_levels/view_menu/representation_menu/ring_action_mechanical_simulation.gd
@@ -32,6 +32,5 @@ func _execute_action() -> void:
 	assert(_workspace_context)
 	var representation_settings: RepresentationSettings = _workspace_context.workspace.representation_settings
 	representation_settings.set_rendering_representation(Rendering.Representation.MECHANICAL_SIMULATION)
-	_workspace_context.workspace.representation_settings.emit_changed()
 	_ring_menu.refresh_button_availability()
 	_workspace_context.snapshot_moment("Representation change to Mechanical Simulation")


### PR DESCRIPTION
Task: BUG - Switching Representation View Types Shows Hydrogens when they've been set to not show in the Workspace Settings