### PR TITLE
Project description in Workspace Settings tab now has word wrap enabled

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/general_settings/general_settings.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/e_workspace_settings_docker/controls/general_settings/general_settings.tscn
@@ -22,6 +22,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 placeholder_text = "Project description here..."
+wrap_mode = 1
 
 [node name="Label2" type="Label" parent="."]
 layout_mode = 2


### PR DESCRIPTION
Task: BUG: Description text box in Workspace Settings does not have word wrap enabled