### PR TITLE
Fix procedure for saving changes and then closing a workspace

### DIFF
--- a/godot_project/autoloads/MolecularEditorContext.gd
+++ b/godot_project/autoloads/MolecularEditorContext.gd
@@ -232,9 +232,9 @@ func save_workspace(in_workspace: Workspace, in_path: String = "") -> void:
 	if path.is_empty():
 		Editor_Utils.get_editor().show_save_workspace_dialog(in_workspace)
 		return
-	var currently_open_workspace: Workspace = _find_workspace_with_resource_path(in_path)
+	var currently_open_workspace: Workspace = _find_workspace_with_resource_path(path)
 	var there_is_another_open_workspace_from_that_file: bool = \
-		is_instance_valid(currently_open_workspace) and not in_workspace == currently_open_workspace
+		is_instance_valid(currently_open_workspace) and in_workspace != currently_open_workspace
 	if there_is_another_open_workspace_from_that_file:
 		# The path selected by the user points to a file that already exists
 		# and there is another open workspace that was loaded from that file
@@ -286,10 +286,40 @@ func _find_workspace_with_resource_path(in_resource_path: String) -> Workspace:
 func request_close_workspace(in_workspace: Workspace) -> void:
 	var context: WorkspaceContext = get_workspace_context(in_workspace)
 	if context.has_unsaved_changes():
+		var save_promise := Promise.new()
+		var on_discard_unsaved_changes: Callable = func() -> void:
+			# Accepted to not save changes, close workspace
+			save_promise.fulfill("close")
+		var on_saved: Callable = func(out_workspace: Workspace) -> void:
+			# Promise is fulfilled if workspace is saved, close workspace
+			if in_workspace == out_workspace:
+				save_promise.fulfill("close")
+		var on_save_dialog_canceled: Callable = func() -> void:
+			# Save dialog was canceled, cancel closing workspace
+			save_promise.fulfill("abort")
+		var on_abort: Callable = func() -> void:
+			save_promise.fulfill("abort")
+		var save_and_resume: Callable = func() -> void:
+			MolecularEditorContext.workspace_saved.connect(on_saved)
+			Editor_Utils.get_editor().save_file_dialog.canceled.connect(on_save_dialog_canceled)
+			MolecularEditorContext.save_workspace(in_workspace)
 		Editor_Utils.get_editor().show_close_workspace_confirmation_dialog(
 			in_workspace.get_user_friendly_name(),
-			close_workspace_no_prompt.bind(in_workspace),
-			save_workspace.bind(in_workspace))
+			on_discard_unsaved_changes, save_and_resume, on_abort)
+		await save_promise.wait_for_fulfill()
+		if MolecularEditorContext.workspace_saved.is_connected(on_saved):
+			MolecularEditorContext.workspace_saved.disconnect(on_saved)
+		if Editor_Utils.get_editor().save_file_dialog.canceled.is_connected(on_save_dialog_canceled):
+			Editor_Utils.get_editor().save_file_dialog.canceled.disconnect(on_save_dialog_canceled)
+		var result: String = save_promise.get_result()
+		match result:
+			"close":
+				close_workspace_no_prompt(in_workspace)
+			"abort":
+				# Cancel closing
+				return
+			_:
+				assert(false, "Unexpected save_promise result! " + result)
 	else:
 		close_workspace_no_prompt(in_workspace)
 

--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_bonds_panel.gd
@@ -37,6 +37,8 @@ func _ensure_initialized(in_workspace_context: WorkspaceContext) -> void:
 
 
 func _update_panel_state() -> void:
