### PR TITLE
Record Simulation Video: Ensure timestamp label is visible on any background color possible

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd
@@ -86,7 +86,6 @@ func _on_about_to_popup() -> void:
 	_setup_quality_preset_option_button()
 	_update_time_label_layout()
 	_update_time_label_text()
-	_update_time_color()
 	_update_progress()
 
 
@@ -133,12 +132,6 @@ func _on_stop_button_pressed() -> void:
 	_stopped = true
 	_stop_button.disabled = true
 	_abort_button.disabled = true
-
-
-# OVERRIDE
-func _on_color_picker_button_background_color_color_changed(in_color: Color) -> void:
-	super._on_color_picker_button_background_color_color_changed(in_color)
-	_update_time_color()
 
 
 func _abort_button_pressed() -> void:
@@ -213,15 +206,6 @@ func _update_time_label_layout() -> void:
 	else:
 		# align bottom
 		_time_label.size_flags_vertical = Control.SIZE_SHRINK_END
-
-
-func _update_time_color() -> void:
-	if _workspace_context != null:
-		var background: Color = _color_picker_button_background_color.color
-		if _radio_background_environment.button_pressed:
-			var settings: RepresentationSettings = _workspace_context.workspace.representation_settings
-			background = settings.get_final_background_color()
-		_time_label.self_modulate.v = 0.1 if (background.v > 0.4 and background.s < 0.6) else 1.0
 
 
 func _update_time_label_text() -> void:

--- a/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.tscn
+++ b/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://dmiufmrvro7me"]
+[gd_scene load_steps=11 format=3 uid="uid://dmiufmrvro7me"]
 
 [ext_resource type="PackedScene" uid="uid://blxop3sf64kc3" path="res://editor/controls/screen_capture_dialog/screen_capture_dialog.tscn" id="1_fq33m"]
 [ext_resource type="Script" uid="uid://clhsgmheddras" path="res://editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd" id="2_vnntt"]
@@ -6,6 +6,12 @@
 [ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="4_3apb5"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_fxhsi"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_0eixy"]
+font_size = 48
+shadow_size = 16
+shadow_color = Color(0.176876, 0.0964739, 0.336584, 1)
+shadow_offset = Vector2(0, 0)
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_vnntt"]
 
@@ -195,8 +201,8 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8
-theme_override_font_sizes/font_size = 24
 text = "0.25 fs"
+label_settings = SubResource("LabelSettings_0eixy")
 
 [node name="ButtonFit" parent="VBoxContainer/HBoxContainer/PreviewControls/PanelContainer/VBoxContainer/HBoxContainer" index="1"]
 button_group = SubResource("ButtonGroup_vnntt")


### PR DESCRIPTION
Task: BUG: Timestamp label needs contrast with bright backgrounds

**Note:** This PR makes timestamp label very big, this is because outline size is for some reason limited to 1/3 of the font size, and in order to guarrantee outline was big enough to produce contrast an arbitrary size of 48 was chosen

<img width="1541" height="812" alt="image" src="https://github.com/user-attachments/assets/a6ab6b2b-c190-4b75-97e3-47ba037665b3" />
