### PR TITLE
Align Selection Panel: Update UI when the panel becomes visible

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/align_selection_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/align_selection_panel.gd
@@ -40,8 +40,6 @@ static var _empty_texture := AtlasTexture.new() # Behaves as a 0x0 texture
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:
 	_ensure_workspace_initialized(in_workspace_context)
-	if _align_selection_parameters.can_align_selection():
-		_update_ui()
 	return _align_selection_parameters.can_align_selection()
 
 
@@ -98,6 +96,8 @@ func _on_workspace_context_history_changed() -> void:
 
 func _on_visibility_changed() -> void:
 	_align_selection_parameters.set_alignment_tools_enabled(is_visible_in_tree())
+	if is_visible_in_tree():
+		ScriptUtils.call_deferred_once(_update_tree)
 
 
 func _update_ui() -> void:


### PR DESCRIPTION
Task: BUG: Changes in selection while Align Seleciton Panel is invisible are ignored, showing an outdated the lsit of selected items