### PR TITLE
Dont 'leak' mouse scroll events from the Alert Panel

### DIFF
--- a/godot_project/editor/controls/workspace_view/controls/alerts_panel/alerts_panel.tscn
+++ b/godot_project/editor/controls/workspace_view/controls/alerts_panel/alerts_panel.tscn
@@ -14,6 +14,7 @@ shader = ExtResource("1_15atc")
 material = SubResource("ShaderMaterial_tuc5w")
 size_flags_horizontal = 3
 size_flags_vertical = 3
+mouse_force_pass_scroll_events = false
 theme_type_variation = &"BlurryPanel"
 script = ExtResource("2_se7m7")
 


### PR DESCRIPTION
Task: UX: Scrolling with the mouse wheel in the alert panel makes the camera move when you "overshoot" the scrollbar