### PR TITLE
Change wording of dialog warning about hidden atoms when correcting hydrogens

### DIFF
--- a/godot_project/editor/ring_menu_levels/atoms/ring_action_add_hydrogens.gd
+++ b/godot_project/editor/ring_menu_levels/atoms/ring_action_add_hydrogens.gd
@@ -68,7 +68,7 @@ func _execute_action() -> void:
 	
 	if show_show_hidden_dialog:
 		var promise: Promise = _workspace_context.show_warning_dialog(
-			tr(&"Selected atoms are bond to hidden atoms with incomplete valence.\nMake them visible?"),
+			tr(&"Some atoms are bonded to hidden atoms with incomplete valences.\nMake them visible?"),
 			tr(&"Yes"), tr(&"No")
 		)
 		await promise.wait_for_fulfill()


### PR DESCRIPTION
Task: UX Question: Should Correct-Hydrogens warn the user when used in a group with hidden atoms with incomplete valence?
