### PR TITLE
Change step size of auto create springs max length to have mroe resolution

### DIFF
--- a/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.tscn
+++ b/godot_project/editor/controls/dockers/workspace_docker/a_create_docker/auto_create_springs_panel.tscn
@@ -59,10 +59,11 @@ unique_name_in_owner = true
 layout_mode = 2
 min_value = 0.1
 max_value = 20.0
-step = 0.1
+step = 0.01
 value = 1.0
 allow_greater = true
 suffix = "nm"
+custom_arrow_step = 0.1
 
 [node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer2"]
 layout_mode = 2


### PR DESCRIPTION
Task: UI/UX: "Maximum Spring Length" property of auto-create-springs has a step of 0.1, which is too big. Should have step of 0.01 and arrow step of 0.1