### PR TITLE
Add an options to trim from Carbon Nanotubes the atoms that would result in an invalid simulation

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_carbon_nanotube.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_carbon_nanotube.gd
@@ -6,6 +6,7 @@ var _m_spin_box_slider: SpinBoxSlider
 var _graphene_latice_preview: GrapheneLatticePreview
 var _diameter_label: Label
 var _circumference_label: Label
+var _trim_invalid_valence_carbons_check_button: CheckButton
 
 
 var _workspace_context: WorkspaceContext
@@ -24,6 +25,9 @@ func _ensure_initialized(in_workspace_context: WorkspaceContext) -> void:
 		_graphene_latice_preview.m = _workspace_context.create_object_parameters.get_nanotube_m_index()
 		_n_spin_box_slider.value = _graphene_latice_preview.n
 		_m_spin_box_slider.value = _graphene_latice_preview.m
+		_trim_invalid_valence_carbons_check_button.set_pressed_no_signal(
+			_workspace_context.create_object_parameters.is_trim_invalid_valence_carbons_enabled()
+		)
 		_update_estimates()
 
 
@@ -34,9 +38,11 @@ func _notification(what: int) -> void:
 		_graphene_latice_preview = %GrapheneLaticePreview as GrapheneLatticePreview
 		_diameter_label = %DiameterLabel as Label
 		_circumference_label = %CircumferenceLabel as Label
+		_trim_invalid_valence_carbons_check_button = %TrimInvalidValenceCarbonsCheckButton as CheckButton
 		
 		_n_spin_box_slider.value_changed.connect(_on_n_spin_box_slider_value_changed)
 		_m_spin_box_slider.value_changed.connect(_on_m_spin_box_slider_value_changed)
+		_trim_invalid_valence_carbons_check_button.toggled.connect(_on_trim_invalid_valence_carbons_check_button_toggled)
 		
 		var create_as_virtual_group_button: Button = %CreateAsVirtualGroupButton as Button
 		create_as_virtual_group_button.toggled.connect(_on_create_as_virtual_group_button_toggled)
@@ -56,6 +62,10 @@ func _on_m_spin_box_slider_value_changed(in_value: int) -> void:
 
 func _on_create_as_virtual_group_button_toggled(in_button_pressed: bool) -> void:
 	_workspace_context.create_object_parameters.set_create_nanotube_as_virtual_group(in_button_pressed)
+
+
+func _on_trim_invalid_valence_carbons_check_button_toggled(in_button_pressed: bool) -> void:
+	_workspace_context.create_object_parameters.set_trim_invalid_valence_carbons_enabled(in_button_pressed)
 
 
 func _update_estimates() -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_carbon_nanotube.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/create_carbon_nanotube.tscn
@@ -82,6 +82,15 @@ layout_mode = 2
 theme_type_variation = &"HeaderSmall"
 text = "1.2 nm"
 
