### PR TITLE
Handle coping hidden objects when they are part of a selected group

### DIFF
--- a/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
+++ b/godot_project/autoloads/nano_editor_clipboard/nano_editor_clipboard.gd
@@ -35,10 +35,10 @@ func copy(in_workspace_context: WorkspaceContext) -> void:
 		
 		match nano_structure.get_type():
 			&"MolecularStructure":
-				_copy_selected_atoms(
+				_copy_atoms(
 					structure_context, nano_structure, atom_selection, new_content
 				)
-				_copy_selected_springs(
+				_copy_springs(
 					structure_context, nano_structure, spring_selection, atom_selection, new_content
 				)
 			&"Cylinder",&"Cone",&"Pyramid",&"Box",&"Capsule",&"Plane",&"Prism",&"Sphere",&"Torus":
@@ -50,7 +50,9 @@ func copy(in_workspace_context: WorkspaceContext) -> void:
 			&"ParticleEmitter":
 				_copy_particle_emitter(structure_context, nano_structure, new_content)
 			&"DnaStructure":
-				if structure_context.is_dna_structure_fully_selected():
+				if (structure_context.is_dna_structure_fully_selected() 
+						# Include hidden DNA objects
+						or structure_context.nano_structure.get_visible() == false):
 					_copy_dna_structure(structure_context, nano_structure, new_content)
 			_:
 				push_warning("Nano structure type not implemented for copy")
@@ -61,18 +63,26 @@ func copy(in_workspace_context: WorkspaceContext) -> void:
 
 
 func _get_selected_structure_and_atoms(in_workspace_context: WorkspaceContext) -> Array[Dictionary]:
+	var active_strucutre_id: int = in_workspace_context.get_current_structure_context().get_int_guid()
 	var nano_structure: NanoStructure = null
 	var atom_selection: PackedInt32Array = []
 	var spring_selection: PackedInt32Array = []
 	var result: Array[Dictionary] = []
+	const SELECTION_WITH_EMPTY_GROUPS = true
+	const SELECTION_WITH_HIDDEN_OBJECTS = true
 	var selected_structures: Array[StructureContext] = \
-		in_workspace_context.get_structure_contexts_with_selection(true)
+		in_workspace_context.get_structure_contexts_with_selection(
+			SELECTION_WITH_EMPTY_GROUPS, SELECTION_WITH_HIDDEN_OBJECTS)
 	for structure_context in selected_structures:
 		nano_structure = structure_context.nano_structure
 		if !nano_structure:
 			continue
-		atom_selection = structure_context.get_selected_atoms()
-		spring_selection = structure_context.get_selected_springs()
+		if active_strucutre_id == structure_context.get_int_guid():
+			atom_selection = structure_context.get_selected_atoms()
+			spring_selection = structure_context.get_selected_springs()
+		elif nano_structure is AtomicStructure and not nano_structure is DnaStructure:
+			atom_selection = (nano_structure as AtomicStructure).get_valid_atoms()
+			spring_selection = (nano_structure as AtomicStructure).springs_get_all()
 		var context_selection: Dictionary = {
 			nano_structure = nano_structure,
 			atom_selection = atom_selection,
@@ -83,7 +93,7 @@ func _get_selected_structure_and_atoms(in_workspace_context: WorkspaceContext) -
 	return result
 
 
-func _copy_selected_atoms(
+func _copy_atoms(
 	in_structure_context: StructureContext,
 	in_structure: NanoStructure,
 	in_atom_selection: PackedInt32Array,
@@ -137,7 +147,7 @@ func _copy_selected_atoms(
 	out_content.push_back(new_content)
 
 
-func _copy_selected_springs(
+func _copy_springs(
 	in_structure_context: StructureContext,
 	in_structure: AtomicStructure,
 	in_spring_selection: PackedInt32Array,
@@ -711,6 +721,8 @@ func paste_object(
 	out_workspace_context.workspace.add_structure(new_structure, in_parent_structure)
 	var new_structure_context: StructureContext = \
 		out_workspace_context.get_nano_structure_context(new_structure)
+	if not new_structure.get_visible():
+		new_structure.set_visible(true)
 	new_structure_context.select_all()
 	
 	return new_structure

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -942,12 +942,19 @@ func get_visible_structure_contexts(in_include_empty_structures: bool = false) -
 	return result
 
 
-func get_editable_structure_contexts() -> Array[StructureContext]:
+func get_editable_structure_contexts(in_include_hidden_virtual_objects: bool = false) -> Array[StructureContext]:
 	if ScriptUtils.is_callable_queued(_emit_new_editable_structures):
 		ScriptUtils.flush_now(_emit_new_editable_structures)
 	var editable_structure_contexts: Array[StructureContext] = []
 	for editable_id: int in _editable_structure_contexts_ids:
 		editable_structure_contexts.append(_structure_contexts[editable_id])
+		if in_include_hidden_virtual_objects and editable_id != _current_structure_context_id:
+			# hidden virtual objects are included as part of a subgroup
+			var childs: Array[NanoStructure] = workspace.get_child_structures(
+					_structure_contexts[editable_id].nano_structure)
+			for child: NanoStructure in childs:
+				if child.get_visible() == false and (child.is_virtual_object() or child is DnaStructure):
+					editable_structure_contexts.append(get_structure_context(child.int_guid))
 	return editable_structure_contexts
 
 
@@ -1138,12 +1145,30 @@ func get_selected_anchors_contexts() -> Array[StructureContext]:
 	return selected_anchors
 
 
-func get_structure_contexts_with_selection(in_include_empty_groups_with_selected_subgroups: bool = false) -> Array[StructureContext]:
+func get_structure_contexts_with_selection(
+		in_include_empty_groups_with_selected_subgroups: bool = false,
+		include_hidden_virtual_objects: bool = false) -> Array[StructureContext]:
 	var result: Array[StructureContext] = []
-	var editable := get_editable_structure_contexts()
+	var editable := get_editable_structure_contexts(include_hidden_virtual_objects)
 	for structure_context: StructureContext in editable:
 		if structure_context.nano_structure.get_visible() and structure_context.has_selection(in_include_empty_groups_with_selected_subgroups):
 			result.push_back(structure_context)
+		else:
+			if include_hidden_virtual_objects:
+				if not (structure_context.nano_structure.is_virtual_object() or 
+					structure_context.nano_structure is DnaStructure):
+						continue
+				# hidden object is returned as a part of a group that is selected
+				var should_include_hidden: bool = false
+				var current: NanoStructure = structure_context.nano_structure
+				while current != get_current_structure_context().nano_structure:
+					current = workspace.get_parent_structure(current)
+					var parent_context: StructureContext = get_structure_context(current.int_guid)
+					if current.get_visible() and parent_context.has_selection(in_include_empty_groups_with_selected_subgroups):
+						should_include_hidden = true
+						break
+				if should_include_hidden:
+					result.push_back(structure_context)
 	return result
 
 


### PR DESCRIPTION
Tasks:
- BUG: Possible to copy a group without including it's springs
- BUG - When Copying a Group, if there are hidden objects within the group, they should also be copied to the pasted group.