### PR TITLE
Fix graphene lattice preview picking the wrong viewport texture for post-procesing when Alerts window is visible

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/graphene_latice_preview.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/graphene_latice_preview.tscn
@@ -38,5 +38,9 @@ n = 4
 m = 3
 lattice_color = Color(0.46121, 0.46121, 0.46121, 1)
 
-[node name="Polygon2D" type="Polygon2D" parent="."]
+[node name="BackBufferCopy" type="BackBufferCopy" parent="."]
+copy_mode = 2
+
+[node name="Polygon2D" type="Polygon2D" parent="BackBufferCopy"]
+unique_name_in_owner = true
 material = SubResource("ShaderMaterial_od5b7")

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/graphene_lattice_preview.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/controls/graphene_lattice_preview.gd
@@ -11,7 +11,7 @@ extends Control
 	get():  return lattice_color
 
 
-@onready var _polygon_2d: Polygon2D = $Polygon2D
+@onready var _polygon_2d: Polygon2D = %Polygon2D
 
 
 func _ready() -> void:


### PR DESCRIPTION
BackBufferCopy node ensures the screen texture is the expected one

Task: BUG - Nanotube Graph becomes transparent when "Alert" box is up