### PR TITLE
When applying theme and switching materials, properly initialize new materials

### DIFF
--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/sphere_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/sphere_representation/assets/sphere_material.gd
@@ -73,7 +73,7 @@ func reset() -> void:
 
 func copy_state_from(in_from_material: ShaderMaterial) -> void:
 	RenderingUtils.copy_selected_uniforms_from(in_from_material, self, [UNIFORM_SCALE, UNIFORM_IS_HOVERED,
-			 UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA])
+			 UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA, UNIFORM_SHOW_HYDROGENS])
 
 
 func create_state_snapshot() -> Dictionary:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/assets/capsule_stick_material.gd
@@ -78,8 +78,11 @@ func saturate() -> void:
 	set_shader_parameter(UNIFORM_VALUE, NORMAL_VALUE)
 
 
-func copy_state_from(_in_from_material: ShaderMaterial) -> void:
-	return # no need in this case
+func copy_state_from(in_from_material: ShaderMaterial) -> void:
+	RenderingUtils.copy_selected_uniforms_from(in_from_material, self, [
+			INSTANCE_UNIFORM_BASE_SCALE, UNIFORM_CAPS_STARTS_AT_LOCAL_Z, UNIFORM_OUTLINE_THICKNESS,
+			UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA, UNIFORM_SHOW_HYDROGENS,
+			UNIFORM_OUTLINE_THICKNESS])
 
 
 func create_state_snapshot() -> Dictionary:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/capsule_stick_representation.gd
@@ -97,13 +97,12 @@ static func calc_bond_width_factor(_in_bond_order: int, in_smaller_atom_radius: 
 
 
 func apply_theme(in_theme: Theme3D) -> void:
-	var old_order_1_material: ShaderMaterial = _material_bond_1
-	var old_order_2_material: ShaderMaterial = _material_bond_2
-	var old_order_3_material: ShaderMaterial = _material_bond_3
+	var old_capsule_material: ShaderMaterial = _capsule_material
 	
-	_material_bond_1 = in_theme.create_stick_order_1_material()
-	_material_bond_2 = in_theme.create_stick_order_2_material()
-	_material_bond_3 = in_theme.create_stick_order_3_material()
+	_capsule_material = in_theme.create_stick_order_1_material()
+	_material_bond_1 = _capsule_material
+	_material_bond_2 = _capsule_material
+	_material_bond_3 = _capsule_material
 	
 	assert(_material_bond_1 is CapsuleStickMaterial)
 	assert(_material_bond_2 is CapsuleStickMaterial)
@@ -116,9 +115,9 @@ func apply_theme(in_theme: Theme3D) -> void:
 	_tripple_stick_multimesh.set_mesh_override(in_theme.create_stick_mesh_order_3())
 	_tripple_stick_multimesh.set_material_override(_material_bond_3)
 	
-	_material_bond_1.copy_state_from(old_order_1_material)
-	_material_bond_2.copy_state_from(old_order_2_material)
-	_material_bond_3.copy_state_from(old_order_3_material)
+	if old_capsule_material:
+		# Old material could be null if theme is set before initialization
+		_capsule_material.copy_state_from(old_capsule_material)
 	
 	var is_built: bool = _workspace_context != null
 	if is_built:

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/enhanced_capsule_stick_representation.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/capsule_stick_representation/enhanced_capsule_stick_representation.gd
@@ -42,3 +42,16 @@ func apply_theme(in_theme: Theme3D) -> void:
 	var is_built: bool = _workspace_context != null
 	if is_built:
 		_update_is_selectable_uniform()
+
+func hydrogens_rendering_off() -> void:
+	_material_bond_1.disable_hydrogen_rendering()
+	_material_bond_2.disable_hydrogen_rendering()
+	_material_bond_3.disable_hydrogen_rendering()
+	_init_material_uniforms()
+
+
+func hydrogens_rendering_on() -> void:
+	_material_bond_1.enable_hydrogen_rendering()
+	_material_bond_2.enable_hydrogen_rendering()
+	_material_bond_2.enable_hydrogen_rendering()
+	_init_material_uniforms()

--- a/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/cylinder_stick_material.gd
+++ b/godot_project/editor/rendering/atomic_structure_renderer/representation/stick_representation/cylinder_stick_representation/assets/cylinder_stick_material.gd
@@ -70,7 +70,7 @@ func saturate() -> void:
 
 func copy_state_from(in_from_material: ShaderMaterial) -> void:
 	RenderingUtils.copy_selected_uniforms_from(in_from_material, self, [UNIFORM_ATOM_SCALE,
-			UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA,
+			UNIFORM_GIZMO_ORIGIN, UNIFORM_GIZMO_ROTATION, UNIFORM_SELECTION_DELTA, UNIFORM_SHOW_HYDROGENS,
 			UNIFORM_OUTLINE_THICKNESS])
 
 


### PR DESCRIPTION
Tasks:
- BUG: Undo can cause visible hydrogens when should be hidden, and invisible hidrogen bonds when should be visible
- BUG: Hidden hydrogens are visible when opening a file with 'show hydrogens' disabled