### PR TITLE
Create undo step when showing/hiding hydrogens from ring menu

### DIFF
--- a/godot_project/editor/ring_menu_levels/view_menu/ring_action_show_hydrogens.gd
+++ b/godot_project/editor/ring_menu_levels/view_menu/ring_action_show_hydrogens.gd
@@ -28,6 +28,7 @@ func _execute_action() -> void:
 		_workspace_context.disable_hydrogens_visualization(true)
 	else:
 		_workspace_context.enable_hydrogens_visualization(false)
+	_workspace_context.snapshot_moment("Change Hydrogen Visibility")
 	_ring_menu.close()
 
 


### PR DESCRIPTION
Task: BUG: Running "Show/Hide hydrogens" from ring menu doesn't create an undo step
