### PR TITLE
Fix several corner cases where invisible objects could be selected

### DIFF
--- a/godot_project/project_workspace/structs/representation_settings.gd
+++ b/godot_project/project_workspace/structs/representation_settings.gd
@@ -18,6 +18,16 @@ const HYDROGENS_VISIBLE_BY_DEFAULT = true
 const BONDS_VISIBLE_BY_DEFAULT = true
 const ATOMS_AUTO_POSING_VISIBLE_BY_DEFAULT = true
 const SIMULATION_BOUNDARIES_VISIBLE_BY_DEFAULT = false
+const HIDE_DURING_SIMULATION_DEFAULT: Dictionary[StringName, bool] = {
+	group = false,
+	reference_shapes = true,
+	dna_objects = true,
+	nanotube_objects = true,
+	virtual_motors = true,
+	particle_emitters = true,
+	anchors_and_springs = true,
+}
+
 
 enum UserAtomSizeSource {
 	PHYSICAL_RADIUS,
@@ -83,14 +93,7 @@ enum NanotubeRepresentation {
 @export var _color_schema: PeriodicTable.ColorSchema = PeriodicTable.ColorSchema.MSEP
 
 
-@export var _hide_during_simulation: Dictionary[StringName, bool] = {
-	reference_shapes = true,
-	dna_objects = true,
-	nanotube_objects = true,
-	virtual_motors = true,
-	particle_emitters = true,
-	anchors_and_springs = true,
-}
+@export var _hide_during_simulation: Dictionary[StringName, bool] = HIDE_DURING_SIMULATION_DEFAULT.duplicate()
 
 
 func set_balls_and_sticks_size_source(in_size_souce: UserAtomSizeSource) -> void:
@@ -273,6 +276,7 @@ func get_color_schema() -> PeriodicTable.ColorSchema:
 
 func set_should_hide_virtual_object_during_simulation(in_type: StringName, in_should_hide: bool) -> void:
 	var key: StringName = _variant_to_virtual_object_key(in_type)
+	assert(key != &"group", "Do not change this value")
 	if _hide_during_simulation[key] == in_should_hide:
 		return
 	_hide_during_simulation[key] = in_should_hide
@@ -281,7 +285,19 @@ func set_should_hide_virtual_object_during_simulation(in_type: StringName, in_sh
 
 func get_should_hide_virtual_object_during_simulation(in_type: Variant) -> bool:
 	var key: StringName = _variant_to_virtual_object_key(in_type)
+	_sanitize_list()
 	return _hide_during_simulation.get(key, true)
+
+
+func _sanitize_list() -> void:
+	if _hide_during_simulation.size() == HIDE_DURING_SIMULATION_DEFAULT.size():
+		return
+	# This inserts missing values when a file is loaded from disk and was saved without
+	#values that was added afterwards
+	for key: StringName in HIDE_DURING_SIMULATION_DEFAULT:
+		if not key in _hide_during_simulation:
+			_hide_during_simulation[key] = HIDE_DURING_SIMULATION_DEFAULT[key]
+	assert(_hide_during_simulation.size() == HIDE_DURING_SIMULATION_DEFAULT.size())
 
 
 func get_final_background_color() -> Color:
@@ -303,6 +319,8 @@ func _variant_to_virtual_object_key(in_type: Variant) -> StringName:
 
 static func script_to_virtual_object_key(in_script: Script) -> StringName:
 	var SCRIPT_TO_KEY_MAP: Dictionary[Script, StringName] = {
+		NanoMolecularStructure: &"group",
+		LMDBNanoStruct: &"group",
 		NanoShape: &"reference_shapes",
 		DnaStructure: &"dna_objects",
 		CarbonNanotubeStructure: &"nanotube_objects",

--- a/godot_project/project_workspace/workspace_context/structure_context/collision_engine/collision_engine.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/collision_engine/collision_engine.gd
@@ -123,6 +123,10 @@ func initialize(in_structure_context: StructureContext) -> void:
 			_add_bond(bond_id, nano_structure)
 		
 		var springs: PackedInt32Array = nano_structure.springs_get_visible()
+		if _structure_context.workspace_context.is_simulating() and \
+				nano_structure.get_representation_settings()\
+				.get_should_hide_virtual_object_during_simulation(NanoVirtualAnchor):
+			springs = []
 		for spring_id in springs:
 			_add_spring(spring_id)
 	

--- a/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/selection_db/selection_db.gd
@@ -310,12 +310,15 @@ func invert_selection() -> void:
 		set_bond_selection(inverted_bonds)
 		
 		# ---- Springs ----
-		var visible_springs: PackedInt32Array = nano_structure.springs_get_visible()
-		var springs_to_select: PackedInt32Array = PackedInt32Array()
-		for spring_id: int in visible_springs:
-			if not _spring_selection.is_spring_selected(spring_id):
-				springs_to_select.append(spring_id)
-		set_spring_selection(springs_to_select)
+		if _structure_context.workspace_context.is_simulating() == false or \
+				nano_structure.get_representation_settings() \
+				.get_should_hide_virtual_object_during_simulation(NanoVirtualAnchor) == false:
+			var visible_springs: PackedInt32Array = nano_structure.springs_get_visible()
+			var springs_to_select: PackedInt32Array = PackedInt32Array()
+			for spring_id: int in visible_springs:
+				if not _spring_selection.is_spring_selected(spring_id):
+					springs_to_select.append(spring_id)
+			set_spring_selection(springs_to_select)
 	
 	# ---- DNA Structures ----
 	if nano_structure is DnaStructure:
@@ -350,7 +353,12 @@ func select_all() -> void:
 		assert(!nano_structure.is_being_edited(), "Setting the selection while structure is changing is insecure and should be avoided")
 		set_atom_selection(nano_structure.get_visible_atoms())
 		set_bond_selection(nano_structure.get_visible_bonds())
-		set_spring_selection(nano_structure.springs_get_visible())
+		var visible_springs: PackedInt32Array = nano_structure.springs_get_visible()
+		if _structure_context.workspace_context.is_simulating() and \
+				nano_structure.get_representation_settings() \
+				.get_should_hide_virtual_object_during_simulation(NanoVirtualAnchor):
+			visible_springs = []
+		set_spring_selection(visible_springs)
 
 
 func set_atom_selection(in_atoms_to_select: PackedInt32Array) -> void:

--- a/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
+++ b/godot_project/project_workspace/workspace_context/structure_context/structure_context.gd
@@ -135,6 +135,9 @@ func is_editable() -> bool:
 			_is_editable = false
 		elif nano_structure == null or not nano_structure.get_visible():
 			_is_editable = false
+		elif workspace_context.is_simulating() and nano_structure.get_representation_settings() \
+				.get_should_hide_virtual_object_during_simulation(nano_structure.get_script()):
+			_is_editable = false
 		else:
 			_is_editable = is_active() or workspace_context.workspace.is_a_ancestor_of_b(
 					workspace_context.get_current_structure_context().nano_structure,

--- a/godot_project/project_workspace/workspace_context/workspace_context.gd
+++ b/godot_project/project_workspace/workspace_context/workspace_context.gd
@@ -269,7 +269,7 @@ func _try_deselect_hidden_virtual_objects() -> bool:
 	for type: Script in types_to_evaluate:
 		var type_str: StringName = RepresentationSettings.script_to_virtual_object_key(type)
 		if workspace.representation_settings.get_should_hide_virtual_object_during_simulation(type_str):
-			selection_changed = selection_changed or _try_deselect_hidden_virtual_objects_of_type(type_str)
+			selection_changed = _try_deselect_hidden_virtual_objects_of_type(type_str) or selection_changed
 	return selection_changed
 
 func _try_deselect_hidden_virtual_objects_of_type(object_type: StringName) -> bool:
@@ -280,7 +280,7 @@ func _try_deselect_hidden_virtual_objects_of_type(object_type: StringName) -> bo
 			if RepresentationSettings.script_to_virtual_object_key(ctx.nano_structure.get_script()) == object_type:
 				# DnaStructure and CarbonNanotubeStructure
 				ctx.clear_selection()
-			elif RepresentationSettings.script_to_virtual_object_key(NanoVirtualAnchor) == object_type:
+			if RepresentationSettings.script_to_virtual_object_key(NanoVirtualAnchor) == object_type:
 				# Unselect any selected spring
 				var selected_springs: PackedInt32Array = ctx.get_selected_springs()
 				if selected_springs.size() > 0:
@@ -605,6 +605,7 @@ func start_simulating(in_simulation_data: SimulationData) -> void:
 	_simulation = in_simulation_data
 	if _try_deselect_hidden_virtual_objects():
 		snapshot_moment("Change Selection")
+	_queue_emit_new_editable_structures()
 	simulation_started.emit()
 
 
@@ -678,6 +679,7 @@ func abort_simulation_if_running() -> void:
 	seek_simulation(0.0)
 	_simulation = null
 	_is_simulation_playback_running = false
+	_queue_emit_new_editable_structures()
 	simulation_finished.emit()
 
 


### PR DESCRIPTION
- When starting a simulation, only one type of virtual object was being unselected
- It was still possible to box select springs invisible because of active simulation
- It was possible to select hidden-during-simulation virtual objects with 'select all' command
- It was possible to select hidden-during-simulation virtual objects with 'invert selection' command

Task: BUG: RingMenu>Select>SelectAll can select virtual objects hidden during simulation