### PR TITLE
Adjust priority of bottom bar messages.

### DIFF
--- a/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
+++ b/godot_project/editor/controls/editor_viewport_container/EditorViewportContainer.gd
@@ -239,11 +239,11 @@ func _create_selection_message(in_new_region: Rect2) -> String:
 
 
 func _on_object_hydrogen_atoms_count_change(in_added: int, in_removed: int) -> void:
-	_message_bar.show_message(_describe_hydrogen_atoms_correction_action(in_added, in_removed))
+	_message_bar.show_hint(_describe_hydrogen_atoms_correction_action(in_added, in_removed))
 
 
 func _on_workspace_context_bonds_auto_created(in_added: int) -> void:
-	_message_bar.show_message("%s Bond%s created." % [in_added, "" if in_added == 1 else "s"])
+	_message_bar.show_hint("%s Bond%s created." % [in_added, "" if in_added == 1 else "s"])
 
 
 func _on_workspace_context_atoms_added_to_structure(
@@ -331,15 +331,15 @@ func _process(delta: float) -> void:
 
 
 func _on_history_snapshot_created(in_snapshot_name: String) -> void:
-	_message_bar.show_message(in_snapshot_name)
+	_message_bar.show_action(in_snapshot_name)
 
 
 func _on_history_previous_snapshot_applied(in_snapshot_name: String) -> void:
-	_message_bar.show_message("Undo: " + in_snapshot_name)
+	_message_bar.show_action("Undo: " + in_snapshot_name)
 
 
 func _on_history_next_snapshot_applied(in_snapshot_name: String) -> void:
-	_message_bar.show_message("Redo: " + in_snapshot_name)
+	_message_bar.show_action("Redo: " + in_snapshot_name)
 
 
 func _on_history_changed() -> void:

--- a/godot_project/editor/controls/message_bar/message_bar.gd
+++ b/godot_project/editor/controls/message_bar/message_bar.gd
@@ -8,38 +8,52 @@ const Style: Dictionary = {
 	HINT_END = "",
 }
 const Priority: Dictionary = {
-	UNSET = -1,
+	UNSET  = -1,
 	MESSAGE = 0,
-	HINT = 1,
-	WARNING = 2,
+	ACTION  = 1,
+	HINT    = 2,
+	WARNING = 3,
 }
 
 @onready var _label_messages: RichTextLabel = $HBoxContainerMessages/LabelMessages
 @onready var _label_fps: Label = $HBoxContainerMessages/LabelFPS
 @onready var _label_distance: Label = $HBoxContainerMessages/Distance
 
-var _meta_callbacks: Dictionary = {
-#	meta_identifier<String> = callback<Callable>
-}
+var _meta_callbacks: Dictionary = {}
 var _fps_timer: Timer = null
-var _last_message_priority: int = -1
+var _action_expired_timer: Timer = null
+var _scheduled_message: String
+var _scheduled_message_meta_callbacks: Dictionary
+var _current_message_priority: int = Priority.UNSET
+var _last_message_priority: int = Priority.UNSET
 
 
 func _ready() -> void:
 	_label_messages.meta_clicked.connect(_on_label_messages_meta_clicked)
-	_set_up_fps_timer()
+	_set_up_timers()
 
 
 func show_message(in_message: String, in_meta_callbacks: Dictionary = {}) -> void:
 	if not _can_show(in_message, Priority.MESSAGE):
 		return
+	_scheduled_message = in_message
+	_scheduled_message_meta_callbacks = in_meta_callbacks
+	_action_expired_timer.start(1.0)
 	_meta_callbacks = in_meta_callbacks
 	_label_messages.text = in_message
+
+
+func show_action(in_action: String, in_meta_callbacks: Dictionary = {}) -> void:
+	if not _can_show(in_action, Priority.ACTION):
+		return
+	_meta_callbacks = in_meta_callbacks
+	_label_messages.text = in_action
 
 
 func show_hint(in_hint: String, in_meta_callbacks: Dictionary = {}) -> void:
 	if not _can_show(in_hint, Priority.HINT):
 		return
+	_action_expired_timer.stop()
 	_meta_callbacks = in_meta_callbacks
 	_label_messages.text = Style.HINT_BEGIN + in_hint + Style.HINT_END
 
@@ -47,6 +61,7 @@ func show_hint(in_hint: String, in_meta_callbacks: Dictionary = {}) -> void:
 func show_warning(in_warning: String, in_meta_callbacks: Dictionary = {}) -> void:
 	if not _can_show(in_warning, Priority.WARNING):
 		return
+	_action_expired_timer.stop()
 	_meta_callbacks = in_meta_callbacks
 	_label_messages.text = Style.WARNING_BEGIN + in_warning + Style.WARNING_END
 
@@ -76,6 +91,7 @@ func _can_show(in_text: String, in_priority: int) -> bool:
 	if in_text.is_empty() or in_priority < _last_message_priority:
 		return false
 	_last_message_priority = in_priority
+	_current_message_priority = in_priority
 	ScriptUtils.call_deferred_once(_reset_priority)
 	return true
 
@@ -92,17 +108,27 @@ func _on_label_messages_meta_clicked(in_meta_identifier: Variant) -> void:
 		push_error("Invalid meta identifier %s")
 
 
-func _set_up_fps_timer() -> void:
+func _set_up_timers() -> void:
 	if OS.has_feature("debug"):
 		_fps_timer = Timer.new()
 		_fps_timer.one_shot = false
 		_fps_timer.timeout.connect(_on_fps_timer_timeout)
 		add_child(_fps_timer)
 		_fps_timer.start(0.2)
+	_action_expired_timer = Timer.new()
+	_action_expired_timer.one_shot = true
+	_action_expired_timer.timeout.connect(_on_action_expired_timer_timeout)
+	add_child(_action_expired_timer)
+	_action_expired_timer.start(1.0)
 
 
 func _on_fps_timer_timeout() -> void:
 	_update_fps_label()
+
+
+func _on_action_expired_timer_timeout() -> void:
+	if _current_message_priority == Priority.ACTION and not _scheduled_message in ["", _label_messages.text]:
+		show_message(_scheduled_message, _scheduled_message_meta_callbacks)
 
 
 func _update_fps_label() -> void:


### PR DESCRIPTION
After one second of the last performed action, bottom bar will show secondary information depending on the last performed action. When no additional information is provided, will describe current selection

Task: BUG - Measurement Tool No longer Works