### PR TITLE
Make particle emitter template visualization less transparent in bright background

### DIFF
--- a/godot_project/editor/rendering/particle_emitter_renderer/particle_emitter_renderer.gd
+++ b/godot_project/editor/rendering/particle_emitter_renderer/particle_emitter_renderer.gd
@@ -124,6 +124,18 @@ func transform_by_external_transform(in_selection_initial_pos: Vector3, in_initi
 		preview.set_preview_transform(global_transform.translated(emitter.calculate_instance_offset(i)))
 
 
+func apply_theme(in_theme: Theme3D) -> void:
+	for i: int in _structure_previews.size():
+		var preview: StructurePreview = _structure_previews[i]
+		preview.apply_theme(in_theme)
+		var background_color: Color = in_theme.get_background_color()
+		preview.set_transparency(
+			StructurePreview.DEFAULT_PREVIEW_TRANSPARENCY
+			if background_color.v < 0.8 else
+			StructurePreview.PREVIEW_TRANSPARENCY_ON_BRIGTH_BACKGROUND
+		)
+
+
 func _set_structure_preview_count(in_count: int) -> void:
 	const STRUCTURE_PREVIEW_SCN: PackedScene = preload("uid://dtf1gkl710hh8")
 	while in_count < _structure_previews.size():

--- a/godot_project/editor/rendering/rendering.gd
+++ b/godot_project/editor/rendering/rendering.gd
@@ -388,6 +388,10 @@ func apply_theme(in_theme: Theme3D) -> void:
 		if structure_renderer is InstancePlaceholder:
 			continue
 		structure_renderer.apply_theme(in_theme)
+	for emitter_renderer: Node in _particle_emitter_renderers.get_children():
+		if emitter_renderer is InstancePlaceholder:
+			continue
+		emitter_renderer.apply_theme(in_theme)
 	
 	_atom_preview.apply_theme(in_theme)
 	_ballstick_bond_preview.apply_theme(in_theme)

--- a/godot_project/editor/rendering/structure_preview/structure_preview.gd
+++ b/godot_project/editor/rendering/structure_preview/structure_preview.gd
@@ -7,6 +7,7 @@ const WorkspaceContextScn: String = "uid://xof5f45xkn2n"
 const StructureContextScn = preload("res://project_workspace/workspace_context/structure_context/structure_context.tscn")
 
 const DEFAULT_PREVIEW_TRANSPARENCY: float = 0.35
+const PREVIEW_TRANSPARENCY_ON_BRIGTH_BACKGROUND: float = 0.2
 const UNIFORM_BASE_SCALE: StringName = &"base_scale"
 const UNIFORM_ATOM_SCALE: StringName = &"atom_scale"
 
@@ -80,6 +81,11 @@ func set_structure(in_structure: NanoStructure) -> void:
 	_on_representation_settings_bond_visibility_changed(display_bonds)
 	
 	_atomic_structure_renderer.apply_theme(representation_settings.get_theme())
+
+
+func apply_theme(in_theme: Theme3D) -> void:
+	if is_instance_valid(_atomic_structure_renderer):
+		_atomic_structure_renderer.apply_theme(in_theme)
 
 
 func set_preview_transform(in_transform: Transform3D) -> void:


### PR DESCRIPTION
Task: BUG: Template of Particle emitters are barely vissible in Academic view