### PR TITLE
Move new and load buttons at the top of the welcome page

### DIFF
--- a/godot_project/editor/controls/welcome_page/welcome_page.gd
+++ b/godot_project/editor/controls/welcome_page/welcome_page.gd
@@ -25,8 +25,6 @@ func _update_workspaces_list() -> void:
 	if !is_visible_in_tree():
 		return
 	for child in known_workspaces_box.get_children():
-		if child in [new_workspace, load_workspace_from_disk]:
-			continue
 		child.queue_free()
 	var d: DirAccess = DirAccess.open("user://")
 	var workspace_to_activate: Workspace = null
@@ -60,8 +58,7 @@ func _update_workspaces_list() -> void:
 			if not opening_workspace:
 				MolecularEditorContext.create_workspace()
 	_first_run = false
-	known_workspaces_box.move_child(load_workspace_from_disk, known_workspaces_box.get_child_count() - 1)
-	known_workspaces_box.move_child(new_workspace, known_workspaces_box.get_child_count() - 1)
+
 
 func _ensure_settings_exists() -> void:
 	var d: DirAccess = DirAccess.open("user://")

--- a/godot_project/editor/controls/welcome_page/welcome_page.tscn
+++ b/godot_project/editor/controls/welcome_page/welcome_page.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://dnppynbygr3na"]
+[gd_scene load_steps=6 format=3 uid="uid://dnppynbygr3na"]
 
 [ext_resource type="Script" uid="uid://brc5dgewcso0y" path="res://editor/controls/welcome_page/welcome_page.gd" id="1_h6th3"]
 [ext_resource type="PackedScene" uid="uid://dcasl2w72vcie" path="res://editor/controls/welcome_page/controls/load_recent_button.tscn" id="2_b1dtx"]
