### PR TITLE
Nanotube: When toggling trim atoms with invalid valence, highlight added atoms

### DIFF
--- a/godot_project/editor/rendering/carbon_nanotube_renderer/carbon_nanotube_renderer.gd
+++ b/godot_project/editor/rendering/carbon_nanotube_renderer/carbon_nanotube_renderer.gd
@@ -81,6 +81,7 @@ func _ensure_structure_signal_connections(in_structure: CarbonNanotubeStructure)
 	if not in_structure.visibility_changed.is_connected(_on_object_visibility_changed):
 		in_structure.path_changed.connect(_on_tube_path_changed)
 		in_structure.chiral_indices_changed.connect(_on_tube_chiral_indices_changed.unbind(2))
+		in_structure.trim_invalid_atoms_policy_changed.connect(_on_trim_invalid_atoms_policy_changed.unbind(1))
 		in_structure.visibility_changed.connect(_on_object_visibility_changed)
 
 
@@ -350,6 +351,11 @@ func _on_tube_chiral_indices_changed() -> void:
 	queue_redraw()
 	ScriptUtils.call_deferred_once(_update_simplified_representation)
 	_refresh_atomic_preview_selection.bind(true).call_deferred()
+
+
+func _on_trim_invalid_atoms_policy_changed() -> void:
+	if _simplified_representation_visible == false:
+		_refresh_atomic_preview_selection.bind(true).call_deferred()
 
 
 func _on_nanotube_representation_changed(representation: RepresentationSettings.NanotubeRepresentation) -> void:

--- a/godot_project/project_workspace/structs/carbon_nanotube_structure.gd
+++ b/godot_project/project_workspace/structs/carbon_nanotube_structure.gd
@@ -5,6 +5,7 @@ const NanotubeRepresentation = RepresentationSettings.NanotubeRepresentation
 
 signal path_changed(from: Vector3, to: Vector3)
 signal chiral_indices_changed(n: int, m: int)
+signal trim_invalid_atoms_policy_changed(trim_invalid_valence_carbons: bool)
 
 @export var _chiral_index_n: int
 @export var _chiral_index_m: int
@@ -253,6 +254,8 @@ func end_edit() -> void:
 			super.end_edit()
 		if _last_n != _chiral_index_n or _last_m != _chiral_index_m:
 			chiral_indices_changed.emit(_chiral_index_n, _chiral_index_m)
+		if _last_trim_invalid_valence_carbons != _trim_invalid_valence_carbons:
+			trim_invalid_atoms_policy_changed.emit(_trim_invalid_valence_carbons)
 		emit_changed()
 	else:
 		_is_being_edited = false


### PR DESCRIPTION
Task: BUG: Toggling "Trim Atoms with Invalid Valence" ON and OFF in Atoms&Bonds view will make added atoms to the nanotube not be highligted as the rest