### PR TITLE
Update estimated simulation lenght as soon as project loads

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -87,6 +87,7 @@ func _ensure_workspace_initialized(out_workspace_context: WorkspaceContext) -> v
 		assert(TimeSpanPicker.Unit.NANOSECOND == SimulationParameters.PlaybackUnit.Nanoseconds,
 				"TimeSpanPicker.Unit and SimulationParameter.PlaybackUnit are out of sync!")
 		_on_simulation_parameters_changed()
+		_update_estimated_length()
 
 
 func _ready() -> void:


### PR DESCRIPTION
BUG: when loading a project simulation settings will show the default `Frame Count` instead of what was configured on save