### PR TITLE
Center the alignment planes on the box

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/advanced_align_settings_popup.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/advanced_align_settings_popup.tscn
@@ -25,7 +25,7 @@
 
 [node name="AdvancedAlignSettingsPopup" type="PopupPanel"]
 auto_translate_mode = 1
-size = Vector2i(210, 273)
+size = Vector2i(210, 277)
 visible = true
 script = ExtResource("1_ov5gt")
 
@@ -285,11 +285,12 @@ prefix = "Vertical:    "
 suffix = "%"
 custom_arrow_step = 5.0
 
-[node name="DCustomSpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer"]
+[node name="DCustomSpinBox" parent="MarginContainer/VBoxContainer" instance=ExtResource("10_ogeke")]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = -100.0
-step = 0.0
-value = -100.0
+step = 0.1
+allow_greater = true
+allow_lesser = true
 prefix = "Depth:      "
 suffix = "%"

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/align_selection_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/align_selection_panel.gd
@@ -244,12 +244,9 @@ func _on_alignable_boxes_tree_button_clicked(item: TreeItem, _column: int, id: i
 func _get_box_face_icon(selected_face: BoxFace) -> Texture2D:
 	const ICONS: Dictionary[BoxFace, Texture2D] = {
 		BoxFace.UNDEFINED : preload("uid://dr6k8q285dgls"),
-		BoxFace.FRONT  : preload("uid://d16yxekfb4k3h"),
-		BoxFace.BACK   : preload("uid://0vpkfnqii60i"),
-		BoxFace.TOP    : preload("uid://de1hnqihu4ugw"),
-		BoxFace.BOTTOM : preload("uid://b8qwlg7asmnsf"),
-		BoxFace.LEFT   : preload("uid://deu8o23ue70ft"),
-		BoxFace.RIGHT  : preload("uid://c01w40g4dq4eg"),
+		BoxFace.XY : preload("uid://d16yxekfb4k3h"),
+		BoxFace.XZ : preload("uid://de1hnqihu4ugw"),
+		BoxFace.YZ : preload("uid://c01w40g4dq4eg"),
 	}
 	return ICONS[selected_face]
 

--- a/godot_project/editor/rendering/align_selection_preview/align_selection_preview.gd
+++ b/godot_project/editor/rendering/align_selection_preview/align_selection_preview.gd
@@ -86,15 +86,6 @@ func _process(_delta: float) -> void:
 
 
 func _draw() -> void:
-	const OPPOSITE_FACE: Dictionary[BoxFace, BoxFace] = {
-		BoxFace.UNDEFINED: BoxFace.UNDEFINED,
-		BoxFace.FRONT: BoxFace.BACK,
-		BoxFace.BACK: BoxFace.FRONT,
-		BoxFace.TOP: BoxFace.BOTTOM,
-		BoxFace.BOTTOM: BoxFace.TOP,
-		BoxFace.LEFT: BoxFace.RIGHT,
-		BoxFace.RIGHT: BoxFace.LEFT,
-	}
 	if not is_processing() or _align_selection_parameters == null:
 		return
 	
@@ -104,13 +95,9 @@ func _draw() -> void:
 		if obb == null or obb == highlighted_obb:
 			continue
 		_draw_obb_face(obb, obb.selected_face, false, true)
-		if _align_selection_parameters.is_align_depth_enabled():
-			_draw_obb_face(obb, OPPOSITE_FACE[obb.selected_face], false, false)
 		_draw_obb_reference_point(obb, obb.selected_face, false)
 		_draw_transform(obb.transform, obb.box.size * 0.25, false)
 	if highlighted_obb != null:
-		if _align_selection_parameters.is_align_depth_enabled():
-			_draw_obb_face(highlighted_obb, OPPOSITE_FACE[highlighted_obb.align_to_face], false)
 		_draw_obb_face(highlighted_obb, highlighted_obb.align_to_face, true)
 		_draw_obb_reference_point(highlighted_obb, highlighted_obb.align_to_face, true)
 
@@ -137,23 +124,9 @@ func _draw_transform(t: Transform3D, handle_size: Vector3, is_highlighted_face: 
 func _draw_obb_face(in_obb: AlignableOBB, in_face: BoxFace, in_highlighted: bool = false, in_filled: bool = in_highlighted) -> void:
 	if in_obb == null or in_face == BoxFace.UNDEFINED:
 		return
-	
-	var face_corners: PackedVector3Array
-	match in_face:
-		BoxFace.TOP:
-			face_corners = in_obb.get_face_corners(Vector3.UP)
-		BoxFace.BOTTOM:
-			face_corners = in_obb.get_face_corners(Vector3.DOWN)
-		BoxFace.FRONT:
-			face_corners = in_obb.get_face_corners(Vector3.BACK)
-		BoxFace.BACK:
-			face_corners = in_obb.get_face_corners(Vector3.FORWARD)
-		BoxFace.LEFT:
-			face_corners = in_obb.get_face_corners(Vector3.LEFT)
-		BoxFace.RIGHT:
-			face_corners = in_obb.get_face_corners(Vector3.RIGHT)
-		
 	# Draw half transparent face
+	var align_depth: bool = _align_selection_parameters.is_align_depth_enabled()
+	var face_corners: PackedVector3Array = in_obb.get_face_corners(in_face, align_depth)
 	var polygon := PackedVector2Array()
 	var uvs := PackedVector2Array()
 	for corner: Vector3 in face_corners:
@@ -195,9 +168,6 @@ func _draw_obb_reference_point(in_obb: AlignableOBB, in_face: BoxFace, in_highli
 			no_depth_ref_point = ref_point
 			if _align_selection_parameters.is_align_depth_enabled():
 				ref_point += basis.z * (in_obb.offset_ratio_d * face_size.z)
-			else:
-				ref_point += basis.z * (face_size.z * 0.5)
-				
 		var line_size: float = 0.01
 		var camera: Camera3D = get_viewport().get_camera_3d()
 		if camera.projection == Camera3D.ProjectionType.PROJECTION_PERSPECTIVE:

--- a/godot_project/project_workspace/workspace_context/align_selection_parameters.gd
+++ b/godot_project/project_workspace/workspace_context/align_selection_parameters.gd
@@ -193,17 +193,6 @@ func set_align_depth_enabled(in_enabled: bool) -> void:
 	if in_enabled == _align_depth_enabled:
 		return
 	_align_depth_enabled = in_enabled
-	if in_enabled == true:
-		# Some of the selectable faces gets removed
-		# Make sure faces selection are valid
-		for box: AlignableOBB in get_alignable_boxes():
-			const INVALID_TO_VALID_FACE: Dictionary[BoxFace, BoxFace] = {
-				BoxFace.BACK : BoxFace.FRONT,
-				BoxFace.BOTTOM : BoxFace.TOP,
-				BoxFace.LEFT : BoxFace.RIGHT,
-			}
-			box.align_to_face = INVALID_TO_VALID_FACE.get(box.align_to_face, box.align_to_face)
-			box.selected_face = INVALID_TO_VALID_FACE.get(box.selected_face, box.selected_face)
 	request_redraw_preview()
 
 
@@ -227,8 +216,8 @@ func set_specific_obb(out_box: AlignableOBB) -> void:
 	if _align_to_box_index != id:
 		_align_to_box_index = id
 		if out_box.selected_face == BoxFace.UNDEFINED:
-			out_box.align_to_face = BoxFace.FRONT
-			if not out_box.has_face(BoxFace.FRONT):
+			out_box.align_to_face = BoxFace.XY
+			if not out_box.has_face(BoxFace.XY):
 				out_box.advance_align_to_face(1)
 		else:
 			out_box.align_to_face = out_box.selected_face

--- a/godot_project/project_workspace/workspace_context/alignable_oriented_bounding_box.gd
+++ b/godot_project/project_workspace/workspace_context/alignable_oriented_bounding_box.gd
@@ -2,19 +2,17 @@ class_name AlignableOBB
 extends OBB
 
 
+## Each indices matches the plane's normal index (X -> 0, Y -> 1, Z -> 2)
 enum BoxFace {
 	UNDEFINED = -1,
-	FRONT  = 0,
-	BACK   = 1,
-	TOP    = 2,
-	BOTTOM = 3,
-	LEFT   = 4,
-	RIGHT  = 5,
+	YZ = 0,
+	XZ = 1,
+	XY = 2,
 }
 
 
 var selected_face := BoxFace.UNDEFINED
-var align_to_face := BoxFace.FRONT
+var align_to_face := BoxFace.YZ
 var align_to_center_of_mass: bool = true
 var offset_ratio_h: float = 0.0
 var offset_ratio_v: float = 0.0
@@ -28,7 +26,7 @@ var description: String:
 		assert(_initialized == false, "Value cannot be changed upon creation")
 		description = v
 
-
+var _local_center_of_mass: Vector3
 var _params: AlignSelectionParameters
 
 
@@ -47,6 +45,7 @@ func _init(
 	super._init(in_size, in_transform,in_source)
 	_initialized = false
 	world_center_of_mass = _calculate_center_of_mass_from_source()
+	_local_center_of_mass = transform.affine_inverse() * world_center_of_mass
 	_params = in_align_parameters
 	if not has_face(align_to_face):
 		advance_align_to_face(1)
@@ -112,30 +111,55 @@ func get_alignable_faces() -> Array[BoxFace]:
 	match zero_len_axes_count:
 		3:
 			# Empty box, align to an arbitrary face (front)
-			return [BoxFace.FRONT]
+			return [BoxFace.YZ]
 		2:
 			# A straight line, likely 2 atoms, this would make 2 faces valid, but we only send one
 			match non_zero_len_axes[0]: # The only axis with size
 				Vector3.AXIS_X:
-					return [BoxFace.FRONT]
+					return [BoxFace.XY]
 				Vector3.AXIS_Y:
-					return [BoxFace.FRONT]
+					return [BoxFace.XY]
 				Vector3.AXIS_Z:
-					return [BoxFace.TOP]
+					return [BoxFace.XZ]
 		1:
 			match non_zero_len_axes: # box is a plane, only 1 face is needed
 				[Vector3.AXIS_X, Vector3.AXIS_Y]:
-					return [BoxFace.FRONT]
+					return [BoxFace.XY]
 				[Vector3.AXIS_X, Vector3.AXIS_Z]:
-					return [BoxFace.TOP]
+					return [BoxFace.XZ]
 				[Vector3.AXIS_Y, Vector3.AXIS_Z]:
-					return [BoxFace.LEFT]
+					return [BoxFace.YZ]
 		_:
 			pass # default
-	if _params.is_align_depth_enabled():
-		# We dont need the secondary side of each main face
-		return [BoxFace.FRONT, BoxFace.TOP, BoxFace.RIGHT]
-	return [BoxFace.FRONT, BoxFace.BACK, BoxFace.TOP, BoxFace.BOTTOM, BoxFace.LEFT, BoxFace.RIGHT]
+
+	return [BoxFace.XY, BoxFace.XZ, BoxFace.YZ]
+
+
+func get_face_corners(face: BoxFace, depth_enabled: bool = false) -> PackedVector3Array:
+	var corners: Array[Vector3]
+	var offset: Vector3 = Vector3.ZERO
+	match face:
+		BoxFace.XZ:
+			corners = [Vector3(-1, 0, 1), Vector3(1, 0, 1), Vector3(1, 0, -1), Vector3(-1, 0, -1)]
+			offset = Vector3.UP
+		BoxFace.XY:
+			corners = [Vector3(-1, 1, 0), Vector3(1, 1, 0), Vector3(1, -1, 0), Vector3(-1, -1, 0)]
+			offset = Vector3.BACK
+		BoxFace.YZ:
+			corners = [Vector3(0, 1, 1), Vector3(0, 1, -1), Vector3(0, -1, -1), Vector3(0, -1, 1)]
+			offset = Vector3.RIGHT
+	if align_to_center_of_mass:
+		offset *= _local_center_of_mass
+	elif depth_enabled:
+		offset *= box.size * offset_ratio_d
+	else:
+		offset = Vector3.ZERO
+	var result := PackedVector3Array()
+	var half_size: Vector3 = box.size * .5
+	for local_point in corners:
+		result.push_back(transform * (local_point * half_size + offset))
+	return result
+
 
 ## At least 2 of the 3 size dimensions needs to be greater than 0 for the
 ## box to have a valid surface.
@@ -153,37 +177,16 @@ func has_face(box_face: BoxFace) -> bool:
 
 func get_face_basis(in_face: BoxFace) -> Basis:
 	match in_face:
-		BoxFace.FRONT:
+		BoxFace.XY:
 			return transform.basis.orthonormalized()
-		BoxFace.BACK:
-			var basis: Basis = transform.basis.orthonormalized()
-			return Basis(
-				-basis[0],
-				basis[1],
-				-basis[2],
-			)
-		BoxFace.TOP:
+		BoxFace.XZ:
 			var basis: Basis = transform.basis.orthonormalized()
 			return Basis(
 				basis[0],
 				-basis[2],
 				basis[1],
 			)
-		BoxFace.BOTTOM:
-			var basis: Basis = transform.basis.orthonormalized()
-			return Basis(
-				basis[0],
-				basis[2],
-				-basis[1],
-			)
-		BoxFace.LEFT:
-			var basis: Basis = transform.basis.orthonormalized()
-			return Basis(
-				-basis[2],
-				basis[1],
-				-basis[0],
-			)
-		BoxFace.RIGHT:
+		BoxFace.YZ:
 			var basis: Basis = transform.basis.orthonormalized()
 			return Basis(
 				basis[2],
@@ -197,11 +200,11 @@ func get_face_basis(in_face: BoxFace) -> Basis:
 ## Returns the width and heigth of the face as X and Y components, and the depth of the box in the Z
 func get_face_size(in_face: BoxFace) -> Vector3:
 	match in_face:
-		BoxFace.FRONT, BoxFace.BACK:
+		BoxFace.XY:
 			return Vector3(box.size.x, box.size.y, box.size.z)
-		BoxFace.TOP, BoxFace.BOTTOM:
+		BoxFace.XZ:
 			return Vector3(box.size.x, box.size.z, box.size.y)
-		BoxFace.LEFT, BoxFace.RIGHT:
+		BoxFace.YZ:
 			return Vector3(box.size.z, box.size.y, box.size.x)
 	return Vector3()
 
@@ -212,7 +215,6 @@ func align_rotation_to_box(in_box: AlignableOBB) -> bool:
 	if in_box == self:
 		return false
 	return align_rotation_to_basis(in_box.get_face_basis(in_box.align_to_face))
-	
 
 
 func align_rotation_to_basis(in_basis: Basis) -> bool:

--- a/godot_project/project_workspace/workspace_context/oriented_bounding_box.gd
+++ b/godot_project/project_workspace/workspace_context/oriented_bounding_box.gd
@@ -26,37 +26,3 @@ func _init(in_size: Vector3, in_transform: Transform3D, in_source: Dictionary[St
 	point_cloud_source.make_read_only()
 	transform = in_transform
 	_initialized = true
-
-
-func get_face_corners(face_normal: Vector3) -> PackedVector3Array:
-	const C := [
-		Vector3(-1, 1, -1), # 0 Top Front Left
-		Vector3(1, 1, -1), # 1 Top Front right
-		Vector3(1, 1, 1), # 2 Top Back Right
-		Vector3(-1, 1, 1), # 3 Top Back Left
-		Vector3(-1, -1, -1), # 4 Bottom Front Left
-		Vector3(1, -1, -1), # 5 Bottom Front Right
-		Vector3(1, -1, 1), # 6 Bottom Back Right
-		Vector3(-1, -1, 1), # 7 Bottom Back Left
-	]
-	var corners: Array[Vector3]
-	match face_normal:
-		Vector3.UP:
-			corners = [C[0], C[1], C[2], C[3]]
-		Vector3.DOWN:
-			corners = [C[4], C[5], C[6], C[7]]
-		Vector3.FORWARD:
-			corners = [C[0], C[1], C[5], C[4]]
-		Vector3.BACK:
-			corners = [C[3], C[2], C[6], C[7]]
-		Vector3.LEFT:
-			corners = [C[0], C[3], C[7], C[4]]
-		Vector3.RIGHT:
-			corners = [C[1], C[2], C[6], C[5]]
-	
-	var result := PackedVector3Array()
-	var half_size: Vector3 = box.size * .5
-	for local_point in corners:
-		result.push_back(transform * (local_point * half_size))
-	
-	return result


### PR DESCRIPTION
Card: Alignment planes should appear once (no longer like boxes), and should be placed passing through the center of mass

---

Changes:

+ Keep 3 alignment planes (instead of all 6 faces of the box, opposite faces are removed)
+ The active alignment plane follows the align depth / center of mass properties
<img width="509" height="422" alt="image" src="https://github.com/user-attachments/assets/7310f253-ac05-4739-bf7d-55c7cb29da75" />
 
+ The advanced depth slider is now a CustomSpinBox for feature parity with the horizontal and vertical sliders
<img width="199" height="171" alt="image" src="https://github.com/user-attachments/assets/595d6b8c-7ed1-4004-8b91-e37e9c506ec3" />
 