### PR TITLE
Fixes to Auto-Create-Springs and Relax-Considering-Springs

### DIFF
--- a/godot_project/autoloads/openmm/openmm.gd
+++ b/godot_project/autoloads/openmm/openmm.gd
@@ -920,14 +920,40 @@ func _create_payload(
 			
 			var atom_ids: PackedInt32Array = context.nano_structure.get_valid_atoms()
 			var bond_ids: PackedInt32Array = context.nano_structure.get_valid_bonds()
-			var springs_ids: PackedInt32Array = context.nano_structure.springs_get_all()
+			var springs_ids := PackedInt32Array()
+			if in_include_springs:
+				springs_ids = context.nano_structure.springs_get_all()
 			if partial_set:
 				if in_atom_set == AtomicStructure.AtomSet.SELECTED_ONLY:
 					atom_ids = context.get_selected_atoms()
+					var selected_springs_ids: PackedInt32Array = context.get_selected_springs()
+					# Filter selected springs
+					for spring_idx: int in range(springs_ids.size() - 1, -1, -1):
+						var spring_id: int = springs_ids[spring_idx]
+						var atom_1: int = structure.spring_get_atom_id(spring_id)
+						var valid: bool = true
+						if not spring_id in selected_springs_ids:
+							valid = false
+						elif structure.spring_is_atom_to_atom(spring_id):
+							var atom_2: int = structure.spring_get_second_atom_id(spring_id)
+							# Spring is considered if at least one atom is selected
+							if (not atom_1 in atom_ids) and (not atom_2 in atom_ids):
+								valid = false
+						else:
+							# Spring is considered if at least atom is selected, anchor is not considered
+							if not atom_1 in atom_ids:
+								valid = false
+						if valid == false:
+							springs_ids.remove_at(spring_idx)
 				elif in_atom_set == AtomicStructure.AtomSet.ALL_VISIBLE:
 					atom_ids = structure.get_visible_atoms()
+					# Filter visible springs
+					for spring_idx: int in range(springs_ids.size() - 1, -1, -1):
+						var spring_id: int = springs_ids[spring_idx]
+						if not structure.spring_is_visible(spring_id):
+							springs_ids.remove_at(spring_idx)
 				# Ignore selected bonds, instead we will find existing bonds between selected atoms
-				var all_bonds_ids: PackedInt32Array = bond_ids
+				var all_bonds_ids: PackedInt32Array = bond_ids.duplicate()
 				bond_ids = []
 				for bond_id: int in all_bonds_ids:
 					var bond: Vector3i = structure.get_bond(bond_id)
@@ -935,11 +961,6 @@ func _create_payload(
 					var atom_2: int = bond.y
 					if atom_1 in atom_ids and atom_2 in atom_ids:
 						bond_ids.push_back(bond_id)
-				springs_ids = []
-				for spring_id: int in context.get_selected_springs():
-					# Only add the spring if the atom is also selected
-					if structure.spring_get_atom_id(spring_id) in atom_ids:
-						springs_ids.push_back(spring_id)
 			var is_partially_selected: bool = atom_ids.size() != structure.get_valid_atoms_count()
 			payload.add_structure(structure, atom_ids, bond_ids, is_partially_selected)
 		

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd
@@ -113,9 +113,9 @@ func _on_auto_create_springs_button_pressed() -> void:
 		_create_atom_to_anchor_springs()
 		return
 	elif _atom_to_atom_button.button_pressed:
-		var out_spring_count: Dictionary[StringName, int] = {count = 0}
+		var out_new_springs: Dictionary[int, PackedInt32Array] = {}
 		var out_stopped: Dictionary[StringName, bool] = {value = false}
-		var promise: Promise = _create_atom_to_atom_springs(out_spring_count, out_stopped)
+		var promise: Promise = _create_atom_to_atom_springs(out_new_springs, out_stopped)
 		var _on_stop: Callable = func() -> void:
 			out_stopped.value = true
 		_workspace_context.start_async_work(
@@ -124,8 +124,13 @@ func _on_auto_create_springs_button_pressed() -> void:
 		await promise.wait_for_fulfill()
 		if BusyIndicator.is_active():
 			_workspace_context.end_async_work()
-		if out_spring_count.count > 0:
-			_workspace_context.snapshot_moment("Create %d Springs" % out_spring_count.count)
+		if out_new_springs.size() > 0:
+			var count: int = 0
+			for structure_id: int in out_new_springs:
+				var structure_context: StructureContext = _workspace_context.get_structure_context(structure_id)
+				structure_context.select_springs(out_new_springs[structure_id])
+				count += out_new_springs[structure_id].size()
+			_workspace_context.snapshot_moment("Create %d Springs" % count)
 		return
 
 func _create_atom_to_anchor_springs() -> void:
@@ -173,7 +178,7 @@ func _create_atom_to_anchor_springs() -> void:
 	if new_spring_count > 0:
 		_workspace_context.snapshot_moment("Create %d Springs" % new_spring_count)
 
-func _create_atom_to_atom_springs(out_spring_count: Dictionary[StringName, int], out_stopped: Dictionary[StringName,bool]) -> Promise:
+func _create_atom_to_atom_springs(out_new_springs: Dictionary[int, PackedInt32Array], out_stopped: Dictionary[StringName,bool]) -> Promise:
 	var promise := Promise.new()
 	var selected_atoms: Dictionary[AtomicStructure, PackedInt32Array] = {}
 	for structure_context: StructureContext in _workspace_context.get_structure_contexts_with_selection():
@@ -185,7 +190,7 @@ func _create_atom_to_atom_springs(out_spring_count: Dictionary[StringName, int],
 	else:
 		var thread := Thread.new()
 		thread.start(_create_atom_to_atom_springs_in_thread.bind(
-			thread, promise, selected_atoms, out_spring_count, out_stopped))
+			thread, promise, selected_atoms, out_new_springs, out_stopped))
 	return promise
 
 
@@ -193,7 +198,7 @@ func _create_atom_to_atom_springs_in_thread(
 		out_thread: Thread,
 		out_promise: Promise,
 		out_selected_atoms: Dictionary[AtomicStructure, PackedInt32Array],
-		out_spring_count: Dictionary[StringName, int],
+		out_new_springs: Dictionary[int, PackedInt32Array],
 		out_stopped: Dictionary[StringName,bool]) -> void:
 	var max_distance_sqrd: float = _max_spring_length_slider.value * _max_spring_length_slider.value
 	var constant_force: float = _workspace_context.create_object_parameters.get_spring_constant_force()
@@ -201,6 +206,7 @@ func _create_atom_to_atom_springs_in_thread(
 	var MANUAL_EQUILIBRIUM_LENGTH: float = 0.1
 	var flush_semaphore := Semaphore.new()
 	for structure: AtomicStructure in out_selected_atoms.keys():
+		var first_created: bool = false
 		var last_flush: float = Time.get_unix_time_from_system()
 		var atom_selection: PackedInt32Array = out_selected_atoms[structure]
 		if _ignore_hydrogens_check_button.button_pressed:
@@ -231,11 +237,14 @@ func _create_atom_to_atom_springs_in_thread(
 						if structure.atom_get_bond_target(atom1, bond_id) == atom2:
 							# Bond exists
 							continue
-				structure.spring_create_between_atoms(
+				var spring_id: int = structure.spring_create_between_atoms(
 					atom1, atom2, constant_force,
 					EQUILIBRIUM_LENGTH_IS_AUTO, MANUAL_EQUILIBRIUM_LENGTH
 				)
-				out_spring_count.count += 1
+				if not first_created:
+					first_created = true
+					out_new_springs[structure.get_int_guid()] = PackedInt32Array()
+				out_new_springs[structure.get_int_guid()].append(spring_id)
 				var time: float = Time.get_unix_time_from_system()
 				if time - last_flush >= 1.0:
 					# Update main every 1 second


### PR DESCRIPTION
- Auto create atom-to-atom springs now selects ewly created springs
- When relaxing all visible springs, consider all springs and not only selected ones

Task: BUG - Error in auto-creating springs between atoms