### PR TITLE
Fix several crashes when closing a project while the tab is inactive

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/lock_atoms.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/lock_atoms.gd
@@ -27,6 +27,7 @@ func should_show(in_workspace_context: WorkspaceContext)-> bool:
 
 
 func _refresh_ui() -> void:
+	if not is_instance_valid(_workspace_context): return
 	var selected_atom_count: int = 0
 	for context: StructureContext in _workspace_context.get_structure_contexts_with_selection():
 		selected_atom_count += context.get_selected_atoms().size()

--- a/godot_project/editor/rendering/carbon_nanotube_renderer/carbon_nanotube_renderer.gd
+++ b/godot_project/editor/rendering/carbon_nanotube_renderer/carbon_nanotube_renderer.gd
@@ -203,6 +203,8 @@ func _update_simplified_representation_selection() -> void:
 func _on_path_representation_drawn() -> void:
 	if is_queued_for_deletion() or not _visible or not _is_selectable:
 		return
+	if not is_instance_valid(_workspace_context):
+		return
 	if (_is_simulating and _should_hide_in_simulation):
 		return
 	var from_3d: Vector3 = _control_point_override.get(0, _tube_start)

--- a/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
+++ b/godot_project/editor/rendering/dna_structure_renderer/dna_structure_renderer.gd
@@ -507,6 +507,8 @@ func _update_visibility() -> void:
 func _on_path_representation_drawn() -> void:
 	if is_queued_for_deletion() or not _is_selectable or Engine.is_editor_hint():
 		return
+	if not is_instance_valid(_workspace_context):
+		return
 	if (_is_simulating and _should_hide_in_simulation):
 		return
 	var dna_structure: DnaStructure = _workspace_context.workspace.get_structure_by_int_guid(_structure_id) as DnaStructure


### PR DESCRIPTION
Tasks:
- CRASH: Closing a project with DNA Object when not active
- CRASH: Closing a project with Nanotube when not active
- CRASH: Closing a project with selected atoms when not active