### PR TITLE
Refresh recent project list when applicaiton focuses

### DIFF
--- a/godot_project/editor/controls/welcome_page/welcome_page.gd
+++ b/godot_project/editor/controls/welcome_page/welcome_page.gd
@@ -21,6 +21,13 @@ func _ready() -> void:
 	load_workspace_from_disk.pressed.connect(_on_load_workspace_from_disk_pressed)
 	visibility_changed.connect(_update_workspaces_list)
 
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_WM_WINDOW_FOCUS_IN:
+		if is_visible_in_tree():
+			_update_workspaces_list()
+
+
 func _update_workspaces_list() -> void:
 	if !is_visible_in_tree():
 		return


### PR DESCRIPTION
This fixes a crash if you try to click a project that was deleted while the app was unfocused

Task: CRASH: Opening a deleted project