### PR TITLE
Show a warning to the user when performing an undo would abort current simulation

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/atomic_structure_model_validator.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/atomic_structure_model_validator.gd
@@ -493,7 +493,7 @@ class IgnoredSpring extends Metadata:
 		var symbol: String = PeriodicTable.get_by_atomic_number(atomic_number).symbol
 		spring_ids = in_atom_springs
 		var message: String = tr_n(
-			&"Spring attached to Locked {0} atom will be ignored during simulaitons",
+			&"Spring attached to Locked {0} atom will be ignored during simulations",
 			&"Springs attached to Locked {0} atom will be ignored during simulations", in_atom_springs.size())
 		text += message.format([symbol])
 

--- a/godot_project/editor/ring_menu_levels/edit_menu/ring_action_undo.gd
+++ b/godot_project/editor/ring_menu_levels/edit_menu/ring_action_undo.gd
@@ -34,5 +34,14 @@ func get_description() -> String:
 
 
 func _execute_action() -> void:
+	if _workspace_context.ignored_warnings.undo_aborts_simulation == false \
+			and _workspace_context.would_undo_abort_simulation():
+		var promise: Promise = _workspace_context.show_warning_dialog(
+			tr(&"Performing an Undo step will abort current simulation"),
+			tr(&"Proceed"), tr(&"Cancel"), &"undo_aborts_simulation", true
+		)
+		await promise.wait_for_fulfill()
+		if promise.get_result() == false:
+			return
 	_workspace_context.apply_previous_snapshot()
 

--- a/godot_project/project_workspace/workspace_context/history/history.gd
+++ b/godot_project/project_workspace/workspace_context/history/history.gd
@@ -92,6 +92,7 @@ var _last_snapshot_name: String = ""
 
 func initialize(in_workspace_context: WorkspaceContext) -> void:
 	_workspace_context = in_workspace_context
+	register_snapshotable(self)
 
 
 func register_snapshotable(in_system: Object) -> void:
@@ -161,6 +162,8 @@ func apply_previous_snapshot() -> void:
 		return
 	if _snapshot_stack.is_empty():
 		return
+	if would_undo_abort_simulation():
+		_workspace_context.abort_simulation_if_running()
 	var undone_snapshot_name: String = _name_stack[_stack_pointer]
 	_stack_pointer -= 1
 	_apply_snapshot_from_stack(_stack_pointer)
@@ -242,6 +245,14 @@ func get_version() -> int:
 	return _version_stack[_stack_pointer]
 
 
+func would_undo_abort_simulation() -> bool:
+	return (
+			can_undo()
+			and _workspace_context.is_simulating()
+			and _workspace_context.get_simulation_id() != _snapshot_stack[_stack_pointer-1][self]["current_simulation_id"]
+		)
+
+
 func get_last_snapshot_name() -> String:
 	return _last_snapshot_name
 
@@ -270,6 +281,18 @@ func _monitor_redundant_snapshots(in_snapshot_name: String) -> void:
 		return
 	push_error("Possibly redundant snapshot detected. previous: ", _last_snapshot_name,
 				" , current: ", in_snapshot_name)
+
+
+func create_state_snapshot() -> Dictionary:
+	return {
+		"current_simulation_id": _workspace_context.get_simulation_id()
+	}
+
+
+func apply_state_snapshot(_state: Dictionary) -> void:
+	# Ignore state, current_simulation_id is used to determine if Undo can be
+	# done without aborting simulation
+	pass
 
 
 static func create_signal_snapshot_for_object(in_object: Object) -> Dictionary:

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -19,7 +19,7 @@ signal aborted_creating_object()
 signal object_tree_visibility_changed()
 signal atoms_relaxation_started()
 signal atoms_relaxation_finished(error_description_or_empty: String)
-# When simulaiton starts
+# When simulation starts
 signal simulation_started()
 # When last frame of simulation is received, or user stops simulation without aborting it
 signal simulation_background_processing_completed()
@@ -72,6 +72,7 @@ var ignored_warnings: Dictionary = {
 	overlapping_emitters_in_simulation = false,
 	convert_dna_to_atoms = false,
 	extend_dna_chain_length = false,
+	undo_aborts_simulation = false
 }
 
 var visible_object_tree: bool = false:
@@ -1701,6 +1702,10 @@ func can_redo() -> bool:
 
 func can_undo() -> bool:
 	return _history.can_undo()
+
+
+func would_undo_abort_simulation() -> bool:
+	return _history.would_undo_abort_simulation()
 
 
 func _on_history_changed() -> void:


### PR DESCRIPTION
Task: BUG: Hidden objects can be selected during simulation