### PR TITLE
Update rules for minimum size of several tree lists

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/connect_motors_to_groups_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/connect_motors_to_groups_panel.gd
@@ -70,6 +70,7 @@ func _add_structure_to_tree(
 	var structure_item: TreeItem = _tree_items.get(in_structure.int_guid, null) as TreeItem
 	if structure_item == null:
 		structure_item = _structures_tree.create_item(in_parent_tree_item, in_structure.int_guid)
+		structure_item.set_text_overrun_behavior(_TREE_COLUMN_0, TextServer.OVERRUN_NO_TRIMMING)
 	var is_checkable: bool = not in_structure is NanoVirtualMotor
 	structure_item.set_cell_mode(_TREE_COLUMN_0, TreeItem.CELL_MODE_CHECK if is_checkable else TreeItem.CELL_MODE_STRING)
 	structure_item.set_editable(_TREE_COLUMN_0, is_checkable)

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/find_atoms_by_type.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/find_atoms_by_type.gd
@@ -6,6 +6,7 @@ const DELETE_ICON: Texture2D = preload("res://editor/controls/menu_bar/menu_edit
 
 var _workspace_context: WorkspaceContext
 var _selected_types: Dictionary = {}
+var _structure_count: int = 0
 
 @onready var _elements_tree: Tree = %ElementsTree as Tree
 @onready var _element_picker: ElementPickerBase = %ElementPicker as ElementPickerBase
@@ -54,6 +55,7 @@ func _refresh_groups_tree() -> void:
 	_groups_tree.clear()
 	var root: TreeItem = _groups_tree.create_item()
 	_groups_tree.hide_root = true
+	_structure_count = 0
 	for structure: NanoStructure in _workspace_context.workspace.get_root_child_structures():
 		if not structure is AtomicStructure or structure is AtomicVirtualStructure:
 			# DNA is intentionally ignored because their atoms are not interactible
@@ -62,9 +64,11 @@ func _refresh_groups_tree() -> void:
 
 
 func _add_groups_recursively(in_structure: AtomicStructure, in_parent_item: TreeItem) -> void:
+	_structure_count += 1
 	var group_item: TreeItem = _groups_tree.create_item(in_parent_item)
 	var count: int = _count_found_atoms(in_structure)
 	const COL_0 := 0
+	group_item.set_text_overrun_behavior(COL_0, TextServer.OVERRUN_NO_TRIMMING)
 	group_item.set_text(COL_0, "%s (%d)" % [in_structure.get_structure_name(), count])
 	group_item.set_meta(&"group_id", in_structure.int_guid)
 	group_item.set_meta(&"count", count)
@@ -74,6 +78,16 @@ func _add_groups_recursively(in_structure: AtomicStructure, in_parent_item: Tree
 			# DNA is intentionally ignored because their atoms are not interactible
 			continue
 		_add_groups_recursively(structure, group_item)
+	ScriptUtils.call_deferred_once(_update_minsize)
+
+
+func _update_minsize() -> void:
+	if _structure_count > 5:
+		_groups_tree.custom_minimum_size.y = 200
+		_groups_tree.scroll_vertical_enabled = true
+	else:
+		_groups_tree.custom_minimum_size.y = 0
+		_groups_tree.scroll_vertical_enabled = false
 
 
 func _count_found_atoms(in_structure: AtomicStructure) -> int:

--- a/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/find_atoms_by_type.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/c_dynamic_context_docker/dynamic_context_controls/find_atoms_by_type.tscn
@@ -51,5 +51,3 @@ size_flags_vertical = 2
 focus_mode = 0
 hide_root = true
 select_mode = 1
-scroll_horizontal_enabled = false
-scroll_vertical_enabled = false

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker_popup_panel.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_group_picker/nano_group_picker_popup_panel.gd
@@ -193,6 +193,7 @@ func _create_structure_tree_item(in_structure_id: int) -> TreeItem:
 	var tree_item: TreeItem = _tree.create_item(parent_item, in_structure_id)
 	_structure_id_to_tree_item[in_structure_id] = tree_item
 	tree_item.set_text(_TREE_COLUMN_0, nano_structure.get_structure_name())
+	tree_item.set_text_overrun_behavior(_TREE_COLUMN_0, TextServer.OVERRUN_NO_TRIMMING)
 	return tree_item
 
 

--- a/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
+++ b/godot_project/editor/controls/dockers/workspace_docker/groups_docker/groups_docker_controls/nano_groups_list.gd
@@ -449,6 +449,7 @@ func _create_structure_tree_item(in_structure_id: int) -> TreeItem:
 	if structure_context == get_workspace_context().get_current_structure_context():
 		_edited_structure_tree_item = tree_item
 	tree_item.set_text(_TREE_COLUMN_0, nano_structure.get_structure_name())
+	tree_item.set_text_overrun_behavior(_TREE_COLUMN_0, TextServer.OVERRUN_NO_TRIMMING)
 	tree_item.add_button(_TREE_COLUMN_0, _BUTTON_ICONS[_TREE_BUTTON_ID_RENAME],
 			_TREE_BUTTON_ID_RENAME, false, tr(&"Edit the name of this structure"))
 	if nano_structure != get_workspace_context().workspace.get_main_structure():


### PR DESCRIPTION
- Group names will no longer be trimmed
- Find Atom By Type now has a maximum heigth

Task: BUG - Draw Error when List of potential groups to connect to motor gets too long.

|Before|After|
|--|--|
|<img width="1634" height="780" alt="image" src="https://github.com/user-attachments/assets/f5215a8c-0f12-43e6-b237-dae99ff9d9ba" />|<img width="498" height="300" alt="image" src="https://github.com/user-attachments/assets/6aa56f5a-322d-447f-9f1f-38a8f4dcd089" />|
|<img width="346" height="656" alt="image" src="https://github.com/user-attachments/assets/8e416d76-f6d0-4001-bb7e-60361597fc2a" />|<img width="309" height="434" alt="image" src="https://github.com/user-attachments/assets/3afbd359-b067-4504-a302-56057f571f1d" />|
|<img width="1369" height="659" alt="image" src="https://github.com/user-attachments/assets/d0886b9f-c44d-4d2e-acb5-c2b56ff0c200" />|<img width="512" height="599" alt="image" src="https://github.com/user-attachments/assets/ba5e5fe1-ad98-41f4-9ee7-9573845e7487" />|