+	if not is_instance_valid(_workspace_context):
+		return
 	_no_selection_label.self_modulate.a = 0.0
 	_auto_create_bonds_button.disabled = false
 	var has_selected_atoms: bool = false

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/3d_preview.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/3d_preview.gd
@@ -67,4 +67,6 @@ func _on_workspace_representation_settings_changed(_representation: Rendering.Re
 
 
 func _internal_update() -> void:
+	if not is_instance_valid(_workspace_context):
+		return
 	three_d_preview_container.texture = _workspace_context.get_rendering().get_selection_preview_texture()

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_atom_type.gd
@@ -148,6 +148,8 @@ func _on_workspace_context_structure_about_to_remove(_in_structure: NanoStructur
 
 
 func _refresh_target_list() -> void:
+	if not is_instance_valid(_workspace_context):
+		return
 	var total: int = 0
 	const MARGINS_OFFSET: float = 12
 	var per_element_count: Dictionary = {

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_bond_type.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/change_bond_type.gd
@@ -60,6 +60,8 @@ func _on_rendering_representation_changed() -> void:
 
 
 func _update_availability() -> void:
+	if not is_instance_valid(_workspace_context):
+		return
 	var representation: Rendering.Representation = _workspace_context.workspace.representation_settings.get_rendering_representation()
 	var representation_allows_editing: bool = representation != Rendering.Representation.STICKS
 	var selected_count: int = 0

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_virtual_spring_parameters.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/edit_virtual_spring_parameters.gd
@@ -39,6 +39,8 @@ func _on_workspace_context_structure_about_to_remove(_in_structure: NanoStructur
 
 func _update_edited_springs() -> void:
 	var workspace_context: WorkspaceContext = _workspace_context_wref.get_ref() as WorkspaceContext
+	if not is_instance_valid(workspace_context):
+		return
 	var selected_contexts: Array[StructureContext] = workspace_context.get_structure_contexts_with_selection()
 	var selected_contexts_with_springs: Array[StructureContext] = []
 	for context: StructureContext in selected_contexts:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/selection_info.gd
@@ -48,6 +48,8 @@ func _on_workspace_context_structure_about_to_remove(_in_structe: NanoStructure)
 
 func _update_selected_info() -> void:
 	_clear()
+	if not is_instance_valid(_workspace_context):
+		return
 	var contexts_with_selection: Array[StructureContext] = _workspace_context.get_structure_contexts_with_selection(false)
 	var root: TreeItem = _tree_info.create_item()
 	_tree_info.set_column_title(0, "Property")

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/assign_group_panel.gd
@@ -147,6 +147,8 @@ func _on_line_edit_new_structure_name_text_changed(_new_text: String) -> void:
 
 
 func _update_apply_button_state() -> void:
+	if not is_instance_valid(_workspace_context):
+		return
 	var new_group_name_is_empty: bool = _line_edit_new_structure_name.text.is_empty()
 	var can_move_molecule: bool = WorkspaceUtils.can_move_selection_to_another_group(_workspace_context)
 	var active_picker: NanoGroupPicker = _get_active_group_picker()

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
@@ -402,6 +402,8 @@ func _on_workspace_context_selection_in_structures_changed(in_structure_contexts
 	_update_structure_selection.call_deferred(groups_to_update)
 
 func _update_structure_selection(in_groups_to_update: PackedInt32Array) -> void:
+	if not is_instance_valid(_workspace_context):
+		return
 	for group_id: int in in_groups_to_update:
 		if not _workspace_context.workspace.has_structure_with_int_guid(group_id):
 			# group has been removed

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/relax_tools_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/relax_tools_panel.gd
@@ -82,6 +82,8 @@ func _on_workspace_context_alerts_panel_visibility_changed(in_is_visible: bool) 
 
 
 func _update_button_run_relaxation_state() -> void:
+	if not is_instance_valid(_workspace_context):
+		return
 	var can_relax: bool = WorkspaceUtils.can_relax(_workspace_context, _get_atom_set())
 	_button_run_relaxation.disabled = not can_relax
 

--- a/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/simulations_docker/simulations_docker_controls/validate_bonds_panel.gd
@@ -60,6 +60,8 @@ func _ensure_initialized(in_workspace_context: WorkspaceContext) -> void:
 
 
 func _update_panel_state() -> void:
+	if not is_instance_valid(_workspace_context):
+		return
 	_no_selection_label.visible = false
 	_validate_button.disabled = false
 	var has_selected_atoms: bool = false

--- a/godot_project/utils/script_utils.gd
+++ b/godot_project/utils/script_utils.gd
@@ -41,6 +41,8 @@ static func _flush_queue() -> void:
 	_is_flushing = true
 	for c: Callable in _callable_queue.keys():
 		if c.is_valid():
+			if c.get_object() is Node and c.get_object().is_queued_for_deletion():
+					continue
 			c.call()
 	_callable_queue.clear()
 	_callables_requested_during_flush.clear()


### PR DESCRIPTION
Tasks:
- BUG: Close and save a workspace leaves you with an unsaved workspace with the contents of the previous workspace
- CRASH: Random crashes in the release build