### PR TITLE
Fix rollover text in create nanotube ring menu action

### DIFF
--- a/godot_project/editor/ring_menu_levels/virtual_objects/ring_action_create_nanotube_object.gd
+++ b/godot_project/editor/ring_menu_levels/virtual_objects/ring_action_create_nanotube_object.gd
@@ -12,9 +12,9 @@ func _init(in_workspace_context: WorkspaceContext, in_menu: NanoRingMenu) -> voi
 	_workspace_context = in_workspace_context
 	_ring_menu = in_menu
 	super._init(
-		tr("DNA Object"),
+		tr("Carbon Nanotube"),
 		_execute_action,
-		tr("Create a high level representation of a DNA chain.")
+		tr("Create a high level representation of a Single Wall Carbon Nanotube.")
 	)
 
 


### PR DESCRIPTION
Task: BUG - Carbon Nanotube Icon in Action Ring incorrectly labeled "DNA Object"