@@ -7,31 +7,6 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_i26yn"]
 bg_color = Color(0.333333, 0.203922, 0.596078, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7md78"]
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_id6tf"]
-bg_color = Color(0.572038, 0, 0.138905, 1)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8wk80"]
-bg_color = Color(1, 1, 1, 0.341176)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
 
 [node name="WelcomePage" type="Panel"]
 anchors_preset = 15
@@ -79,49 +54,36 @@ theme_override_constants/margin_left = 20
 
 [node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer"]
 layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 70)
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="NewWorkspace" type="Button" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(426, 0)
+layout_mode = 2
+tooltip_text = "Create a new workspace"
+theme_type_variation = &"WelcomeButton"
+text = "New Workspace"
+icon = ExtResource("3_f3hfv")
+
+[node name="LoadWorkspaceFromDisk" type="Button" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(426, 0)
+layout_mode = 2
+tooltip_text = "Load a workspace file from the filesystem"
+theme_type_variation = &"WelcomeButton"
+text = "Load from Disk"
+icon = ExtResource("3_id6tf")
 
 [node name="KnownWorkspacesBox" type="HFlowContainer" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/h_separation = 20
 theme_override_constants/v_separation = 20
-
-[node name="NewWorkspace" type="Button" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer/KnownWorkspacesBox"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(426, 240)
-layout_mode = 2
-tooltip_text = "Create a new workspace"
-theme_override_styles/focus = SubResource("StyleBoxFlat_7md78")
-theme_override_styles/disabled_mirrored = SubResource("StyleBoxFlat_id6tf")
-theme_override_styles/disabled = SubResource("StyleBoxFlat_id6tf")
-theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/hover = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/normal_mirrored = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/normal = SubResource("StyleBoxFlat_8wk80")
-icon = ExtResource("3_f3hfv")
-icon_alignment = 1
-
-[node name="Label" type="Label" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer/KnownWorkspacesBox/NewWorkspace"]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = -1
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -43.0
-offset_right = -10.0
-offset_bottom = -10.0
-grow_horizontal = 2
-grow_vertical = 0
-theme_type_variation = &"HeaderLarge"
-text = "New Workspace"
-autowrap_mode = 1
-text_overrun_behavior = 3
 
 [node name="LoadRecentButton" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer/KnownWorkspacesBox" instance=ExtResource("2_b1dtx")]
 layout_mode = 2
@@ -134,39 +96,3 @@ layout_mode = 2
 
 [node name="LoadRecentButton4" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer/KnownWorkspacesBox" instance=ExtResource("2_b1dtx")]
 layout_mode = 2
-
-[node name="LoadWorkspaceFromDisk" type="Button" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer/KnownWorkspacesBox"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(426, 240)
-layout_mode = 2
-tooltip_text = "Load a workspace file from the filesystem"
-theme_override_styles/focus = SubResource("StyleBoxFlat_7md78")
-theme_override_styles/disabled_mirrored = SubResource("StyleBoxFlat_id6tf")
-theme_override_styles/disabled = SubResource("StyleBoxFlat_id6tf")
-theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/hover = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/normal_mirrored = SubResource("StyleBoxFlat_8wk80")
-theme_override_styles/normal = SubResource("StyleBoxFlat_8wk80")
-icon = ExtResource("3_id6tf")
-icon_alignment = 1
-
-[node name="Label" type="Label" parent="ScrollContainer/HBoxContainer/MainContainer/LinksContainer/VBoxContainer/KnownWorkspacesBox/LoadWorkspaceFromDisk"]
-layout_mode = 1
-anchors_preset = -1
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -43.0
-offset_right = -10.0
-offset_bottom = -10.0
-grow_horizontal = 2
-grow_vertical = 0
-theme_type_variation = &"HeaderLarge"
-text = "Load from Disk"
-autowrap_mode = 1
-text_overrun_behavior = 3

--- a/godot_project/theme/theme.tres
+++ b/godot_project/theme/theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=102 format=3 uid="uid://d3fnr4sbrd6ik"]
+[gd_resource type="Theme" load_steps=106 format=3 uid="uid://d3fnr4sbrd6ik"]
 
 [ext_resource type="FontFile" uid="uid://b3jkav4yxw06w" path="res://theme/Gidole-Regular.ttf" id="1_8indu"]
 [ext_resource type="Texture2D" uid="uid://bh1ju2ymvv1co" path="res://theme/icons/icon_on.svg" id="1_n28s0"]
@@ -975,6 +975,40 @@ content_margin_bottom = 4.0
 color = Color(1, 1, 1, 0.227451)
 vertical = true
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_id6tf"]
+bg_color = Color(0.572038, 0, 0.138905, 1)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7md78"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8wk80"]
+content_margin_left = 20.0
+bg_color = Color(1, 1, 1, 0.392157)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_p4hxb"]
+content_margin_left = 20.0
+bg_color = Color(1, 1, 1, 0.341176)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ruent"]
 content_margin_left = 10.0
 content_margin_top = 4.0
@@ -1263,6 +1297,26 @@ TreeCrystal/colors/font_color = Color(1, 1, 1, 1)
 VBoxContainerLarge/base_type = &"VBoxContainer"
 VBoxContainerLarge/constants/separation = 24
 VSeparator/styles/separator = SubResource("StyleBoxLine_rucdj")
+WelcomeButton/base_type = &"Button"
+WelcomeButton/colors/font_color = Color(0.95, 0.95, 0.95, 1)
+WelcomeButton/colors/font_hover_color = Color(1, 1, 1, 1)
+WelcomeButton/colors/font_pressed_color = Color(1, 1, 1, 1)
+WelcomeButton/colors/icon_hover_color = Color(1, 1, 1, 1)
+WelcomeButton/colors/icon_normal_color = Color(0.95, 0.95, 0.95, 1)
+WelcomeButton/colors/icon_pressed_color = Color(1, 1, 1, 1)
+WelcomeButton/constants/icon_max_width = 48
+WelcomeButton/font_sizes/font_size = 28
+WelcomeButton/styles/disabled = SubResource("StyleBoxFlat_id6tf")
+WelcomeButton/styles/disabled_mirrored = SubResource("StyleBoxFlat_id6tf")
+WelcomeButton/styles/focus = SubResource("StyleBoxFlat_7md78")
+WelcomeButton/styles/hover = SubResource("StyleBoxFlat_8wk80")
+WelcomeButton/styles/hover_mirrored = SubResource("StyleBoxFlat_8wk80")
+WelcomeButton/styles/hover_pressed = SubResource("StyleBoxFlat_p4hxb")
+WelcomeButton/styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_p4hxb")
+WelcomeButton/styles/normal = SubResource("StyleBoxFlat_p4hxb")
+WelcomeButton/styles/normal_mirrored = SubResource("StyleBoxFlat_p4hxb")
+WelcomeButton/styles/pressed = SubResource("StyleBoxFlat_p4hxb")
+WelcomeButton/styles/pressed_mirrored = SubResource("StyleBoxFlat_p4hxb")
 WorkspaceTabBar/base_type = &"TabBar"
 WorkspaceTabBar/styles/tab_disabled = SubResource("StyleBoxFlat_ruent")
 WorkspaceTabBar/styles/tab_focus = SubResource("StyleBoxFlat_wnj71")


### PR DESCRIPTION
Card: UX: Move the new & load buttons at the top of the welcome page


+ Move & Load workspace buttons are smaller, and always at the top
+ Theme overrides were moved in a dedicated Theme Variation

<img width="1446" height="802" alt="image" src="https://github.com/user-attachments/assets/27c2217b-a356-41ac-80e1-fa7b8be23fb1" />
