### PR TITLE
Update spinning molecule videotutorial

### DIFF
--- a/godot_project/documentation/video_tutorials/1_create_spinning_molecule.ogv
+++ b/godot_project/documentation/video_tutorials/1_create_spinning_molecule.ogv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e8b573223c48059a3dc67d60cf946a16c2c76caa9860edab589d2c51a179f04
-size 46219009
+oid sha256:cae08d8d1c0acfa7356ce987cad88a6dc6cef31bef97e1e882f88ca88166af72
+size 62153315


### PR DESCRIPTION
Related to #865
pdf documentation also needs updating to include usage of the new Align Selection tools

Task: Replace Tutorial 1 Video