### PR TITLE
Add an optional background to the videos timestamp

### DIFF
--- a/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd
+++ b/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd
@@ -5,12 +5,14 @@ var _time_scale_picker: TimeSpanPicker
 var _time_visible_button: CheckButton
 var _time_position_option_button: OptionButton
 var _time_label_font_size_spinbox: SpinBoxSlider
+var _time_background_visible_button: CheckButton
 
 var _framerate_spin_box: SpinBoxSlider
 var _quality_preset_option_button: OptionButton
 var _crf_spin_box: SpinBoxSlider
 
-var _crop_rect_control: MarginContainer
+var _crop_rect_control: Control
+var _time_container: MarginContainer
 var _time_label: Label
 var _video_time_elapsed_label: Label
 var _time_slider: HSlider
@@ -40,12 +42,14 @@ func _notification(what: int) -> void:
 		_time_visible_button = %TimeVisibleButton as CheckButton
 		_time_position_option_button = %TimePositionOptionButton as OptionButton
 		_time_label_font_size_spinbox = %TimeLabelFontSizeSpinbox as SpinBoxSlider
+		_time_background_visible_button = %TimeBackgroundVisibleButton as CheckButton
 		
 		_framerate_spin_box = %FramerateSpinBox as SpinBoxSlider
 		_quality_preset_option_button = %QualityPresetOptionButton as  OptionButton
 		_crf_spin_box = %CrfSpinBox as  SpinBoxSlider
 		
-		_crop_rect_control = %CropRectControl as MarginContainer
+		_crop_rect_control = %CropRectControl as Control
+		_time_container = %TimeContainer as MarginContainer
 		_time_label = %TimeLabel as Label
 		_video_time_elapsed_label = %VideoTimeElapsedLabel as Label
 		_time_slider = %TimeSlider as HSlider
@@ -59,6 +63,7 @@ func _notification(what: int) -> void:
 		crop_settings_changed.connect(_on_crop_settings_changed)
 		_time_scale_picker.time_span_changed.connect(_on_time_scale_picker_time_span_changed.unbind(2))
 		_time_visible_button.toggled.connect(_update_time_label_layout.unbind(1))
+		_time_background_visible_button.toggled.connect(_update_time_color.unbind(1))
 		_time_position_option_button.item_selected.connect(_update_time_label_layout.unbind(1))
 		_time_label_font_size_spinbox.value_changed.connect(_on_time_label_font_size_spinbox_value_changed)
 		_time_slider.value_changed.connect(_on_time_slider_value_changed)
@@ -122,6 +127,8 @@ func _on_time_scale_picker_time_span_changed() -> void:
 
 func _on_time_label_font_size_spinbox_value_changed(in_value: float) -> void:
 	_time_label.add_theme_font_size_override(&"font_size", int(in_value))
+	# Changing the font size is not instant, so the layout update has to be deferred
+	_update_time_label_layout.call_deferred()
 
 
 func _on_time_slider_value_changed(in_frame: float) -> void:
@@ -179,10 +186,13 @@ func _setup_quality_preset_option_button() -> void:
 
 
 func _update_time_label_layout() -> void:
-	if _time_label.visible != _time_visible_button.button_pressed:
-		_time_label.visible = _time_visible_button.button_pressed
+	if _crop_rect_control.visible != _time_visible_button.button_pressed:
+		_crop_rect_control.visible = _time_visible_button.button_pressed
 		# This ensures text is updated when visibility changes
 		_update_time_label_text()
+	
+	_crop_rect_control.set_anchors_and_offsets_preset(Control.LayoutPreset.PRESET_FULL_RECT)
+
 	if _check_button_crop.button_pressed:
 		var crop_rect := Rect2i(
 			int(_spin_box_slider_h_offset.value),
@@ -190,33 +200,25 @@ func _update_time_label_layout() -> void:
 			int(_spin_box_slider_crop_width.value),
 			int(_spin_box_slider_crop_height.value)
 		)
-		_crop_rect_control.set_anchor_and_offset(SIDE_LEFT, 0, crop_rect.position.x)
-		_crop_rect_control.set_anchor_and_offset(SIDE_TOP, 0, crop_rect.position.y)
-		var offset := Vector2i(_crop_rect_control.get_viewport_rect().size) - crop_rect.end
-		_crop_rect_control.set_anchor_and_offset(SIDE_RIGHT, 1, -offset.x)
-		_crop_rect_control.set_anchor_and_offset(SIDE_BOTTOM, 1, -offset.y)
-	else:
-		_crop_rect_control.set_anchor_and_offset(SIDE_LEFT, 0, 0)
-		_crop_rect_control.set_anchor_and_offset(SIDE_TOP, 0, 0)
-		_crop_rect_control.set_anchor_and_offset(SIDE_RIGHT, 1, 0)
-		_crop_rect_control.set_anchor_and_offset(SIDE_BOTTOM, 1, 0)
+		_crop_rect_control.offset_left = crop_rect.position.x
+		_crop_rect_control.offset_top = crop_rect.position.y
+		var offset := _sub_viewport_preview.size - crop_rect.end
+		_crop_rect_control.offset_right = -offset.x
+		_crop_rect_control.offset_bottom = -offset.y
+
 	var alignment: Control.LayoutPreset = _time_position_option_button.get_selected_id() as Control.LayoutPreset
