### PR TITLE
Fix crash when auto-creating atom-to-anchor springs

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.gd
@@ -136,7 +136,7 @@ func _create_atom_to_anchor_springs() -> void:
 		if ctx.nano_structure is NanoVirtualAnchor:
 			anchors.append(ctx)
 		var selected_atoms: PackedInt32Array = ctx.get_selected_atoms()
-		if _ignore_hydrogens_check_button.button_pressed:
+		if _ignore_hydrogens_check_button.button_pressed and ctx.nano_structure is AtomicStructure:
 			_remove_hydrogens(ctx.nano_structure, selected_atoms)
 		if selected_atoms.size() > 0:
 			atoms[ctx] = selected_atoms


### PR DESCRIPTION
Task: CRASH: Attempting to auto-create-springs to anchors