### PR TITLE
When project button in the Welcome tab zooms it, should not enlarge the clickable area

### DIFF
--- a/godot_project/editor/controls/welcome_page/controls/load_recent_button.tscn
+++ b/godot_project/editor/controls/welcome_page/controls/load_recent_button.tscn
@@ -223,6 +223,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 texture = ExtResource("1_uewrw")
 expand_mode = 1
 stretch_mode = 5


### PR DESCRIPTION
Task: BUG: Hover space in "open recet project" button is bigger than it looks like