### PR TITLE
Add a shortcut in simulations manel to manage what objects are hidden during simulations

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.gd
@@ -24,13 +24,13 @@ func _notification(what: int) -> void:
 		_hydrogens_toggle = $Settings/PanelContainer/VBoxContainer/ShowHydrogensToggle
 		_dna_representation_option_button = %DnaRepresentationOptionButton
 		_nanotube_representation_option_button = %NanotubeRepresentationOptionButton
-		_hide_simulation_boundaries_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideSimulationBoundariesToggle
-		_hide_reference_shapes_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideReferenceShapesToggle
-		_hide_dna_objects_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideDnaObjectsToggle
-		_hide_nanotube_objects_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideNanotubeObjectsToggle
-		_hide_virtual_motors_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideVirtualMotorsToggle
-		_hide_particle_emitters_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideParticleEmittersToggle
-		_hide_anchors_and_springs_toggle = $Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideAnchorsAndSpringsToggle
+		_hide_simulation_boundaries_toggle = %HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideSimulationBoundariesToggle
+		_hide_reference_shapes_toggle = %HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideReferenceShapesToggle
+		_hide_dna_objects_toggle = %HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideDnaObjectsToggle
+		_hide_nanotube_objects_toggle = %HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideNanotubeObjectsToggle
+		_hide_virtual_motors_toggle = %HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideVirtualMotorsToggle
+		_hide_particle_emitters_toggle = %HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideParticleEmittersToggle
+		_hide_anchors_and_springs_toggle = %HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideAnchorsAndSpringsToggle
 
 
 func should_show(in_workspace_context: WorkspaceContext)-> bool:

--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/visibility_settings/visibility_settings.tscn
@@ -90,50 +90,54 @@ popup/item_0/id = 0
 popup/item_1/text = "Atoms and Bonds"
 popup/item_1/id = 1
 
-[node name="Title" type="Label" parent="Settings/PanelContainer/VBoxContainer"]
+[node name="HideDuringSimulationContainer" type="VBoxContainer" parent="Settings/PanelContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Title" type="Label" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer"]
 layout_mode = 2
 theme_type_variation = &"HeaderSmall"
 text = "Hide During Simulations"
 
-[node name="PanelContainer" type="PanelContainer" parent="Settings/PanelContainer/VBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer"]
 layout_mode = 2
 theme_type_variation = &"SubcategoryPanel"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Settings/PanelContainer/VBoxContainer/PanelContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer"]
 layout_mode = 2
 
-[node name="HideSimulationBoundariesToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+[node name="HideSimulationBoundariesToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 button_pressed = true
 text = "Simulation Boundaries"
 
-[node name="HideReferenceShapesToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+[node name="HideReferenceShapesToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 button_pressed = true
 text = "Reference Shapes"
 
-[node name="HideDnaObjectsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+[node name="HideDnaObjectsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 button_pressed = true
 text = "DNA Objects"
 
-[node name="HideNanotubeObjectsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+[node name="HideNanotubeObjectsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 button_pressed = true
 text = "Carbon Nanotube Objects"
 
-[node name="HideVirtualMotorsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+[node name="HideVirtualMotorsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 button_pressed = true
 text = "Virtual Motors"
 
-[node name="HideParticleEmittersToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+[node name="HideParticleEmittersToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 button_pressed = true
 text = "Particle Emitters
 "
 
-[node name="HideAnchorsAndSpringsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer"]
+[node name="HideAnchorsAndSpringsToggle" type="CheckButton" parent="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer"]
 layout_mode = 2
 button_pressed = true
 text = "Anchors and Springs
@@ -145,10 +149,10 @@ text = "Anchors and Springs
 [connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/ShowPotentialAtomsToggle" to="." method="_on_show_potential_atoms_toggle_toggled"]
 [connection signal="item_selected" from="Settings/PanelContainer/VBoxContainer/DnaSettingsContainer/DnaRepresentationOptionButton" to="." method="_on_dna_representation_option_button_item_selected"]
 [connection signal="item_selected" from="Settings/PanelContainer/VBoxContainer/NanotubeSettingsContainer/NanotubeRepresentationOptionButton" to="." method="_on_nanotube_representation_option_button_item_selected"]
-[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideSimulationBoundariesToggle" to="." method="_on_hide_simulation_boundaries_toggle_toggled"]
-[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideReferenceShapesToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"reference_shapes"]]
-[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideDnaObjectsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"dna_objects"]]
-[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideNanotubeObjectsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"nanotube_objects"]]
-[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideVirtualMotorsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"virtual_motors"]]
-[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideParticleEmittersToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"particle_emitters"]]
-[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/PanelContainer/VBoxContainer/HideAnchorsAndSpringsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"anchors_and_springs"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideSimulationBoundariesToggle" to="." method="_on_hide_simulation_boundaries_toggle_toggled"]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideReferenceShapesToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"reference_shapes"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideDnaObjectsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"dna_objects"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideNanotubeObjectsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"nanotube_objects"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideVirtualMotorsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"virtual_motors"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideParticleEmittersToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"particle_emitters"]]
+[connection signal="toggled" from="Settings/PanelContainer/VBoxContainer/HideDuringSimulationContainer/PanelContainer/VBoxContainer/HideAnchorsAndSpringsToggle" to="." method="_on_hide_virtual_objects_toggle" binds= [&"anchors_and_springs"]]

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.gd
@@ -793,6 +793,14 @@ func _on_open_mm_failure_tracker_results_collected() -> void:
 	_update_view_alerts_button()
 
 
+func _on_manage_hidden_rich_text_label_meta_clicked(meta: Variant) -> void:
+	if meta == "manage":
+		MolecularEditorContext.request_workspace_docker_focus(
+			WorkspaceSettingsDocker.UNIQUE_DOCKER_NAME,
+			&"Representation Settings", [^"VisibilitySettings", ^"%HideDuringSimulationContainer"]
+		)
+
+
 func _physics_process(_delta: float) -> void:
 	if not _workspace_context.is_active():
 		return

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/simulation_tools_panel.tscn
@@ -220,6 +220,14 @@ text = "❌ Project is empty. Create atoms before running a simulation."
 horizontal_alignment = 1
 autowrap_mode = 2
 
+[node name="ManageHiddenRichTextLabel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+bbcode_enabled = true
+text = "[url=manage]Manage Visibility of Virtual Objects[/url]"
+fit_content = true
+scroll_active = false
+horizontal_alignment = 1
+
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
 size_flags_horizontal = 4
@@ -261,3 +269,5 @@ text = "View 4 Alerts..."
 
 [node name="OpenMMFailureTracker" parent="." instance=ExtResource("9_6sv07")]
 unique_name_in_owner = true
+
+[connection signal="meta_clicked" from="MarginContainer/VBoxContainer/ManageHiddenRichTextLabel" to="." method="_on_manage_hidden_rich_text_label_meta_clicked"]


### PR DESCRIPTION
Task: UX: Add a "manage hidden objects during simulation" button to the Molecular Dynamics simulation panel