### PR TITLE
Dont focus in Alignable Objects list

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/align_selection_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/align_selection_panel.tscn
@@ -30,6 +30,7 @@ theme_type_variation = &"SubcategoryPanel"
 [node name="AlignableBoxesTree" type="Tree" parent="PanelContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+focus_mode = 0
 columns = 2
 column_titles_visible = true
 allow_search = false


### PR DESCRIPTION
Task: BUG - Arrow keys no longer function after clicking on anything in the alignment panel.