### PR TITLE
Fix corner case where atoms in the limits of the nanotube template where not added

### DIFF
--- a/godot_project/utils/carbon_tubule_basis.gd
+++ b/godot_project/utils/carbon_tubule_basis.gd
@@ -144,7 +144,7 @@ func generate() -> CrystalCell:
 					if (abs(p.x) < FLT_EPSILON): p.x = 0.0;
 					if (abs(p.z) < FLT_EPSILON): p.z = 0.0;
 				# If point "p" is within [0,1) in x and z, we have a point:
-				if ((p.x < 1.0) and (p.x >= 0.0) and (p.z < 1.0) and (p.z >= 0.0)):
+				if ((p.x <= 1.0) and (p.x >= 0.0) and (p.z <= 1.0) and (p.z >= 0.0)):
 					# Check if we're too close to 1.0:
 					if ((1.0 - p.x > FLT_EPSILON) and (1.0 - p.z > FLT_EPSILON)):
 					# Recalculate in terms of Ch and Tprime:


### PR DESCRIPTION
Task: BUG: nanotube broken topology

Fixes this:
<img width="1734" height="856" alt="image" src="https://github.com/user-attachments/assets/ca464660-5366-4764-b584-ec5962805d38" />
