### PR TITLE
Fix infinite loop caused by malformed obb

### DIFF
--- a/godot_project/project_workspace/workspace_context/alignable_oriented_bounding_box.gd
+++ b/godot_project/project_workspace/workspace_context/alignable_oriented_bounding_box.gd
@@ -56,8 +56,14 @@ func advance_align_to_face(dir: int) -> void:
 		advance_align_to_face(dir)
 
 
+## At least 2 of the 3 size dimensions needs to be greater than 0 for the
+## box to have a valid surface.
 func has_alignable_face() -> bool:
-	return box.has_surface()
+	var zero_length_count: int = 0
+	for i in 3:
+		if is_zero_approx(box.size[i]):
+			zero_length_count += 1
+	return zero_length_count <= 1
 
 
 func has_face(box_face: BoxFace) -> bool:
@@ -238,6 +244,3 @@ func align_position_to(reference_obb: AlignableOBB) -> bool:
 			something_changed = true
 	
 	return something_changed
-
-
-


### PR DESCRIPTION
Card: BUG: selecting exactly two atoms causes an infinite loop when the align panel is open

---

`AABB.has_surface()` only checks if at least one of the three size component is greater than 0. But if there's only one, it's a line, not a face. Not sure if it's worth notifying upstream.