### PR TITLE
Show hydrogens when showing hidden objects

### DIFF
--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -1342,6 +1342,8 @@ func has_visible_objects() -> bool:
 
 
 func has_hidden_objects() -> bool:
+	if not are_hydrogens_visualized():
+		return true
 	for context: StructureContext in _structure_contexts.values():
 		if not context.nano_structure.get_visible() or context.has_hidden_atoms_bonds_springs_or_motor_links():
 			return true

--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -491,6 +491,7 @@ static func hide_selected_objects(out_workspace_context: WorkspaceContext) -> vo
 
 
 static func show_hidden_objects(out_workspace_context: WorkspaceContext) -> void:
+	out_workspace_context.enable_hydrogens_visualization(false)
 	var hidden_structures: Array[StructureContext] = out_workspace_context.get_structure_contexts_with_hidden_objects()
 	if hidden_structures.is_empty():
 		return


### PR DESCRIPTION
Card: Unhide Hidden Objects should toggle the workspace setting: "Show Hydrogens" to On.