+[node name="Label4" type="Label" parent="VBoxContainer/GridContainer2"]
+layout_mode = 2
+text = "· Trim Atoms with Invalid Valence"
+
+[node name="TrimInvalidValenceCarbonsCheckButton" type="CheckButton" parent="VBoxContainer/GridContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+
 [node name="Label2" type="Label" parent="VBoxContainer"]
 layout_mode = 2
 text = "Create as:"

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_carbon_nanotube.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_carbon_nanotube.gd
@@ -6,6 +6,7 @@ var _m_spin_box_slider: SpinBoxSlider
 var _graphene_latice_preview: GrapheneLatticePreview
 var _diameter_label: Label
 var _circumference_label: Label
+var _trim_invalid_valence_carbons_check_button: CheckButton
 var _length_spin_box_slider: SpinBoxSlider
 var _convert_to_atoms_button: Button
 var _change_representation_button: RichTextLabel
@@ -39,6 +40,7 @@ func _notification(what: int) -> void:
 		_graphene_latice_preview = %GrapheneLaticePreview as GrapheneLatticePreview
 		_diameter_label = %DiameterLabel as Label
 		_circumference_label = %CircumferenceLabel as Label
+		_trim_invalid_valence_carbons_check_button = %TrimInvalidValenceCarbonsCheckButton as CheckButton
 		_length_spin_box_slider = %LengthSpinBoxSlider as SpinBoxSlider
 		_convert_to_atoms_button = %ConvertToAtomsButton as Button
 		_change_representation_button = %ChangeRepresentationButton as RichTextLabel
@@ -47,6 +49,7 @@ func _notification(what: int) -> void:
 		_m_spin_box_slider.value_changed.connect(_on_m_spin_box_slider_value_changed)
 		_n_spin_box_slider.value_confirmed.connect(_on_n_spin_box_slider_value_confirmed)
 		_m_spin_box_slider.value_confirmed.connect(_on_m_spin_box_slider_value_confirmed)
+		_trim_invalid_valence_carbons_check_button.toggled.connect(_on_trim_invalid_valence_carbons_check_button_toggled)
 		_length_spin_box_slider.value_confirmed.connect(_on_length_spin_box_slider_value_confirmed)
 		_convert_to_atoms_button.pressed.connect(_on_convert_to_atoms_button_pressed)
 		_change_representation_button.meta_clicked.connect(_on_change_representation_button_meta_clicked)
@@ -63,6 +66,9 @@ func _set_selected_context(out_nanotube_or_null: CarbonNanotubeStructure) -> voi
 		_graphene_latice_preview.m = _edited_nanotube.get_chiral_index_m()
 		_n_spin_box_slider.set_value_no_signal(_graphene_latice_preview.n)
 		_m_spin_box_slider.set_value_no_signal(_graphene_latice_preview.m)
+		_trim_invalid_valence_carbons_check_button.set_pressed_no_signal(
+			_edited_nanotube.is_trim_invalid_valence_carbons_enabled()
+		)
 		_length_spin_box_slider.set_value_no_signal(_edited_nanotube.get_tube_length())
 		_edited_nanotube.path_changed.connect(_on_edited_nanotube_path_changed.unbind(2))
 		_update_estimates()
@@ -92,6 +98,14 @@ func _on_m_spin_box_slider_value_confirmed(in_value: int) -> void:
 		_edited_nanotube.set_chiral_index_m(in_value)
 		_edited_nanotube.end_edit()
 		_workspace_context.snapshot_moment("Set: Nanotube Chiral Index")
+
+
+func _on_trim_invalid_valence_carbons_check_button_toggled(in_button_pressed: bool) -> void:
+	if _edited_nanotube:
+		_edited_nanotube.start_edit()
+		_edited_nanotube.set_trim_invalid_valence_carbons(in_button_pressed)
+		_edited_nanotube.end_edit()
+		_workspace_context.snapshot_moment("Set: Trim Invalid Valence Atoms")
 
 
 func _on_length_spin_box_slider_value_confirmed(in_value: float) -> void:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_carbon_nanotube.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_carbon_nanotube.tscn
@@ -116,6 +116,15 @@ theme_type_variation = &"HeaderSmall"
 text = "1.2 nm"
 vertical_alignment = 1
 
+[node name="Label5" type="Label" parent="EditorContainer/GridContainer2"]
+layout_mode = 2
+text = "· Trim Atoms with Invalid Valence"
+
+[node name="TrimInvalidValenceCarbonsCheckButton" type="CheckButton" parent="EditorContainer/GridContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+
 [node name="Label4" type="Label" parent="EditorContainer/GridContainer2"]
 layout_mode = 2
 text = "· Length"

--- a/godot_project/editor/input_handlers/molecular_structures/create_nanotube_input_handler.gd
+++ b/godot_project/editor/input_handlers/molecular_structures/create_nanotube_input_handler.gd
@@ -130,10 +130,11 @@ func _create_tube_structure(from_pos: Vector3, to_pos: Vector3) -> void:
 	
 	var n: int = _workspace_context.create_object_parameters.get_nanotube_n_index()
 	var m: int = _workspace_context.create_object_parameters.get_nanotube_m_index()
+	var trim_invalid_valence_carbons: bool = _workspace_context.create_object_parameters.is_trim_invalid_valence_carbons_enabled()
 	var structure_context: StructureContext = _workspace_context.get_current_structure_context()
 	var structure: NanoStructure = structure_context.nano_structure
 	
-	var nanotube := CarbonNanotubeStructure.create_nanotube(n, m, from_pos, to_pos)
+	var nanotube := CarbonNanotubeStructure.create_nanotube(n, m, from_pos, to_pos, trim_invalid_valence_carbons)
 	var obj_name: String = nanotube.get_readable_type()
 	obj_name += " %d" % _workspace_context.workspace.get_structures().size()
 	nanotube.set_structure_name(obj_name)

--- a/godot_project/project_workspace/structs/carbon_nanotube_structure.gd
+++ b/godot_project/project_workspace/structs/carbon_nanotube_structure.gd
@@ -10,12 +10,14 @@ signal chiral_indices_changed(n: int, m: int)
 @export var _chiral_index_m: int
 @export var _position_begin: Vector3
 @export var _position_end: Vector3
+@export var _trim_invalid_valence_carbons: bool = true
 
 
 var _signal_queue_path_changed: bool
 
 var _last_n: int
 var _last_m: int
+var _last_trim_invalid_valence_carbons: bool
 var _basis: CarbonTubuleBasis
 var _template: CarbonTubuleBasis.CrystalCell
 
@@ -33,12 +35,13 @@ static var _unpacked_bond_ids: Dictionary[int, UnpackedBondId]
 var _track_atoms: bool = false
 
 
-static func create_nanotube(n: int, m: int, from_pos: Vector3, to_pos: Vector3) -> CarbonNanotubeStructure:
+static func create_nanotube(n: int, m: int, from_pos: Vector3, to_pos: Vector3, in_trim_invalid_valence_carbons: bool) -> CarbonNanotubeStructure:
 	var tube := CarbonNanotubeStructure.new()
 	tube._chiral_index_n = n
 	tube._chiral_index_m = m
 	tube._position_begin = from_pos
 	tube._position_end = to_pos
+	tube._trim_invalid_valence_carbons = in_trim_invalid_valence_carbons
 	tube.start_edit()
 	tube._signal_queue_path_changed = true
 	tube.end_edit()
@@ -80,6 +83,15 @@ func set_chiral_index_m(in_m: int) -> void:
 
 func get_chiral_index_m() -> int:
 	return _chiral_index_m
+
+
+func set_trim_invalid_valence_carbons(in_trim: bool) -> void:
+	assert(_is_being_edited, "Parameters can only be changed while structure is being edited")
+	_trim_invalid_valence_carbons = in_trim
+
+
+func is_trim_invalid_valence_carbons_enabled() -> bool:
+	return _trim_invalid_valence_carbons
 #endregion: Parameters
 
 
@@ -160,6 +172,7 @@ func start_edit() -> void:
 	super.start_edit()
 	_last_n = _chiral_index_n
 	_last_m = _chiral_index_m
+	_last_trim_invalid_valence_carbons = _trim_invalid_valence_carbons
 	return
 
 
@@ -169,6 +182,7 @@ func end_edit() -> void:
 		_signal_queue_path_changed
 		or _last_n != _chiral_index_n
 		or _last_m != _chiral_index_m
+		or _last_trim_invalid_valence_carbons != _trim_invalid_valence_carbons
 	)
 	if has_changed:
 		_aabb_cache = AABB()
@@ -277,7 +291,7 @@ func get_valid_atoms_count() -> int:
 	return _atoms_count_cache
 
 
-func is_atom_valid(in_atom_id: int) -> bool:
+func is_atom_valid(in_atom_id: int, check_trimmed: bool = true) -> bool:
 	if _track_atoms == false:
 		return false
 	var unpacked := UnpackedAtomId.new(in_atom_id)
@@ -293,6 +307,9 @@ func is_atom_valid(in_atom_id: int) -> bool:
 		var tube_len_sqrd: float = _position_begin.distance_squared_to(_position_end)
 		if z_pos ** 2 > tube_len_sqrd:
 			return false
+	if check_trimmed and _trim_invalid_valence_carbons and \
+			_should_trim_unpacked_atom(unpacked.repetition_idx, unpacked.sub_atom_id):
+		return false
 	return true
 
 
@@ -310,20 +327,65 @@ func get_valid_atoms() -> PackedInt32Array:
 		var cell_length: float = _basis.get_translational_vector_length()
 		var repeat_count: int = ceili(tube_length / cell_length)
 		
-		var _atom_exceeds_tube_len: Callable = func(repetition_idx: int, sub_atom_id: int) -> bool:
+		var atom_exceeds_tube_len: Callable = func(repetition_idx: int, sub_atom_id: int) -> bool:
 			if repetition_idx < (repeat_count - 1):
 				return false
 			var repetition_offset: float = repetition_idx * cell_length
 			var z_pos: float = _template.basis[sub_atom_id].position.z * cell_length
 			return repetition_offset + z_pos > tube_length
-		
 		for repetition_idx: int in repeat_count:
 			for sub_atom_id: int in template_atom_count:
-				if _atom_exceeds_tube_len.call(repetition_idx, sub_atom_id):
+				if atom_exceeds_tube_len.call(repetition_idx, sub_atom_id):
+					continue
+				if _should_trim_unpacked_atom(repetition_idx, sub_atom_id):
 					continue
 				assert(not _get_atom_id(repetition_idx, sub_atom_id) in _atoms_ids_cache, "Math failed and there are repeated atom ids!")
 				_atoms_ids_cache.append(_get_atom_id(repetition_idx, sub_atom_id))
 	return _atoms_ids_cache.duplicate()
+
+
+func _should_trim_atom(in_atom_id: int) -> bool:
+	if _trim_invalid_valence_carbons == false:
+		return false
+	var unpacked_id: UnpackedAtomId = _unpack_atom_id(in_atom_id)
+	return _should_trim_unpacked_atom(unpacked_id.repetition_idx, unpacked_id.sub_atom_id)
+
+
+func _should_trim_unpacked_atom(repetition_idx: int, sub_atom_id: int) -> bool:
+	if _trim_invalid_valence_carbons == false:
+		return false
+	if repetition_idx == 0:
+		# first repetition, count non glue bond 
+		var bond_count: int = 0
+		for bond: CarbonTubuleBasis.Bond in _template.bonds:
+			if bond.is_glue: continue
+			if not sub_atom_id in [bond.from_coordinate, bond.to_coordinate]: continue
+			bond_count += 1
+		return bond_count <= 1
+	if repetition_idx >= (get_repetition_count() - 1):
+		# last repetition, count bonds targeting valid atoms
+		var bond_count: int = 0
+		for bond: CarbonTubuleBasis.Bond in _template.bonds:
+			if not sub_atom_id in [bond.from_coordinate, bond.to_coordinate]: continue
+			var other_sub_atom_id: int
+			var other_repetition_idx: int
+			match sub_atom_id:
+				bond.from_coordinate when bond.is_glue:
+					other_sub_atom_id = bond.to_coordinate
+					other_repetition_idx = repetition_idx - 1
+				bond.to_coordinate when bond.is_glue:
+					other_sub_atom_id = bond.from_coordinate
+					other_repetition_idx = repetition_idx + 1
+				bond.from_coordinate when not bond.is_glue:
+					other_sub_atom_id = bond.to_coordinate
+					other_repetition_idx = repetition_idx
+				bond.to_coordinate when not bond.is_glue:
+					other_sub_atom_id = bond.from_coordinate
+					other_repetition_idx = repetition_idx
+			if is_atom_valid(_get_atom_id(other_repetition_idx, other_sub_atom_id), false):
+				bond_count += 1
+		return bond_count <= 1
+	return false
 
 
 func atom_get_atomic_number(in_atom_id: int) -> int:

--- a/godot_project/project_workspace/workspace_context/create_object_parameters.gd
+++ b/godot_project/project_workspace/workspace_context/create_object_parameters.gd
@@ -79,6 +79,7 @@ var _new_structure: NanoStructure = null
 var _nanotube_n_index: int = 2
 var _nanotube_m_index: int = 2
 var _create_nanotube_as_virtual_group: bool = true
+var _trim_invalid_valence_carbons: bool = true
 
 var _create_distance_method := CreateDistanceMethod.CENTER_OF_SELECTION
 
@@ -254,6 +255,14 @@ func set_create_nanotube_as_virtual_group(in_create_as_group: bool) -> void:
 
 func get_create_nanotube_as_virtual_group() -> bool:
 	return _create_nanotube_as_virtual_group
+
+
+func is_trim_invalid_valence_carbons_enabled() -> bool:
+	return _trim_invalid_valence_carbons
+
+
+func set_trim_invalid_valence_carbons_enabled(in_enabled: bool) -> void:
+	_trim_invalid_valence_carbons = in_enabled
 
 
 func set_create_distance_method(in_new_method: CreateDistanceMethod) -> void:


### PR DESCRIPTION
Task: ADD - "Trim Carbons with Invalid Valences" feature to nano-tube feature


https://github.com/user-attachments/assets/b01cc426-2900-4f0c-8727-1bfe03f0fcd0

