### PR TITLE
Attempt to generate more consistent Oriented Bounding Boxes from circle-shaped atom groups

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/align_selection_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/align_selection_panel.gd
@@ -44,8 +44,8 @@ func _ensure_workspace_initialized(in_workspace_context: WorkspaceContext) -> vo
 	_workspace_context = in_workspace_context
 	_align_selection_parameters = in_workspace_context.align_selection_parameters
 	_align_selection_parameters.align_relative_to_changed.connect(_on_align_relative_to_changed)
+	_workspace_context.history_changed.connect(_on_workspace_context_history_changed)
 	visibility_changed.connect(_on_visibility_changed)
-
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_SCENE_INSTANTIATED:
@@ -82,7 +82,11 @@ func _notification(what: int) -> void:
 
 
 func _on_align_relative_to_changed() -> void:
-	_update_ui()
+	ScriptUtils.call_deferred_once(_update_ui)
+
+
+func _on_workspace_context_history_changed() -> void:
+	ScriptUtils.call_deferred_once(_update_ui)
 
 
 func _on_visibility_changed() -> void:
@@ -113,8 +117,8 @@ var _last_alignable_boxes: Array[AlignableOBB] = []
 func _update_tree() -> void:
 	var alignable_boxes: Array[AlignableOBB] = _align_selection_parameters.get_alignable_boxes()
 	if alignable_boxes == _last_alignable_boxes:
-		_refresh_tree_items()
-		# No need to update
+		if not _last_alignable_boxes.is_empty():
+			_refresh_tree_items()
 		return
 	_last_alignable_boxes = alignable_boxes
 	const COL_0 = 0

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -647,9 +647,20 @@ func _get_obb_from_point_cloud(in_positions: Array[Vector3], in_source: Dictiona
 	
 	# If Y is also derivable, re-derive it too for full orthonormality
 	var axis_y := axis_z.cross(axis_x).normalized()
-
+	
 	basis = Basis(axis_x, axis_y, axis_z)
+	
+	const SQUARE_THRESSHOLD = 0.05
+	if abs(size.x - size.y) < SQUARE_THRESSHOLD:
+		# Surface is a square, therefore can be rotated arbitrarily
+		# Align the box to the Y world axis
+		var target_up: Vector3 = Plane(axis_z, 0).project(Vector3.UP).normalized()
+		if target_up != Vector3.ZERO:
+			var angle: float = axis_y.signed_angle_to(target_up, axis_z)
+			basis = basis.rotated(axis_z, angle)
+	
 	axes = [basis[0], basis[1], basis[2]]
+		
 
 	# 8. With handiness corrected, this breaks extents, so need to recalculate them
 	min_extents = Vector3.INF


### PR DESCRIPTION
- NOTE: This will not generate the expected box from a Plane covered with atoms. However the result seems to be better than the one created before

Task: UX: Atoms arranged in a circle shape generates an OBB with very arvitrary rotation

|Before|After|
|--|--|
|<img width="1730" height="819" alt="image" src="https://github.com/user-attachments/assets/a2dcfcd0-532a-4255-bd2d-81845d2f5790" />|<img width="1730" height="819" alt="image" src="https://github.com/user-attachments/assets/74c736f0-ba05-4ae2-aa89-60317c8c4b02" />|
|<img width="1730" height="819" alt="image" src="https://github.com/user-attachments/assets/ab878efe-e577-4fcf-ad47-2f0cb1416f2f" />|<img width="1730" height="819" alt="image" src="https://github.com/user-attachments/assets/af939bf2-5435-42c8-b124-41fbf3a4dad6" />|