### PR TITLE
When using the 'select all linked' button from Groups panel, expand the selection to all individual molecules conencted by springs with a single click

### DIFF
--- a/godot_project/utils/workspace_utils.gd
+++ b/godot_project/utils/workspace_utils.gd
@@ -556,11 +556,15 @@ static func _select_connected(
 		in_linked_by_springs: bool) -> void:
 	var all_structures: Array[StructureContext] = out_workspace_context.get_structure_contexts_with_selection()
 	var selection_changed: bool = false
-	for struct_context in all_structures:
-		if not struct_context.nano_structure is AtomicStructure:
-			continue
-		var result: AtomSelection.AtomSelectionResult = struct_context.select_connected(in_show_hidden_objects, in_linked_by_springs)
-		selection_changed = selection_changed or result.selection_changed
+	var continue_selecting: bool = true
+	while continue_selecting:
+		continue_selecting = false
+		for struct_context in all_structures:
+			if not struct_context.nano_structure is AtomicStructure:
+				continue
+			var result: AtomSelection.AtomSelectionResult = struct_context.select_connected(in_show_hidden_objects, in_linked_by_springs)
+			selection_changed = selection_changed or result.selection_changed
+			continue_selecting = in_linked_by_springs and result.selection_changed
 	if selection_changed:
 		out_workspace_context.snapshot_moment("Select Connected Atoms")
 


### PR DESCRIPTION
Task: UI/UX: In the group panels, sometimes is necesary to click several times the "select all linked atoms" button