### PR TITLE
Add support for gpu movement on the capsule stick shader

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/bond_capsule.gdshader
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/bond_capsule.gdshader
@@ -1,11 +1,12 @@
 
 shader_type spatial;
 
-render_mode skip_vertex_transform,blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx,vertex_lighting; 
+render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx,vertex_lighting; 
 
 #include "res://editor/rendering/atomic_structure_renderer/representation/hydrogens.gdshaderinc"
 #include "res://editor/rendering/atomic_structure_renderer/representation/outlines.gdshaderinc"
 #include "res://editor/rendering/atomic_structure_renderer/representation/selectable.gdshaderinc"
+#include "res://editor/rendering/atomic_structure_renderer/representation/gizmo_transform_delta.gdshaderinc"
 
 // half of the mesh size along z axis, depending on the mesh
 const float MODEL_LENGTH = 0.5;
@@ -42,7 +43,33 @@ vec3 _apply_bond_highlight_factor(vec3 color, float is_selected) {
 	return mix(color, color * BOND_HIGHLIGHT_FACTOR, is_selected);
 }
 
+
 void vertex() {
+	// Common
+	ROUGHNESS=roughness;
+	UV=UV*uv1_scale.xy+uv1_offset.xy;
+	percent = VERTEX.z;
+
+	// Make the capsule match the bond length.
+	// The capsule can't be scaled on the Z axis, or the end caps lose their round shape.
+	// Instead the existing scale is reverted and the caps are moved as one block
+	// to their end position.
+	float scale_z = length(MODELVIEW_MATRIX[2]); // Bond length
+	float cap_vertexes_above_local_pos = caps_starts_at_local_z_position - NUMERICAL_PRECISION;
+	float cap_length = MODEL_LENGTH - caps_starts_at_local_z_position;
+	float bond_length = scale_z + (cap_length * 0.5); // Increase bond length by the caps length to make the sticks connect
+	float new_cap_starting_point = MODEL_LENGTH * bond_length - caps_starts_at_local_z_position - cap_length;
+	VERTEX.z += first_greater_then_second(VERTEX.z, cap_vertexes_above_local_pos) * new_cap_starting_point;
+	VERTEX.z -= first_lower_then_second(VERTEX.z, -cap_vertexes_above_local_pos) * new_cap_starting_point;
+	VERTEX.z /= scale_z; // Cancel old scaling on Z
+	
+	// Gizmo delta
+	vec3 vertex_position = VERTEX;
+	vertex_position += get_bond_rotation_delta(VERTEX, COLOR, MODEL_MATRIX);
+	vertex_position += get_bond_translation_delta(VERTEX, COLOR, MODEL_MATRIX);
+	VERTEX = vertex_position;
+	
+	// Color
 	COLOR.rgb = apply_selectable_dimming(COLOR).rgb;
 	custom_color = apply_selectable_dimming(INSTANCE_CUSTOM).rgb;
 	
@@ -52,47 +79,15 @@ void vertex() {
 	COLOR.rgb = _apply_bond_highlight_factor(COLOR.rgb, right_active);
 	custom_color.rgb = _apply_bond_highlight_factor(custom_color.rgb, left_active);
 	
+	// Outline
 	is_outline = uv_is_outline(UV);
 	float is_preview = _unpack_flag(SELECTION_PREVIEW_VISUAL_LAYER, int(CAMERA_VISIBLE_LAYERS));
 	is_instance_hovered = float_and(is_atom_or_bond_hovered(COLOR.a), float_not(is_preview));
 	VERTEX += calculate_bond_outline_displacement(VERTEX, NORMAL, UV, MODEL_MATRIX, CAMERA_POSITION_WORLD, COLOR, is_preview);
 	
-	//helper to prevent numerical errors
-	float cap_vertexes_above_local_pos = caps_starts_at_local_z_position - NUMERICAL_PRECISION;
-	
-	//
-	ROUGHNESS=roughness;
-	UV=UV*uv1_scale.xy+uv1_offset.xy;
-	
-	//
-	vec3 position = VERTEX;
-	mat4 modelview = MODELVIEW_MATRIX;
-	mat3 rotation = mat3(modelview);
-	vec3 scale = vec3(length(rotation[0]), length(rotation[1]), length(rotation[2]));
-	
-	percent = position.z;
-	
-	//apply width
-	position.xy *= scale.x;
-	
-	// shift caps locally to proper positions
-	float cap_offset = MODEL_LENGTH - caps_starts_at_local_z_position;
-	float bond_length = scale.z + (cap_offset * 0.5); // Increase bond length by the caps length to make the sticks connect
-	float cap_starting_point = MODEL_LENGTH * bond_length - caps_starts_at_local_z_position - cap_offset;
-	position.z += first_greater_then_second(position.z, cap_vertexes_above_local_pos) * cap_starting_point;
-	position.z -= first_lower_then_second(position.z, -cap_vertexes_above_local_pos) * cap_starting_point;
-	
-	//apply transform, exclude scale (scale already applied in form of width and caps shift
-	rotation[0] /= scale.x;
-	rotation[1] /= scale.y;
-	rotation[2] /= scale.z;
-	position /= scale;
-	position = (modelview * vec4(position, 1.0)).xyz;
-	VERTEX = position;
+	// Visibility
 	VERTEX = hide_hydrogen_bonds(VERTEX, COLOR.a, INSTANCE_CUSTOM.a);
 	VERTEX *= is_atom_or_bond_visible(COLOR.a);
-	
-	//preview visibility
 	VERTEX *= float_or(float_not(is_preview), is_atom_or_bond_selected(COLOR.a));
 }
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.gd
@@ -7,11 +7,15 @@ const UNIFORM_OUTLINE_THICKNESS = &"outline_thickness"
 const UNIFORM_IS_HOVERED = &"is_hovered"
 const UNIFORM_SATURATION = &"saturation"
 const UNIFORM_VALUE = &"value_correction"
+const UNIFORM_GIZMO_ORIGIN = &"gizmo_origin"
+const UNIFORM_GIZMO_ROTATION = &"gizmo_rotation"
+const UNIFORM_SELECTION_DELTA = &"selection_delta"
 
 const LOW_SATURATION = 0.5;
 const NORMAL_SATURATION = 1.0;
 const LOW_VALUE = 0.4;
 const NORMAL_VALUE = 1.0;
+
 
 func _init() -> void:
 	RenderingUtils.has_uniforms(self, [INSTANCE_UNIFORM_BASE_SCALE, UNIFORM_CAPS_STARTS_AT_LOCAL_Z,
@@ -20,6 +24,11 @@ func _init() -> void:
 
 func set_scale(new_scale: float) -> CapsuleStickMaterial:
 	set_shader_parameter(INSTANCE_UNIFORM_BASE_SCALE, new_scale)
+	return self
+
+
+func set_atom_scale(new_scale: float) -> CapsuleStickMaterial:
+	# Not applicable
 	return self
 
 
@@ -41,6 +50,21 @@ func set_hovered(in_is_hovered: bool) -> CapsuleStickMaterial:
 
 func set_caps_starts_at_local_z(in_start_distance: float) -> CapsuleStickMaterial:
 	set_shader_parameter(UNIFORM_CAPS_STARTS_AT_LOCAL_Z, in_start_distance)
+	return self
+
+
+func set_gizmo_origin(in_origin_position: Vector3) -> CapsuleStickMaterial:
+	set_shader_parameter(UNIFORM_GIZMO_ORIGIN, in_origin_position)
+	return self
+
+
+func set_gizmo_rotation(in_gizmo_rotation: Basis) -> CapsuleStickMaterial:
+	set_shader_parameter(UNIFORM_GIZMO_ROTATION, in_gizmo_rotation)
+	return self;
+
+
+func set_selection_delta(in_selection_delta: Vector3) -> CapsuleStickMaterial:
+	set_shader_parameter(UNIFORM_SELECTION_DELTA, in_selection_delta)
 	return self
 
 

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -74,38 +74,6 @@ func _calculate_bond_transform(in_nano_structure: AtomicStructure, in_bond: Vect
 	return new_transform
 
 
-func set_atom_selection_position_delta(in_movement_delta: Vector3) -> void:
-	# TODO: implement GPU translation
-	var bonds_to_update: PackedInt32Array = PackedInt32Array()
-	var structure_context: StructureContext = _workspace_context.get_structure_context(_related_structure_id)
-	var related_structure: AtomicStructure = structure_context.nano_structure as AtomicStructure
-	bonds_to_update.append_array(structure_context.get_selected_bonds())
-	bonds_to_update.append_array(_current_bond_partial_selection.keys())
-	for bond_id in bonds_to_update:
-		var bond: Vector3i = related_structure.get_bond(bond_id)
-		var particle_id: ParticleID = _bond_id_to_particle_id[bond_id]
-		var related_multimesh: SegmentedMultimesh = _bond_order_to_segmented_multimesh[particle_id.bond_order]
-		var bond_transform: Transform3D = _calculate_partial_selection_translation(bond, in_movement_delta)
-		related_multimesh.update_particle_transform(particle_id.bond_id, bond_transform)
-	update_segments_if_needed() 
-
-
-func rotate_atom_selection_around_point(in_point: Vector3, in_rotation_to_apply: Basis) -> void:
-	# TODO: implement GPU rotation
-	var structure_context: StructureContext = _workspace_context.get_structure_context(_related_structure_id)
-	var related_structure: AtomicStructure = structure_context.nano_structure as AtomicStructure
-	var bonds_to_update: PackedInt32Array = PackedInt32Array()
-	bonds_to_update.append_array(structure_context.get_selected_bonds())
-	bonds_to_update.append_array(_current_bond_partial_selection.keys())
-	for bond_id in bonds_to_update:
-		var bond: Vector3i = related_structure.get_bond(bond_id)
-		var particle_id: ParticleID = _bond_id_to_particle_id[bond_id]
-		var related_multimesh: SegmentedMultimesh = _bond_order_to_segmented_multimesh[particle_id.bond_order]
-		var bond_transform: Transform3D = _calculate_partial_selection_transform(bond, in_point, in_rotation_to_apply)
-		related_multimesh.update_particle_transform(particle_id.bond_id, bond_transform)
-	update_segments_if_needed() 
-
-
 func hydrogens_rendering_off() -> void:
 	_capsule_material.disable_hydrogen_rendering()
 	_init_material_uniforms()

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/cylinder_stick_representation.gd
@@ -128,50 +128,6 @@ static func calc_bond_visual_radius(in_bond_order: int, in_smaller_atom_radius: 
 	return CYLINDER_MODEL_RADIUS * calc_bond_width_factor(in_bond_order, in_smaller_atom_radius)
 
 
-# *
-# | Shader related, most probably can be moved to StickRepresentation when
-# v CapsuleStickRepresentation supports GPU movement
-func _apply_scale_factor(new_scale_factor: float) -> void:
-	assert(_material_bond_1 is CylinderStickMaterial)
-	assert(_material_bond_2 is CylinderStickMaterial)
-	assert(_material_bond_3 is CylinderStickMaterial)
-	_material_bond_1.set_atom_scale(new_scale_factor)
-	_material_bond_2.set_atom_scale(new_scale_factor)
-	_material_bond_3.set_atom_scale(new_scale_factor)
-
-
-func rotate_atom_selection_around_point(in_point: Vector3, in_rotation_to_apply: Basis) -> void:
-	_material_bond_1.set_gizmo_origin(in_point)
-	_material_bond_2.set_gizmo_origin(in_point)
-	_material_bond_3.set_gizmo_origin(in_point)
-	_material_bond_1.set_gizmo_rotation(in_rotation_to_apply)
-	_material_bond_2.set_gizmo_rotation(in_rotation_to_apply)
-	_material_bond_3.set_gizmo_rotation(in_rotation_to_apply)
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
-	for bond_id: int in _current_bond_partial_selection:
-		var bond: Vector3i = related_nanostructure.get_bond(bond_id)
-		var particle_id: ParticleID = _bond_id_to_particle_id[bond_id]
-		var related_multimesh: SegmentedMultimesh = _bond_order_to_segmented_multimesh[particle_id.bond_order]
-		var bond_transform: Transform3D = _calculate_partial_selection_transform(bond, in_point, in_rotation_to_apply)
-		related_multimesh.update_particle_transform(particle_id.bond_id, bond_transform)
-	update_segments_if_needed()
-
-
-func set_atom_selection_position_delta(in_movement_delta: Vector3) -> void:
-	_material_bond_1.set_selection_delta(in_movement_delta)
-	_material_bond_2.set_selection_delta(in_movement_delta)
-	_material_bond_3.set_selection_delta(in_movement_delta)
-	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
-	for bond_id: int in _current_bond_partial_selection:
-		var bond: Vector3i = related_nanostructure.get_bond(bond_id)
-		var particle_id: ParticleID = _bond_id_to_particle_id[bond_id]
-		var related_multimesh: SegmentedMultimesh = _bond_order_to_segmented_multimesh[particle_id.bond_order]
-		var bond_transform: Transform3D = _calculate_partial_selection_translation(bond, in_movement_delta)
-		related_multimesh.update_particle_transform(particle_id.bond_id, bond_transform)
-	update_segments_if_needed()
-
-
-
 func apply_theme(in_theme: Theme3D) -> void:
 	var old_order_1_material: ShaderMaterial = _material_bond_1
 	var old_order_2_material: ShaderMaterial = _material_bond_2

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/stick_representation.gd
@@ -450,9 +450,10 @@ func refresh_all() -> void:
 	_refresh_bond_partial_influence_status(related_structure.get_valid_bonds())
 
 
-func _apply_scale_factor(_new_scale_factor: float) -> void:
-	assert(false, "this method should be overwritten")
-	return
+func _apply_scale_factor(new_scale_factor: float) -> void:
+	_material_bond_1.set_atom_scale(new_scale_factor)
+	_material_bond_2.set_atom_scale(new_scale_factor)
+	_material_bond_3.set_atom_scale(new_scale_factor)
 
 
 func clear() -> void:
@@ -642,11 +643,21 @@ func refresh_bond_influence(in_partially_selected_bonds: PackedInt32Array) -> vo
 	_refresh_bond_partial_influence_status(bonds_to_refresh.keys())
 
 
-func rotate_atom_selection_around_point(_in_point: Vector3, _in_rotation_to_apply: Basis) -> void:
-	# TODO: CapsuleStickRepresentation and CylinderStickRepresentation most probably will be able to
-	# share this when CapsuleStickRepresentation movement will be moved on the GPU
-	assert(false, "Should be overwritten")
-	return
+func rotate_atom_selection_around_point(in_point: Vector3, in_rotation_to_apply: Basis) -> void:
+	_material_bond_1.set_gizmo_origin(in_point)
+	_material_bond_2.set_gizmo_origin(in_point)
+	_material_bond_3.set_gizmo_origin(in_point)
+	_material_bond_1.set_gizmo_rotation(in_rotation_to_apply)
+	_material_bond_2.set_gizmo_rotation(in_rotation_to_apply)
+	_material_bond_3.set_gizmo_rotation(in_rotation_to_apply)
+	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+	for bond_id: int in _current_bond_partial_selection:
+		var bond: Vector3i = related_nanostructure.get_bond(bond_id)
+		var particle_id: ParticleID = _bond_id_to_particle_id[bond_id]
+		var related_multimesh: SegmentedMultimesh = _bond_order_to_segmented_multimesh[particle_id.bond_order]
+		var bond_transform: Transform3D = _calculate_partial_selection_transform(bond, in_point, in_rotation_to_apply)
+		related_multimesh.update_particle_transform(particle_id.bond_id, bond_transform)
+	update_segments_if_needed()
 
 
 func _calculate_partial_selection_transform(in_bond: Vector3i, in_rotation_point: Vector3, in_rotation_to_apply: Basis) -> Transform3D:
@@ -680,11 +691,18 @@ func _calculate_partial_selection_transform(in_bond: Vector3i, in_rotation_point
 	return _particle_transform
 
 
-func set_atom_selection_position_delta(_in_movement_delta: Vector3) -> void:
-	# TODO: CapsuleStickRepresentation and CylinderStickRepresentation most probably will be able to
-	# share this when CapsuleStickRepresentation movement will be moved on the GPU
-	assert(false, ClassUtils.ABSTRACT_FUNCTION_MSG)
-	return
+func set_atom_selection_position_delta(in_movement_delta: Vector3) -> void:
+	_material_bond_1.set_selection_delta(in_movement_delta)
+	_material_bond_2.set_selection_delta(in_movement_delta)
+	_material_bond_3.set_selection_delta(in_movement_delta)
+	var related_nanostructure: NanoStructure = _workspace_context.workspace.get_structure_by_int_guid(_related_structure_id)
+	for bond_id: int in _current_bond_partial_selection:
+		var bond: Vector3i = related_nanostructure.get_bond(bond_id)
+		var particle_id: ParticleID = _bond_id_to_particle_id[bond_id]
+		var related_multimesh: SegmentedMultimesh = _bond_order_to_segmented_multimesh[particle_id.bond_order]
+		var bond_transform: Transform3D = _calculate_partial_selection_translation(bond, in_movement_delta)
+		related_multimesh.update_particle_transform(particle_id.bond_id, bond_transform)
+	update_segments_if_needed()
 
 
 func _calculate_partial_selection_translation(in_bond: Vector3i, in_delta_translation: Vector3) -> Transform3D:


### PR DESCRIPTION
Card: BUG: Sticks representation not affected by transform gizmo

---

Cylinder and Capsule stick now share the same implementation for gpu movement, and the capsule shader was cleaned up.