### PR TITLE
Fix malformed OBB when subdividing selection in molecules

### DIFF
--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -867,12 +867,12 @@ func _subdivide_molecules(in_atoms: PackedInt32Array) -> Array[PackedInt32Array]
 				var pos_in_queue: int = remaining_atoms.find(atom_id)
 				if pos_in_queue != -1:
 					remaining_atoms.remove_at(pos_in_queue)
-				mol.append(atom_id)
-				for bond_id: int in atomic_structure.atom_get_bonds(atom_id):
-					var other_atom: int = atomic_structure.atom_get_bond_target(atom_id, bond_id)
-					if visited.get(other_atom, false) == true:
-						continue
-					next_round.append(other_atom)
+					mol.append(atom_id)
+					for bond_id: int in atomic_structure.atom_get_bonds(atom_id):
+						var other_atom: int = atomic_structure.atom_get_bond_target(atom_id, bond_id)
+						if visited.get(other_atom, false) == true:
+							continue
+						next_round.append(other_atom)
 	return molecules
 
 func get_selection_snapshot() -> Dictionary:


### PR DESCRIPTION
Task: BUG: Inner shaft of small bearing generates a missaligned OBB when grouping by molecules

|Before|After|
|--|--|
|<img width="1730" height="819" alt="image" src="https://github.com/user-attachments/assets/2d84f262-a988-4e92-aa1c-c1bb1d48b51e" />|<img width="1730" height="819" alt="image" src="https://github.com/user-attachments/assets/1218fe15-d211-4ec7-9800-04d13607eaf2" />|