-	if alignment in [Control.LayoutPreset.PRESET_TOP_LEFT, Control.LayoutPreset.PRESET_BOTTOM_LEFT]:
-		# align left
-		_time_label.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
-	else:
-		# align right
-		_time_label.size_flags_horizontal = Control.SIZE_SHRINK_END
-	if alignment in [Control.LayoutPreset.PRESET_TOP_LEFT, Control.LayoutPreset.PRESET_TOP_RIGHT]:
-		# align top
-		_time_label.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
-	else:
-		# align bottom
-		_time_label.size_flags_vertical = Control.SIZE_SHRINK_END
+	_time_container.set_anchors_and_offsets_preset(alignment)
 
 
 func _update_time_color() -> void:
-	if _workspace_context != null:
+	if _workspace_context == null:
+		return
+	var style_box: StyleBoxFlat = _time_label[&"theme_override_styles/normal"]
+	if _time_background_visible_button.button_pressed:
+		style_box.draw_center = true
+		_time_label.self_modulate = Color.WHITE
+	else:
+		style_box.draw_center = false
 		var background: Color = _color_picker_button_background_color.color
 		if _radio_background_environment.button_pressed:
 			var settings: RepresentationSettings = _workspace_context.workspace.representation_settings

--- a/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.tscn
+++ b/godot_project/editor/controls/screen_capture_dialog/record_simulation_video_dialog.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://dmiufmrvro7me"]
+[gd_scene load_steps=11 format=3 uid="uid://dmiufmrvro7me"]
 
 [ext_resource type="PackedScene" uid="uid://blxop3sf64kc3" path="res://editor/controls/screen_capture_dialog/screen_capture_dialog.tscn" id="1_fq33m"]
 [ext_resource type="Script" uid="uid://clhsgmheddras" path="res://editor/controls/screen_capture_dialog/record_simulation_video_dialog.gd" id="2_vnntt"]
@@ -6,6 +6,17 @@
 [ext_resource type="PackedScene" uid="uid://b15453vqjum8" path="res://editor/controls/general/spin_box_slider.tscn" id="4_3apb5"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_fxhsi"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0eixy"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+bg_color = Color(0.184314, 0.101961, 0.34902, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_vnntt"]
 
@@ -122,6 +133,15 @@ value = 24.0
 allow_greater = true
 suffix = " px"
 
+[node name="TimeBackgroundVisibleLabel" type="Label" parent="VBoxContainer/HBoxContainer/ScrollContainer/SettingsControls/PanelContainerTimeStamp/HBoxContainer" index="8"]
+layout_mode = 2
+text = "Background"
+
+[node name="TimeBackgroundVisibleButton" type="CheckButton" parent="VBoxContainer/HBoxContainer/ScrollContainer/SettingsControls/PanelContainerTimeStamp/HBoxContainer" index="9"]
+unique_name_in_owner = true
+layout_mode = 2
+button_pressed = true
+
 [node name="LabelAdvanced" type="Label" parent="VBoxContainer/HBoxContainer/ScrollContainer/SettingsControls" index="8"]
 layout_mode = 2
 theme_type_variation = &"HeaderSmall"
@@ -178,25 +198,36 @@ value = 17.0
 [node name="SubViewportPreview" parent="VBoxContainer/HBoxContainer/PreviewControls" index="0"]
 render_target_update_mode = 4
 
-[node name="CropRectControl" type="MarginContainer" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview" index="3"]
+[node name="CropRectControl" type="Control" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview" index="3"]
 unique_name_in_owner = true
+layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
+size_flags_horizontal = 4
+size_flags_vertical = 4
 
-[node name="TimeLabel" type="Label" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview/CropRectControl" index="0"]
+[node name="TimeContainer" type="MarginContainer" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview/CropRectControl" index="0"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -37.5
+offset_right = 77.0
+grow_vertical = 0
+
+[node name="TimeLabel" type="Label" parent="VBoxContainer/HBoxContainer/PreviewControls/SubViewportPreview/CropRectControl/TimeContainer" index="0"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 8
-size_flags_vertical = 8
+size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_0eixy")
 text = "0.25 fs"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="ButtonFit" parent="VBoxContainer/HBoxContainer/PreviewControls/PanelContainer/VBoxContainer/HBoxContainer" index="1"]
 button_group = SubResource("ButtonGroup_vnntt")


### PR DESCRIPTION
Card: BUG: Timestamp label needs contrast with bright backgrounds

This PR adds an optional solid background to the timestamp text.
(color could be made user selectable in the future if needed)

Superseeds #947 

<img width="1014" height="426" alt="image" src="https://github.com/user-attachments/assets/2d5acdd8-db4d-48d5-b292-544c9eb8204c" />

<img width="1014" height="426" alt="image" src="https://github.com/user-attachments/assets/6c892e7e-a845-488d-9733-f09f9d343dfb" />
