### PR TITLE
Improvements to VisualMenu

### DIFF
--- a/godot_project/editor/controls/menu_bar/visual_main_menu.tscn
+++ b/godot_project/editor/controls/menu_bar/visual_main_menu.tscn
@@ -18,22 +18,24 @@ corner_detail = 5
 
 [node name="VisualMainMenu" type="PopupPanel"]
 own_world_3d = true
-transparent_bg = true
 size = Vector2i(300, 500)
 visible = true
 unresizable = false
-transparent = true
 min_size = Vector2i(250, 300)
 theme_override_styles/panel = SubResource("StyleBoxFlat_1oi6j")
 script = ExtResource("1_3tn00")
 
 [node name="VisualMenuContent" parent="." instance=ExtResource("1_7tjgu")]
+offset_right = 300.0
+offset_bottom = 500.0
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_right = 300.0
+offset_bottom = 500.0
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2

--- a/godot_project/editor/controls/menu_bar/visual_menu_content.gd
+++ b/godot_project/editor/controls/menu_bar/visual_menu_content.gd
@@ -72,6 +72,8 @@ func _add_menu_bar_path(in_menu: PopupMenu, in_path: String) -> void:
 
 func _on_visibility_changed() -> void:
 	_update_if_visible()
+	if is_visible_in_tree():
+		_line_edit_filter.grab_focus()
 
 func _update_if_visible() -> void:
 	if is_visible_in_tree():

--- a/godot_project/editor/controls/workspace_view/WorkspaceMainView.tscn
+++ b/godot_project/editor/controls/workspace_view/WorkspaceMainView.tscn
@@ -120,10 +120,10 @@ offset_right = 228.0
 unique_name_in_owner = true
 visible = true
 layout_mode = 0
-offset_left = 37.0
-offset_top = 32.0
-offset_right = 85.0
-offset_bottom = 80.0
+offset_left = 29.0
+offset_top = 36.0
+offset_right = 77.0
+offset_bottom = 84.0
 
 [node name="ToggleRingMenuButton" parent="EditorViewportContainer/MainSplit/SecondarySplit/WorkspaceToolsContainer" instance=ExtResource("9_e0lvo")]
 unique_name_in_owner = true

--- a/godot_project/editor/controls/workspace_view/controls/toggle_visual_menu_button.tscn
+++ b/godot_project/editor/controls/workspace_view/controls/toggle_visual_menu_button.tscn
@@ -1,7 +1,18 @@
-[gd_scene load_steps=3 format=3 uid="uid://d1xhpp3gtirdv"]
+[gd_scene load_steps=4 format=3 uid="uid://d1xhpp3gtirdv"]
 
 [ext_resource type="Texture2D" uid="uid://cotufr7dod2qc" path="res://editor/icons/icon_hamburguer_b.svg" id="1_3kdb4"]
 [ext_resource type="Script" uid="uid://b736viaoht22m" path="res://editor/controls/workspace_view/controls/toggle_visual_menu_button.gd" id="2_1kujs"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_omoo0"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+bg_color = Color(0.501961, 0.501961, 0.501961, 0.470588)
+corner_radius_top_left = 999
+corner_radius_top_right = 999
+corner_radius_bottom_right = 999
+corner_radius_bottom_left = 999
 
 [node name="ToggleVisualMenuButton" type="Button"]
 visible = false
@@ -10,9 +21,13 @@ offset_top = 33.0
 offset_right = 74.0
 offset_bottom = 81.0
 focus_mode = 0
+theme_override_colors/icon_pressed_color = Color(1, 1, 1, 1)
+theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_omoo0")
+theme_override_styles/hover = SubResource("StyleBoxFlat_omoo0")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_omoo0")
+theme_override_styles/normal = SubResource("StyleBoxFlat_omoo0")
 action_mode = 0
 icon = ExtResource("1_3kdb4")
-flat = true
 icon_alignment = 1
 expand_icon = true
 script = ExtResource("2_1kujs")


### PR DESCRIPTION
- Now has a translucent gray background, making it visible in bright background
- when clicking it for the second time to hide menu it no longer changes color to cyan
- As soon as menu appears, filter line edit grabs keyboard focus to start typing

Task: BUG: Visual Menu button not visible in bright background

<img width="363" height="297" alt="image" src="https://github.com/user-attachments/assets/e313eaa2-ff27-4691-8a1b-d14867de48af" />
