### PR TITLE
Fix a crash when opening the quick action menu

### DIFF
--- a/godot_project/editor/ring_menu_levels/select_menu/ring_action_align_selection.gd
+++ b/godot_project/editor/ring_menu_levels/select_menu/ring_action_align_selection.gd
@@ -1,3 +1,4 @@
+class_name RingActionAlignSelection
 extends RingMenuAction
 
 const RingMenuSpriteIconScn = preload("res://editor/controls/ring_menu/ring_menu_icon/ring_menu_sprite_icon/ring_menu_sprite_icon.tscn")

--- a/godot_project/editor/ring_menu_levels/select_menu/ring_level_select_menu.gd
+++ b/godot_project/editor/ring_menu_levels/select_menu/ring_level_select_menu.gd
@@ -20,4 +20,4 @@ func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> voi
 	add_action(_workspace_context.action_select_connected)
 	add_action(_workspace_context.action_grow_selection)
 	add_action(_workspace_context.action_shrink_selection)
-	add_action(load("uid://ct1lyvgg2b25q").new(_workspace_context, _ring_menu))
+	add_action(RingActionAlignSelection.new(_workspace_context, _ring_menu))


### PR DESCRIPTION
Not sure if this is a local environment error or if it happens elsewhere.
But not using the UID at least makes it obvious what action is been loaded.